### PR TITLE
feat(website): track email signups in PostHog

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -6722,7 +6722,7 @@ iii.register_function(
       // Mailmodo returns 409 for already-subscribed; treat as success.
       if (!res.ok && res.status !== 409) throw new Error('mailmodo submission failed');
       if (typeof window.iiiNotifyCommonRoomEmail === 'function') window.iiiNotifyCommonRoomEmail(email);
-      if (typeof window.iiiNotifyPostHogEmailSubmit === 'function') window.iiiNotifyPostHogEmailSubmit(formLocation);
+      if (typeof window.iiiNotifyPostHogEmailSubmit === 'function') window.iiiNotifyPostHogEmailSubmit(email, formLocation);
     } catch (_) {
       // Swallow — we still mark the form submitted so users aren't blocked.
     }

--- a/website/index.html
+++ b/website/index.html
@@ -6710,7 +6710,7 @@ iii.register_function(
     const meta = document.querySelector('meta[name="iii:mailmodo-form-url"]');
     return meta && meta.getAttribute('content') ? meta.getAttribute('content').trim() : '';
   }
-  async function submitToMailmodo(email){
+  async function submitToMailmodo(email, formLocation){
     const url = getMailmodoFormUrl();
     if (!url) return;
     try {
@@ -6722,6 +6722,7 @@ iii.register_function(
       // Mailmodo returns 409 for already-subscribed; treat as success.
       if (!res.ok && res.status !== 409) throw new Error('mailmodo submission failed');
       if (typeof window.iiiNotifyCommonRoomEmail === 'function') window.iiiNotifyCommonRoomEmail(email);
+      if (typeof window.iiiNotifyPostHogEmailSubmit === 'function') window.iiiNotifyPostHogEmailSubmit(formLocation);
     } catch (_) {
       // Swallow — we still mark the form submitted so users aren't blocked.
     }
@@ -6750,7 +6751,7 @@ iii.register_function(
       persistAccessRequest(v);
       emailForm.classList.add('submitted');
       emailInput.value = '';
-      submitToMailmodo(v);
+      submitToMailmodo(v, 'hero');
     });
   }
 
@@ -7104,7 +7105,7 @@ iii.register_function(
       persistAccessRequest(v);
       form.classList.add('submitted');
       input.value = '';
-      submitToMailmodo(v);
+      submitToMailmodo(v, 'footer');
     });
   })();
 

--- a/website/posthog-consent.js
+++ b/website/posthog-consent.js
@@ -62,27 +62,52 @@
   };
 
   // Records a successful email-form submission in PostHog. Mirrors the timing of
-  // iiiNotifyCommonRoomEmail, but intentionally omits the email address — we only
-  // need to know that a submission happened, not who it was.
+  // iiiNotifyCommonRoomEmail.
   //
-  // Where the Common Room visitor id (its signals-sdk-user-id cookie) is present
-  // we identify() the person by that id. This is what creates the PostHog person
-  // profile under person_profiles: 'identified_only' (a bare $set on an anonymous
-  // visitor would be dropped), and keys the profile to Common Room so the two
-  // systems can be joined per visitor. The website_email_submit event is captured
-  // regardless, so the conversion is recorded even without a Common Room id.
-  window.iiiNotifyPostHogEmailSubmit = function (formLocation) {
+  // We identify() the person by their email (the cross-system key Common Room
+  // also de-anonymizes on), which creates the PostHog person profile under
+  // person_profiles: 'identified_only'. Where the Common Room visitor id (its
+  // signals-sdk-user-id cookie) is present we attach it too, so the two systems
+  // can be joined per visitor. That cookie is written asynchronously by Common
+  // Room's signals.js, so if it's not there yet we wait briefly and retry once
+  // before recording without it — the submission is always recorded either way.
+  var CR_COOKIE_RETRY_MS = 2000;
+
+  function iiiReadCommonRoomId() {
+    var match = document.cookie.match(/(?:^|;\s*)signals-sdk-user-id=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : null;
+  }
+
+  function iiiSendPostHogEmailSubmit(email, formLocation, crId) {
+    try {
+      if (!window.posthog || typeof window.posthog.capture !== 'function') return;
+      var distinctId = email || crId;
+      if (distinctId) {
+        var personProps = {};
+        if (email) personProps.email = email;
+        if (crId) personProps.common_room_user_id = crId;
+        window.posthog.identify(distinctId, personProps);
+      }
+      var props = { form_location: formLocation || 'unknown' };
+      if (email) props.email = email;
+      if (crId) props.common_room_user_id = crId;
+      window.posthog.capture('website_email_submit', props);
+    } catch (_) {}
+  }
+
+  window.iiiNotifyPostHogEmailSubmit = function (email, formLocation) {
     try {
       if (localStorage.getItem(STORAGE_KEY) !== 'accepted') return;
       if (!window.posthog || typeof window.posthog.capture !== 'function') return;
-      var props = { form_location: formLocation || 'unknown' };
-      var match = document.cookie.match(/(?:^|;\s*)signals-sdk-user-id=([^;]+)/);
-      if (match) {
-        var crId = decodeURIComponent(match[1]);
-        props.common_room_user_id = crId;
-        window.posthog.identify(crId, { common_room_user_id: crId });
+      var crId = iiiReadCommonRoomId();
+      if (crId) {
+        iiiSendPostHogEmailSubmit(email, formLocation, crId);
+      } else {
+        // Common Room may not have written its cookie yet; give it one retry.
+        setTimeout(function () {
+          iiiSendPostHogEmailSubmit(email, formLocation, iiiReadCommonRoomId());
+        }, CR_COOKIE_RETRY_MS);
       }
-      window.posthog.capture('website_email_submit', props);
     } catch (_) {}
   };
 

--- a/website/posthog-consent.js
+++ b/website/posthog-consent.js
@@ -63,9 +63,14 @@
 
   // Records a successful email-form submission in PostHog. Mirrors the timing of
   // iiiNotifyCommonRoomEmail, but intentionally omits the email address — we only
-  // need to know that a submission happened, not who it was. Where available, we
-  // attach the Common Room visitor id (its signals-sdk-user-id cookie) so the two
-  // systems can be joined per visitor.
+  // need to know that a submission happened, not who it was.
+  //
+  // Where the Common Room visitor id (its signals-sdk-user-id cookie) is present
+  // we identify() the person by that id. This is what creates the PostHog person
+  // profile under person_profiles: 'identified_only' (a bare $set on an anonymous
+  // visitor would be dropped), and keys the profile to Common Room so the two
+  // systems can be joined per visitor. The website_email_submit event is captured
+  // regardless, so the conversion is recorded even without a Common Room id.
   window.iiiNotifyPostHogEmailSubmit = function (formLocation) {
     try {
       if (localStorage.getItem(STORAGE_KEY) !== 'accepted') return;
@@ -75,7 +80,7 @@
       if (match) {
         var crId = decodeURIComponent(match[1]);
         props.common_room_user_id = crId;
-        props.$set = { common_room_user_id: crId };
+        window.posthog.identify(crId, { common_room_user_id: crId });
       }
       window.posthog.capture('website_email_submit', props);
     } catch (_) {}

--- a/website/posthog-consent.js
+++ b/website/posthog-consent.js
@@ -61,6 +61,26 @@
     });
   };
 
+  // Records a successful email-form submission in PostHog. Mirrors the timing of
+  // iiiNotifyCommonRoomEmail, but intentionally omits the email address — we only
+  // need to know that a submission happened, not who it was. Where available, we
+  // attach the Common Room visitor id (its signals-sdk-user-id cookie) so the two
+  // systems can be joined per visitor.
+  window.iiiNotifyPostHogEmailSubmit = function (formLocation) {
+    try {
+      if (localStorage.getItem(STORAGE_KEY) !== 'accepted') return;
+      if (!window.posthog || typeof window.posthog.capture !== 'function') return;
+      var props = { form_location: formLocation || 'unknown' };
+      var match = document.cookie.match(/(?:^|;\s*)signals-sdk-user-id=([^;]+)/);
+      if (match) {
+        var crId = decodeURIComponent(match[1]);
+        props.common_room_user_id = crId;
+        props.$set = { common_room_user_id: crId };
+      }
+      window.posthog.capture('website_email_submit', props);
+    } catch (_) {}
+  };
+
   try {
     if (localStorage.getItem(STORAGE_KEY) === 'accepted') window.iiiLoadPostHog();
   } catch (_) {}

--- a/website/posthog-consent.js
+++ b/website/posthog-consent.js
@@ -61,26 +61,22 @@
     });
   };
 
-  // Records a successful email-form submission in PostHog. Mirrors the timing of
-  // iiiNotifyCommonRoomEmail.
-  //
-  // We identify() the person by their email (the cross-system key Common Room
-  // also de-anonymizes on), which creates the PostHog person profile under
-  // person_profiles: 'identified_only'. Where the Common Room visitor id (its
-  // signals-sdk-user-id cookie) is present we attach it too, so the two systems
-  // can be joined per visitor. That cookie is written asynchronously by Common
-  // Room's signals.js, so if it's not there yet we wait briefly and retry once
-  // before recording without it — the submission is always recorded either way.
-  var CR_COOKIE_RETRY_MS = 2000;
-
+  // Records a successful email-form submission in PostHog. We identify() the
+  // person by their email (the cross-system key Common Room also de-anonymizes
+  // on), which creates the PostHog person profile under
+  // person_profiles: 'identified_only'. Where Common Room's signals-sdk-user-id
+  // cookie is already present we attach its visitor id too, so the two systems
+  // can be joined per visitor; if it isn't set yet we just record without it.
   function iiiReadCommonRoomId() {
     var match = document.cookie.match(/(?:^|;\s*)signals-sdk-user-id=([^;]+)/);
     return match ? decodeURIComponent(match[1]) : null;
   }
 
-  function iiiSendPostHogEmailSubmit(email, formLocation, crId) {
+  window.iiiNotifyPostHogEmailSubmit = function (email, formLocation) {
     try {
+      if (localStorage.getItem(STORAGE_KEY) !== 'accepted') return;
       if (!window.posthog || typeof window.posthog.capture !== 'function') return;
+      var crId = iiiReadCommonRoomId();
       var distinctId = email || crId;
       if (distinctId) {
         var personProps = {};
@@ -92,22 +88,6 @@
       if (email) props.email = email;
       if (crId) props.common_room_user_id = crId;
       window.posthog.capture('website_email_submit', props);
-    } catch (_) {}
-  }
-
-  window.iiiNotifyPostHogEmailSubmit = function (email, formLocation) {
-    try {
-      if (localStorage.getItem(STORAGE_KEY) !== 'accepted') return;
-      if (!window.posthog || typeof window.posthog.capture !== 'function') return;
-      var crId = iiiReadCommonRoomId();
-      if (crId) {
-        iiiSendPostHogEmailSubmit(email, formLocation, crId);
-      } else {
-        // Common Room may not have written its cookie yet; give it one retry.
-        setTimeout(function () {
-          iiiSendPostHogEmailSubmit(email, formLocation, iiiReadCommonRoomId());
-        }, CR_COOKIE_RETRY_MS);
-      }
     } catch (_) {}
   };
 


### PR DESCRIPTION
## What

Records a `website_email_submit` event in PostHog when a visitor successfully submits the email signup form (hero or footer), mirroring the existing Common Room notification.

- Fires from inside `submitToMailmodo`, **gated on Mailmodo success** (2xx/409) — in lockstep with the Common Room `signals.form` call.
- Identifies the PostHog person by **email** (the same key Common Room de-anonymizes on), which creates the person profile under `person_profiles: 'identified_only'`.
- Attaches the Common Room visitor id (`signals-sdk-user-id` cookie) as both an event property and a person property when present, so the two systems can be joined per visitor. Read once at submit time; if the cookie isn't set yet we just record without it.
- Captures `form_location` (`hero` / `footer`).

No new event volume on anonymous traffic — only submitters become identified.

## Files
- `website/posthog-consent.js` — `window.iiiNotifyPostHogEmailSubmit(email, formLocation)` helper.
- `website/index.html` — wires the helper into the hero/footer submit flow.

## Notes
- Because tracking is gated on Mailmodo success, submissions Mailmodo rejects won't reach PostHog or Common Room — intended, but worth knowing analytics undercounts while Mailmodo rejections are unresolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)