### PR TITLE
feat(website): add the "iii explained" lens sections

### DIFF
--- a/website/src/components/landing/scripts/02-page-behaviors.html
+++ b/website/src/components/landing/scripts/02-page-behaviors.html
@@ -72,8 +72,8 @@
   });
 
   // ============= Hero rotating descriptors =============
-  // The headline reads "an agentic development environment" on arrival and
-  // holds it long enough to be read as a claim before anything starts moving.
+  // Both carousels hold their first word long enough to be read as a claim
+  // before anything starts moving.
   const HERO_HOLD_MS = 8000;
   function rotateWords(el, words, period){
     if (!el) return;
@@ -88,19 +88,14 @@
     };
     setTimeout(() => { tick(); setInterval(tick, period); }, HERO_HOLD_MS);
   }
-  // Two carousels on one headline. The subject turns slowly, and its period is
-  // not a multiple of the noun's, so the two keep landing on fresh pairings.
   rotateWords(document.getElementById('hero-desc'), [
-    'development','production','testing','staging','debugging',
-    'orchestration','integration','deployment'
+    'simple','scalable','durable','extensible','fast',
+    'composable','observable','reliable','interoperable'
   ], 3000);
-  // Held back with its markup in 03-hero.html — three rotating lines at once
-  // is too much motion. rotateWords no-ops on the missing element either way.
-  // rotateWords(document.getElementById('hero-for'), [
-  //   'building','architecting','experimenting','vibing','shipping',
-  //   'prototyping','refactoring','exploring'
-  // ], 5000);
-  rotateWords(document.getElementById('hero-subj'), ['an agentic','a human'], 8000);
+  // Subheader verb.
+  rotateWords(document.getElementById('hero-verb'), [
+    'discover','compose','extend','observe'
+  ], 3000);
 
   // ============= Email signup helpers =============
   function getMailmodoFormUrl(){

--- a/website/src/components/landing/scripts/02-page-behaviors.html
+++ b/website/src/components/landing/scripts/02-page-behaviors.html
@@ -71,23 +71,36 @@
     });
   });
 
-  // ============= Hero rotating descriptor =============
-  const rotatingDescriptors = [
-    'simple','scalable','durable','extensible','fast',
-    'composable','observable','reliable','interoperable'
-  ];
-  const heroDesc = document.getElementById('hero-desc');
-  if (heroDesc){
-    let rotIdx = 0;
-    setInterval(() => {
-      heroDesc.classList.add('is-anim');
+  // ============= Hero rotating descriptors =============
+  // The headline reads "an agentic development environment" on arrival and
+  // holds it long enough to be read as a claim before anything starts moving.
+  const HERO_HOLD_MS = 8000;
+  function rotateWords(el, words, period){
+    if (!el) return;
+    let i = 0;
+    const tick = () => {
+      el.classList.add('is-anim');
       setTimeout(() => {
-        rotIdx = (rotIdx + 1) % rotatingDescriptors.length;
-        heroDesc.textContent = rotatingDescriptors[rotIdx];
-        heroDesc.classList.remove('is-anim');
+        i = (i + 1) % words.length;
+        el.textContent = words[i];
+        el.classList.remove('is-anim');
       }, 400);
-    }, 3000);
+    };
+    setTimeout(() => { tick(); setInterval(tick, period); }, HERO_HOLD_MS);
   }
+  // Two carousels on one headline. The subject turns slowly, and its period is
+  // not a multiple of the noun's, so the two keep landing on fresh pairings.
+  rotateWords(document.getElementById('hero-desc'), [
+    'development','production','testing','staging','debugging',
+    'orchestration','integration','deployment'
+  ], 3000);
+  // Held back with its markup in 03-hero.html — three rotating lines at once
+  // is too much motion. rotateWords no-ops on the missing element either way.
+  // rotateWords(document.getElementById('hero-for'), [
+  //   'building','architecting','experimenting','vibing','shipping',
+  //   'prototyping','refactoring','exploring'
+  // ], 5000);
+  rotateWords(document.getElementById('hero-subj'), ['an agentic','a human'], 8000);
 
   // ============= Email signup helpers =============
   function getMailmodoFormUrl(){

--- a/website/src/components/landing/scripts/05-hero-viz-engine.html
+++ b/website/src/components/landing/scripts/05-hero-viz-engine.html
@@ -133,7 +133,7 @@
         formulaSub: "",
       },
       actual: {
-        name: "implementation",
+        name: "current approach",
         count: String(actualEdges.length),
         accentCount: false,
         formula:
@@ -141,7 +141,7 @@
         formulaSub: "",
       },
       iii: {
-        name: "iii",
+        name: "iii solution",
         count: "0",
         accentCount: true,
         formula: "<math><mi>O</mi><mo>(</mo><mn>0</mn><mo>)</mo></math>",
@@ -325,7 +325,7 @@
     function buildTriptych() {
       if (triptychBuilt) return;
       triptychBuilt = true;
-      const labels = ["problem space", "implementation", "iii"];
+      const labels = ["problem space", "current approach", "iii solution"];
       const counts = ["45", String(actualEdges.length), "0"];
       const stages = ["mesh", "actual", "iii"];
       for (let s = 0; s < 3; s++) {

--- a/website/src/components/landing/scripts/05-hero-viz-engine.html
+++ b/website/src/components/landing/scripts/05-hero-viz-engine.html
@@ -5,10 +5,11 @@
     if (!root) return;
 
     const N = 10;
-    const VB = 400,
-      cx = VB / 2,
-      cy = VB / 2,
-      R = 144;
+    // A wide band rather than a square: two staggered rows of five, so the
+    // panel can sit beside the headline without the drawing being scaled down.
+    const VBW = 400,
+      VBH = 118;
+    const ROW_Y = [38, 80];
     const NODE_LABELS = [
       "agent",
       "orchestrator",
@@ -22,13 +23,17 @@
       "memory",
     ];
 
-    // Node positions on the unit circle (top-clockwise)
+    // Two rows of five. The bottom row is offset by half a step and every other
+    // node is nudged vertically, so same-row edges never run straight through a
+    // node between their endpoints.
+    const STEP = 72.5;
     const nodes = Array.from({ length: N }, (_, i) => {
-      const a = (i / N) * Math.PI * 2 - Math.PI / 2;
+      const row = i < 5 ? 0 : 1;
+      const k = i % 5;
       return {
-        x: cx + R * Math.cos(a),
-        y: cy + R * Math.sin(a),
-        angle: a,
+        x: (row === 0 ? 40 : 40 + STEP / 2) + k * STEP,
+        y: ROW_Y[row] + (k % 2 ? (row === 0 ? -6 : 6) : 0),
+        row,
         label: NODE_LABELS[i] || "w" + i,
       };
     });
@@ -105,17 +110,13 @@
       const d = mk("circle", { cx: n.x, cy: n.y, r: 2, class: "hv-node-dot" });
       $nodes.appendChild(d);
     }
-    // Labels (positioned slightly outside the ring)
+    // Labels sit outside the band: above the top row, below the bottom row.
     for (const n of nodes) {
-      const lr = R + 22;
-      const lx = cx + lr * Math.cos(n.angle);
-      const ly = cy + lr * Math.sin(n.angle);
       const t = mk("text", {
-        x: lx,
-        y: ly,
+        x: n.x,
+        y: n.row === 0 ? n.y - 17 : n.y + 19,
         class: "hv-node-label",
-        "text-anchor":
-          Math.abs(Math.cos(n.angle)) < 0.2 ? "middle" : Math.cos(n.angle) > 0 ? "start" : "end",
+        "text-anchor": "middle",
         "dominant-baseline": "middle",
       });
       t.textContent = n.label;
@@ -343,7 +344,7 @@
 
         const svg = mk("svg", {
           class: "hv-mini-svg",
-          viewBox: "0 0 400 400",
+          viewBox: "0 0 " + VBW + " " + VBH,
           preserveAspectRatio: "xMidYMid meet",
         });
         const gMesh = mk("g", {});

--- a/website/src/components/landing/scripts/08-friction-anim.html
+++ b/website/src/components/landing/scripts/08-friction-anim.html
@@ -55,7 +55,8 @@
 
     // ---- DOM the engine drives ----
     const $tensions = document.getElementById('fanim-tensions');
-    const $ways = stage.querySelectorAll('.fanim-ways button');
+    const $ways = stage.querySelectorAll('.fanim-switch button');
+    const $marker = document.getElementById('fanim-switch-marker');
 
     const tensionEls = WAYS[0].tensions.map((_, i) => {
       const el = document.createElement('div');
@@ -373,7 +374,14 @@
     // ---- DOM render: nav state and where each tension sits ----
     function render(){
       const s = W();
-      $ways.forEach((b) => b.classList.toggle('on', Number(b.dataset.way) === state.way));
+      $ways.forEach((b) => {
+        const on = Number(b.dataset.way) === state.way;
+        b.classList.toggle('on', on);
+        if (on){
+          $marker.style.transform = 'translateX(' + b.offsetLeft + 'px)';
+          $marker.style.width = b.offsetWidth + 'px';
+        }
+      });
 
       if (!sized) return;
       const z = zones();
@@ -408,6 +416,9 @@
     resize();
 
     $ways.forEach((b) => b.addEventListener('click', () => setWay(Number(b.dataset.way))));
+    // The marker is measured from the label widths, which move when the mono
+    // font finishes loading.
+    if (document.fonts && document.fonts.ready) document.fonts.ready.then(render);
 
     new ResizeObserver(resize).observe(canvas);
     // The site's theme toggle rewrites data-theme on <html>; the canvas colors

--- a/website/src/components/landing/scripts/08-friction-anim.html
+++ b/website/src/components/landing/scripts/08-friction-anim.html
@@ -1,0 +1,433 @@
+<!-- ============= FRICTION ANIMATION ENGINE ============= -->
+<script>
+  (() => {
+    const stage = document.getElementById('fanim-stage');
+    const canvas = document.getElementById('fanim-canvas');
+    if (!stage || !canvas) return;
+
+    const N = 22;
+    const OFF = [[-58,-34],[6,-64],[62,-16],[-30,28],[40,46],[-6,-4]];
+    const FOFF = [[-44,96],[14,110],[70,84],[104,34]];
+    const FOFF2 = [[-58,84],[-2,116],[58,92],[112,52]];
+    const E1 = [[0,1],[0,2],[1,2],[1,3],[2,3],[2,4],[3,4],[3,5],[4,5],[0,4],[1,5]];
+    const EF = [[6,7],[7,8],[8,9],[6,9],[6,1],[8,4],[9,2],[7,3],[9,5]];
+    const E1C = E1.map(([a, b]) => [a + 12, b + 12]);
+    const EFC = EF.map(([a, b]) => [a + 12, b + 12]);
+    const BROKEN_C = ['13-15','14-16','15-17','12-16','19-15'];
+    const PACE = 1;
+
+    const WAYS = [
+      {
+        id: 'old', label: 'the old way',
+        headline: 'every stack pulls against itself.',
+        sub: 'the work it takes to add a thing is the work it takes to change it.',
+        depT0: 1.0, depGap: 1.8, depDone: 1.7, depStep: 0.3,
+        phases: ['decide', 'install', 'integrate', 'test integration', 'containerize', 'log'],
+        ring: 12.4, ship: 13.0, feat: 21.2, rw: 21.9, dur: 1.25,
+        rework: ['design','integrate','test','redesign','integrate','test','ship','downtime','triage','fix'],
+        bad: [2, 7, 8], down: [7, 8], featFail: 2, featEdge: 1, featLink: 4, featDone: 5, featProd: 6,
+        redesign: 3, pfault: true,
+        tensions: ['integration <-> use', 'development <-> production', 'architecture <-> extensibility'],
+        desc: [
+          'to use a service you need to integrate a service, often multiple times at different parts of your application.',
+          'what works in development rarely survives the move to production.',
+          'existing architecture always resists extensibility. necessary changes which are impossible to plan for slow advancement.'
+        ]
+      },
+      {
+        id: 'iii', label: 'the iii way',
+        headline: 'the same stack, without the seams.',
+        sub: 'decide, add. what runs in dev is what runs in prod. extending it is test, ship.',
+        depT0: 0.8, depGap: 0.95, depDone: 0.55, depStep: 0.34,
+        phases: ['decide', 'add'],
+        ring: 6.4, ship: 7.0, feat: 9.6, rw: 10.4, dur: 1.25,
+        rework: ['test', 'ship'],
+        bad: [], down: [], featFail: -1, featEdge: 0, featLink: 0, featDone: 0, featProd: 1,
+        redesign: -1, pfault: false,
+        tensions: ['integration = use', 'development = production', 'architecture = extensibility'],
+        desc: [
+          'a service is a worker. decide, add — using it is the same act as integrating it, once.',
+          'the system you run in dev is the system that runs in prod. nothing is re-made to move it.',
+          'a new worker joins a running system. nothing is redesigned, nothing breaks: test, ship.'
+        ]
+      }
+    ];
+
+    // ---- DOM the engine drives ----
+    const $tensions = document.getElementById('fanim-tensions');
+    const $ways = stage.querySelectorAll('.fanim-ways button');
+
+    const tensionEls = WAYS[0].tensions.map((_, i) => {
+      const el = document.createElement('div');
+      el.className = 'fanim-tension';
+      el.innerHTML =
+        '<div class="fanim-tension-head">' +
+        '<span class="fanim-tension-bar"></span><span class="fanim-tension-name"></span></div>' +
+        '<div class="fanim-tension-body"><p></p></div>';
+      el.addEventListener('click', () => jumpTension(i));
+      $tensions.appendChild(el);
+      return {
+        el,
+        name: el.querySelector('.fanim-tension-name'),
+        desc: el.querySelector('.fanim-tension-body p')
+      };
+    });
+
+    // ---- State ----
+    const state = { way: 0, sub: 0, ph: -1 };
+    let P = [], E = {}, C = {}, colorTries = 0;
+    let t0 = performance.now(), last = t0, raf = null, dtLast = 0.016;
+    let w = 0, h = 0, dpr = 1, cx = 0, cy = 0, sized = false;
+    let logX, logY;
+
+    const W = () => WAYS[state.way];
+    const end = () => { const s = W(); return s.rw + s.rework.length * s.dur + 2.6; };
+    const phase = (st) => {
+      const s = W();
+      return st > s.rw ? Math.min(s.rework.length - 1, Math.floor((st - s.rw) / s.dur)) : -1;
+    };
+    const arrive = (i) => { const s = W(); return s.depT0 + i * s.depGap; };
+    const now = () => ((performance.now() - t0) / 1000) * PACE;
+
+    function recolor(){
+      const cs = getComputedStyle(canvas);
+      const v = (n, fb) => cs.getPropertyValue(n).trim() || fb;
+      const dark = document.documentElement.getAttribute('data-theme') === 'dark';
+      C = {
+        ink: v('--ink', dark ? '#f2f0ed' : '#0a0a0a'),
+        faint: v('--ink-faint', dark ? '#9c9893' : '#6b6865'),
+        ghost: v('--ink-ghost', dark ? '#5d5a55' : '#a3a09c'),
+        rule: v('--rule', dark ? '#2a2926' : '#d8d4cb'),
+        accent: v('--accent', dark ? '#3ea8ff' : '#ff5a1f'),
+        bg: v('--bg', dark ? '#111110' : '#f5f3ee'),
+        ok: dark ? 'oklch(0.72 0.13 152)' : 'oklch(0.56 0.11 150)'
+      };
+      if (!cs.getPropertyValue('--ink').trim() && ++colorTries < 60) setTimeout(recolor, 100);
+    }
+
+    function resize(){
+      const r = canvas.getBoundingClientRect();
+      dpr = Math.min(2, window.devicePixelRatio || 1);
+      canvas.width = Math.max(1, Math.round(r.width * dpr));
+      canvas.height = Math.max(1, Math.round(r.height * dpr));
+      w = r.width; h = r.height;
+      // Vertically centred: the headline block that used to sit under the
+      // drawing is gone, so there is nothing to leave room for.
+      cx = r.width * 0.5; cy = r.height * 0.42;
+      sized = true;
+      render();
+    }
+
+    function reset(){
+      t0 = performance.now(); logX = undefined;
+      P.forEach((p) => { p.born = false; p.a = 0; p.d = 0; p.f = 0; });
+    }
+
+    function setWay(n){
+      if (n === state.way){ reset(); state.sub = 0; state.ph = -1; render(); return; }
+      reset();
+      state.way = n; state.sub = 0; state.ph = -1;
+      render();
+    }
+
+    function jumpTension(i){
+      const s = W();
+      const at = i === 0 ? 0.2 : i === 1 ? s.ring - 0.3 : s.feat - 0.5;
+      logX = undefined;
+      P.forEach((p, n) => { if (i === 0 || n >= 6){ p.born = false; p.a = 0; p.d = 0; p.f = 0; } });
+      t0 = performance.now() - (at * 1000) / PACE;
+      state.sub = i; state.ph = phase(at);
+      render();
+    }
+
+    function zones(){
+      // The tensions park along the top now, so the drawing gets the full width,
+      // and dev/prod sit symmetrically about the centre.
+      const L = 40, R = Math.max(400, w - 40), span = R - L;
+      const dev = L + span * 0.27, prod = L + span * 0.73;
+      // g scales the whole drawing. The original capped it at 1, which pinned
+      // the clusters to their 1200px-wide size however big the stage got.
+      const g = Math.max(0.9, Math.min(2.2, Math.min(w / 1000, h / 620) * 1.35));
+      return { dev, prod, mid: (dev + prod) / 2, g };
+    }
+
+    const proj = (x, y) => ({ x: cx + x, y: cy + y, f: 1 });
+
+    // Where the active tension card docks, and where the dev/prod divider ends.
+    const dockY = () => Math.min(cy + 150 * zones().g, h - 180);
+
+    function target(i, st){
+      const s = W(), p = P[i];
+      const z = zones();
+      const devX = z.dev - w / 2, prodX = z.prod - w / 2, g = z.g;
+      const ph = phase(st);
+      if (i < 6){
+        const on = st > arrive(i);
+        if (on && !p.born){ p.born = true; p.x = devX + OFF[i][0] * 1.9 * g; p.y = OFF[i][1] * 1.9 * g; }
+        return { x: devX + OFF[i][0] * g, y: OFF[i][1] * g, a: on ? 1 : 0, f: 0, d: st > arrive(i) + s.depDone ? 1 : 0 };
+      }
+      if (i < 10){
+        const k = i - 6, on = st > s.feat + k * 0.25;
+        const o = s.redesign >= 0 && ph >= s.redesign ? FOFF2[k] : FOFF[k];
+        if (on && !p.born){ p.born = true; p.x = devX + o[0] * g; p.y = h * 0.7; }
+        const fault = s.featFail >= 0 && ph === s.featFail && (i === 7 || i === 9) ? 1 : 0;
+        return { x: devX + o[0] * g, y: o[1] * g, a: on ? 1 : 0, f: fault, d: ph >= s.featDone ? 1 : 0 };
+      }
+      if (i >= 12 && i < 18){
+        const k = i - 12, on = st > s.ship;
+        if (on && !p.born){ p.born = true; p.x = devX + OFF[k][0] * g; p.y = OFF[k][1] * g; }
+        const down = s.down.indexOf(ph) >= 0;
+        const moveFail = s.pfault && st > s.ship + 1.7 && st < s.feat - 1.6 && (k === 2 || k === 4);
+        const fault = (down && k > 0 && k < 5) || moveFail ? 1 : 0;
+        return { x: prodX + OFF[k][0] * g, y: OFF[k][1] * g, a: on ? 1 : 0, f: fault, d: 1 };
+      }
+      if (i >= 18){
+        const k = i - 18, on = ph >= s.featProd;
+        const o = s.redesign >= 0 ? FOFF2[k] : FOFF[k];
+        if (on && !p.born){ p.born = true; p.x = devX + o[0] * g; p.y = o[1] * g; }
+        const fault = s.down.indexOf(ph) >= 0 && k === 1 ? 1 : 0;
+        return { x: prodX + o[0] * g, y: o[1] * g, a: on ? 1 : 0, f: fault, d: 1 };
+      }
+      return { x: 0, y: 0, a: 0, f: 0, d: 0 };
+    }
+
+    function wantEdges(st){
+      const s = W(), want = {}, ph = phase(st);
+      const down = s.down.indexOf(ph) >= 0;
+      E1.forEach(([a, b]) => { if (st > arrive(Math.max(a, b)) + 0.9) want[a + '-' + b] = 0; });
+      if (ph >= s.featEdge){ want['6-7'] = 0; want['7-8'] = 0; want['8-9'] = 0; want['6-9'] = 0; want['6-1'] = 0; }
+      if (s.featFail >= 0 && ph >= s.featEdge && ph <= s.featFail){
+        want['8-4'] = ph === s.featFail ? 1 : 0;
+        want['9-2'] = ph === s.featFail ? 1 : 0;
+      }
+      if (ph >= s.featLink){ want['7-3'] = 0; want['9-5'] = 0; want['8-4'] = 0; }
+      const moving = s.pfault && st > s.ship + 1.7 && st < s.feat - 1.6;
+      if (st > s.ship + 0.3) E1C.forEach(([a, b]) => {
+        const key = a + '-' + b;
+        if (moving && key === '13-17') return;
+        want[key] = (down && BROKEN_C.indexOf(key) >= 0) || (moving && (key === '14-16' || key === '15-17')) ? 1 : 0;
+      });
+      if (ph >= s.featProd) ['18-19','19-20','20-21','18-21','18-13','19-15','21-17'].forEach((key) => {
+        want[key] = down && BROKEN_C.indexOf(key) >= 0 ? 1 : 0;
+      });
+      return want;
+    }
+
+    function frame(stamp){
+      let dt = ((stamp - last) / 1000) * PACE; last = stamp;
+      dt = Math.min(0.05, dt); dtLast = dt;
+      const st = now();
+      const k = 1 - Math.exp(-7 * dt);
+
+      if (st > end()) setWay(state.way === 0 ? 1 : 0);
+
+      for (let i = 0; i < N; i++){
+        if (i >= 10 && i < 12) continue;
+        const p = P[i], t = target(i, st);
+        const kk = i >= 12 ? 1 - Math.exp(-1.6 * dt) : k;
+        p.x += (t.x - p.x) * kk; p.y += (t.y - p.y) * kk;
+        p.a += (t.a - p.a) * (1 - Math.exp(-6 * dt));
+        p.f += (t.f - p.f) * (1 - Math.exp(-5 * dt));
+        p.d = (p.d || 0) + ((t.d || 0) - (p.d || 0)) * (1 - Math.exp(-5 * dt));
+      }
+      const want = wantEdges(st);
+      for (const key in E){
+        const e = E[key], has = key in want;
+        e.w += ((has ? 1 : 0) - e.w) * (1 - Math.exp(-4.5 * dt));
+        e.br += ((has && want[key] ? 1 : 0) - e.br) * (1 - Math.exp(-5 * dt));
+      }
+      draw(st);
+      sync(st);
+      raf = requestAnimationFrame(frame);
+    }
+
+    function sync(st){
+      const s = W();
+      const sub = st > s.feat - 0.6 ? 2 : st > s.ring - 0.4 ? 1 : 0;
+      const ph = phase(st);
+      if (sub !== state.sub || ph !== state.ph){ state.sub = sub; state.ph = ph; render(); }
+    }
+
+    function draw(st){
+      const ctx = canvas.getContext('2d'), s = W();
+      const ph = phase(st);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, w, h);
+      ctx.lineWidth = 1;
+      ctx.font = "500 15px 'Chivo Mono', ui-monospace, monospace";
+      ctx.textAlign = 'center';
+
+      ctx.globalAlpha = 0.9;
+      ctx.strokeStyle = C.rule;
+      const mid = Math.round(zones().mid);
+      const dEnd = dockY() - 34;
+      // The divider starts level with the top of the labels, which sit clear of
+      // the parked tensions above them.
+      const labelY = 150;
+      ctx.beginPath(); ctx.moveTo(mid + 0.5, labelY - 13); ctx.lineTo(mid + 0.5, dEnd); ctx.stroke();
+      ctx.fillStyle = C.ghost;
+      ctx.textAlign = 'right'; ctx.fillText('Development', mid - 18, labelY);
+      ctx.textAlign = 'left'; ctx.fillText('Production', mid + 18, labelY);
+      ctx.textAlign = 'center';
+
+      const pts = P.map((p) => proj(p.x, p.y));
+
+      for (const key in E){
+        const e = E[key]; if (e.w < 0.02) continue;
+        const A = pts[e.a], B = pts[e.b];
+        const al = Math.min(P[e.a].a, P[e.b].a) * e.w;
+        if (al < 0.02) continue;
+        const brk = e.br;
+        const pending = Math.min(P[e.a].d || 0, P[e.b].d || 0) < 0.5;
+        ctx.globalAlpha = al * (brk > 0.5 ? 0.55 : pending ? 0.5 : 0.22);
+        ctx.strokeStyle = brk > 0.5 ? C.accent : pending ? C.ghost : C.ink;
+        if (brk > 0.5){
+          const g = 0.14 + 0.06 * Math.sin(st * 7 + e.a);
+          ctx.beginPath();
+          ctx.moveTo(A.x, A.y); ctx.lineTo(A.x + (B.x - A.x) * (0.5 - g), A.y + (B.y - A.y) * (0.5 - g));
+          ctx.moveTo(A.x + (B.x - A.x) * (0.5 + g), A.y + (B.y - A.y) * (0.5 + g)); ctx.lineTo(B.x, B.y);
+          ctx.stroke();
+        } else {
+          ctx.beginPath(); ctx.moveTo(A.x, A.y);
+          ctx.lineTo(A.x + (B.x - A.x) * e.w, A.y + (B.y - A.y) * e.w); ctx.stroke();
+        }
+      }
+
+      const box = (idx, fade, alarm) => {
+        let x0 = 1e9, y0 = 1e9, x1 = -1e9, y1 = -1e9;
+        idx.forEach((i) => {
+          if (P[i].a > 0.85){
+            x0 = Math.min(x0, pts[i].x); y0 = Math.min(y0, pts[i].y);
+            x1 = Math.max(x1, pts[i].x); y1 = Math.max(y1, pts[i].y);
+          }
+        });
+        if (x1 <= x0) return null;
+        const m = 22 * zones().g;
+        ctx.globalAlpha = (alarm ? 0.85 : 0.55) * fade;
+        ctx.strokeStyle = alarm ? C.accent : C.rule;
+        ctx.strokeRect(Math.round(x0 - m) + 0.5, Math.round(y0 - m) + 0.5, Math.round(x1 - x0 + m * 2), Math.round(y1 - y0 + m * 2));
+        return { x0: x0 - m, y0: y0 - m, x1: x1 + m, y1: y1 + m };
+      };
+      let db = null, pb = null;
+      if (st > s.ring) db = box([0,1,2,3,4,5,6,7,8,9], Math.min(1, (st - s.ring) / 0.6), s.featFail >= 0 && ph === s.featFail);
+      if (st > s.ship){
+        pb = box([12,13,14,15,16,17,18,19,20,21], Math.min(1, (st - s.ship) / 0.6), s.down.indexOf(ph) >= 0);
+        const shipping = (st > s.ship && st < s.ship + 2.2) || ph === s.featProd;
+        if (pb && shipping){
+          ctx.globalAlpha = 0.8; ctx.fillStyle = C.faint;
+          ctx.fillText(state.way === 0 ? 'ship' : 'identical', (pb.x0 + pb.x1) / 2, pb.y1 + 26);
+        }
+      }
+      const anchor = ph >= s.featProd ? (pb || db) : (db || pb);
+      if (ph >= 0 && anchor){
+        const raw = (st - s.rw) / s.dur, lastPh = s.rework.length - 1;
+        const fr = raw >= lastPh ? Math.min(1, raw - lastPh) : raw % 1;
+        const tx = anchor.x0 - 14, ty = Math.max(anchor.y0 + 14, 152);
+        if (logX === undefined){ logX = tx; logY = ty; }
+        const ks = 1 - Math.exp(-2.6 * Math.min(0.05, dtLast || 0.016));
+        logX += (tx - logX) * ks; logY += (ty - logY) * ks;
+        ctx.textAlign = 'right';
+        for (let j = Math.min(4, ph); j >= 0; j--){
+          const a = Math.max(0, 1 - (j + fr) * 0.26);
+          if (a <= 0.02) continue;
+          const bad = s.bad.indexOf(ph - j) >= 0;
+          ctx.globalAlpha = a * 0.95; ctx.fillStyle = bad ? C.accent : C.faint;
+          ctx.fillText(s.rework[ph - j], logX, logY + (j + fr) * 23);
+        }
+        ctx.textAlign = 'center';
+      }
+
+      let cur = -1;
+      for (let i = 0; i < 6; i++) if (st > arrive(i) && st < arrive(i) + s.depGap) cur = i;
+      if (cur >= 0){
+        const raw = (st - arrive(cur)) / s.depStep, lastPh = s.phases.length - 1;
+        const p2 = Math.min(lastPh, Math.floor(raw)), fr = raw >= lastPh ? Math.min(1, raw - lastPh) : raw % 1;
+        ctx.textAlign = 'center'; ctx.fillStyle = C.faint;
+        for (let j = Math.min(2, p2); j >= 0; j--){
+          const a = Math.max(0, 1 - (j + fr) * 0.36);
+          if (a <= 0.02) continue;
+          ctx.globalAlpha = a * 0.95;
+          const px = Math.min(pts[cur].x, zones().mid - 110);
+          ctx.fillText(s.phases[p2 - j], px, pts[cur].y + 30 + (j + fr) * 20);
+        }
+      }
+
+      for (let i = 0; i < N; i++){
+        const p = P[i]; if (p.a < 0.02) continue;
+        const size = 5.5, half = size / 2;
+        ctx.globalAlpha = p.a;
+        if (p.f > 0.4){
+          ctx.fillStyle = C.accent; ctx.fillRect(pts[i].x - half - 1, pts[i].y - half - 1, size + 2, size + 2);
+          ctx.globalAlpha = p.a * 0.4; ctx.strokeStyle = C.accent;
+          ctx.strokeRect(Math.round(pts[i].x - half - 5) + 0.5, Math.round(pts[i].y - half - 5) + 0.5, Math.round(size + 10), Math.round(size + 10));
+        } else if ((p.d || 0) > 0.5){
+          ctx.fillStyle = C.ok; ctx.fillRect(pts[i].x - half, pts[i].y - half, size, size);
+        } else {
+          ctx.globalAlpha = p.a * 0.8; ctx.strokeStyle = C.ghost;
+          ctx.strokeRect(Math.round(pts[i].x - half) + 0.5, Math.round(pts[i].y - half) + 0.5, Math.round(size), Math.round(size));
+        }
+      }
+      ctx.globalAlpha = 1;
+    }
+
+    // ---- DOM render: nav state and where each tension sits ----
+    function render(){
+      const s = W();
+      $ways.forEach((b) => b.classList.toggle('on', Number(b.dataset.way) === state.way));
+
+      if (!sized) return;
+      const z = zones();
+      const ay = dockY();
+      const x0 = Math.max(215, Math.min(z.dev, w - 460));
+      const x1 = Math.max(x0 + 190, Math.min(z.mid, w - 250));
+      const x2 = Math.max(x1 + 190, Math.min(z.prod, w - 60));
+      const at = [x0, x1, x2];
+      // Parked: a centred row along the top, under the bar. Active: docked to
+      // the moment in the story it belongs to.
+      const cardW = Math.min(520, w - 72);
+      const colW = Math.min(400, (w - 72) / 3);
+      const rowLeft = (w - colW * 3) / 2;
+      tensionEls.forEach((t, i) => {
+        const on = i === state.sub;
+        t.name.textContent = s.tensions[i];
+        t.desc.textContent = s.desc[i];
+        t.el.classList.toggle('on', on);
+        t.el.style.left =
+          (on ? Math.max(16, Math.min(at[i] - cardW / 2, w - cardW - 16)) : rowLeft + i * colW) + 'px';
+        t.el.style.top = (on ? ay : 78) + 'px';
+        t.el.style.width = (on ? cardW : colW - 24) + 'px';
+        t.el.style.opacity = on ? '1' : '0.55';
+      });
+    }
+
+    // ---- Wiring ----
+    for (let i = 0; i < N; i++) P.push({ x: 0, y: 0, z: 0, a: 0, f: 0, d: 0, born: false });
+    const addEdges = (l) => l.forEach(([a, b]) => { E[a + '-' + b] = { a, b, w: 0, br: 0 }; });
+    addEdges(E1); addEdges(EF); addEdges(E1C); addEdges(EFC);
+    recolor();
+    resize();
+
+    $ways.forEach((b) => b.addEventListener('click', () => setWay(Number(b.dataset.way))));
+
+    new ResizeObserver(resize).observe(canvas);
+    // The site's theme toggle rewrites data-theme on <html>; the canvas colors
+    // are read once and have to be re-read when it does.
+    new MutationObserver(recolor).observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme']
+    });
+
+    // Only run while on screen.
+    new IntersectionObserver((ents) => {
+      for (const e of ents){
+        if (e.isIntersecting && !raf){
+          last = performance.now();
+          raf = requestAnimationFrame(frame);
+        } else if (!e.isIntersecting && raf){
+          cancelAnimationFrame(raf);
+          raf = null;
+        }
+      }
+    }, { threshold: 0.05 }).observe(stage);
+  })();
+</script>

--- a/website/src/components/landing/scripts/08-friction-anim.html
+++ b/website/src/components/landing/scripts/08-friction-anim.html
@@ -36,6 +36,9 @@
       },
       {
         id: 'iii', label: 'the iii way',
+        // Half the steps, so it plays slower: otherwise the phase captions are
+        // gone before they can be read.
+        rate: 0.6,
         headline: 'the same stack, without the seams.',
         sub: 'decide, add. what runs in dev is what runs in prod. extending it is test, ship.',
         depT0: 0.8, depGap: 0.95, depDone: 0.55, depStep: 0.34,
@@ -52,6 +55,16 @@
         ]
       }
     ];
+
+    // Each list item holds for the same wall-clock time on both sides, whatever
+    // the side's rate is: a rework step for STEP_S, a phase caption for PHASE_S.
+    // Story time runs at `rate`, so the story-time values are scaled by it.
+    const STEP_S = 1.25, PHASE_S = 0.3;
+    WAYS.forEach((s) => {
+      const r = s.rate || 1;
+      s.dur = STEP_S * r;
+      s.depStep = PHASE_S * r;
+    });
 
     // ---- DOM the engine drives ----
     const $tensions = document.getElementById('fanim-tensions');
@@ -88,7 +101,8 @@
       return st > s.rw ? Math.min(s.rework.length - 1, Math.floor((st - s.rw) / s.dur)) : -1;
     };
     const arrive = (i) => { const s = W(); return s.depT0 + i * s.depGap; };
-    const now = () => ((performance.now() - t0) / 1000) * PACE;
+    const pace = () => PACE * (W().rate || 1);
+    const now = () => ((performance.now() - t0) / 1000) * pace();
 
     function recolor(){
       const cs = getComputedStyle(canvas);
@@ -136,7 +150,7 @@
       const at = i === 0 ? 0.2 : i === 1 ? s.ring - 0.3 : s.feat - 0.5;
       logX = undefined;
       P.forEach((p, n) => { if (i === 0 || n >= 6){ p.born = false; p.a = 0; p.d = 0; p.f = 0; } });
-      t0 = performance.now() - (at * 1000) / PACE;
+      t0 = performance.now() - (at * 1000) / pace();
       state.sub = i; state.ph = phase(at);
       render();
     }
@@ -215,7 +229,7 @@
     }
 
     function frame(stamp){
-      let dt = ((stamp - last) / 1000) * PACE; last = stamp;
+      let dt = ((stamp - last) / 1000) * pace(); last = stamp;
       dt = Math.min(0.05, dt); dtLast = dt;
       const st = now();
       const k = 1 - Math.exp(-7 * dt);

--- a/website/src/components/landing/sections/02-explained.html
+++ b/website/src/components/landing/sections/02-explained.html
@@ -219,7 +219,7 @@
   </style>
 
   <header class="lens-head">
-    <span class="lens-idx">§ 01 · EXPLAINED</span>
+    <span class="lens-idx">§ 04 · EXPLAINED</span>
     <h2 class="lens-title">
       <span class="accent">iii is many things.</span>
       <span class="mute"
@@ -505,7 +505,7 @@
   </style>
 
   <header class="surf-head">
-    <span class="surf-idx">§ 02 · ONE SURFACE</span>
+    <span class="surf-idx">§ 05 · ONE SURFACE</span>
     <h2 class="surf-title">
       <span class="accent">one system.</span>
       <span class="mute"

--- a/website/src/components/landing/sections/02-explained.html
+++ b/website/src/components/landing/sections/02-explained.html
@@ -1,0 +1,641 @@
+<!-- EXPLAINED — "iii is many things. one system."
+
+       Two sections sharing one visual idea: a lens.
+
+       §01 gathers the seven ways people describe iii and refracts them onto a
+       single focus, which resolves into the three primitives. The diagram
+       never changes as you move between claims; only the lit beam does. That
+       is the argument.
+
+       §02 riffs on the same lens from its other face: what leaves the focus is
+       one continuous surface, against a ghosted "today" rail where
+       development, integration, and production are three separate places.
+
+       Fully self-contained: markup, styles, and script all live in this file. -->
+<section class="lens" id="explained" aria-label="iii explained">
+  <style>
+    .lens {
+      position: relative;
+      padding: 0 0 40px;
+    }
+    .lens-head {
+      padding: 80px 36px 32px;
+    }
+    .lens-idx {
+      display: block;
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 14px;
+    }
+    .lens-title {
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-weight: 500;
+      font-size: clamp(20px, 4.2vw, 28px);
+      line-height: 1.25;
+      letter-spacing: -0.01em;
+      color: var(--ink);
+      margin: 0;
+      max-width: 80%;
+    }
+    .lens-title .accent {
+      color: var(--accent);
+    }
+    .lens-title .mute {
+      color: var(--ink-faint);
+    }
+
+    .lens-body {
+      display: grid;
+      grid-template-columns: minmax(280px, 400px) 1fr;
+      gap: 32px;
+      align-items: start;
+      margin: 0 36px;
+      max-width: 1128px;
+    }
+
+    /* ---- claim list ---- */
+    .lens-claims {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      border-top: 1px solid var(--rule);
+    }
+    .lens-claim {
+      border-bottom: 1px solid var(--rule);
+    }
+    .lens-claim button {
+      display: block;
+      width: 100%;
+      text-align: left;
+      background: none;
+      border: 0;
+      padding: 14px 0;
+      cursor: pointer;
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      color: var(--ink-faint);
+      transition: color 0.2s ease;
+    }
+    .lens-claim button:focus-visible {
+      outline: 1px solid var(--accent);
+      outline-offset: 2px;
+    }
+    .lens-claim-name {
+      display: flex;
+      align-items: baseline;
+      gap: 10px;
+      font-size: 14px;
+      letter-spacing: -0.01em;
+    }
+    .lens-claim-num {
+      font-size: 10px;
+      letter-spacing: 0.12em;
+      color: var(--ink-ghost);
+      min-width: 22px;
+    }
+    .lens-claim[data-on="1"] button {
+      color: var(--ink);
+    }
+    .lens-claim[data-on="1"] .lens-claim-num {
+      color: var(--accent);
+    }
+    /* Every explanation stays expanded. Selecting a claim only moves the
+       highlight, so nothing reflows as the beams switch. */
+    .lens-claim-why > span {
+      display: block;
+      font-size: 13px;
+      line-height: 1.55;
+      color: var(--ink-ghost);
+      padding: 6px 0 0 32px;
+      transition: color 0.2s ease;
+    }
+    .lens-claim[data-on="1"] .lens-claim-why > span {
+      color: var(--ink-faint);
+    }
+
+    /* ---- diagram ---- */
+    .lens-stage {
+      position: sticky;
+      top: 96px;
+    }
+    .lens-svg {
+      width: 100%;
+      height: auto;
+      display: block;
+    }
+    .lens-rail {
+      stroke: var(--rule);
+      stroke-width: 1;
+    }
+    .lens-src {
+      fill: var(--rule);
+      transition: fill 0.25s ease;
+    }
+    .lens-src.on {
+      fill: var(--accent);
+    }
+    .lens-beam {
+      fill: none;
+      stroke: var(--rule);
+      stroke-width: 1;
+      transition:
+        stroke 0.25s ease,
+        stroke-width 0.25s ease,
+        opacity 0.25s ease;
+      opacity: 0.7;
+    }
+    .lens-beam.on {
+      stroke: var(--accent);
+      stroke-width: 1.6;
+      opacity: 1;
+    }
+    .lens-glass {
+      fill: var(--panel);
+      fill-opacity: 0.55;
+      stroke: var(--ink-faint);
+      stroke-width: 1;
+    }
+    .lens-focus {
+      fill: var(--accent);
+    }
+    .lens-focus-halo {
+      fill: var(--accent);
+      opacity: 0.14;
+    }
+    .lens-exit {
+      fill: none;
+      stroke: var(--rule);
+      stroke-width: 1;
+      transition:
+        stroke 0.25s ease,
+        opacity 0.25s ease;
+    }
+    .lens-exit.on {
+      stroke: var(--ink-faint);
+    }
+    .lens-prim {
+      opacity: 0.22;
+      transition: opacity 0.25s ease;
+    }
+    .lens-prim.on {
+      opacity: 1;
+    }
+    .lens-prim-label {
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-size: 13px;
+      fill: var(--ink-faint);
+      transition: fill 0.25s ease;
+    }
+    .lens-prim.on .lens-prim-label {
+      fill: var(--ink);
+    }
+    /* No uppercase transform here: these captions include the word iii,
+         which is always lowercase. */
+    .lens-cap {
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-size: 10px;
+      letter-spacing: 0.14em;
+      fill: var(--ink-ghost);
+    }
+
+    @media (max-width: 900px) {
+      .lens-body {
+        grid-template-columns: 1fr;
+        margin: 0 18px;
+      }
+      .lens-stage {
+        position: static;
+        order: -1;
+      }
+      .lens-head {
+        padding: 56px 18px 24px;
+      }
+      .lens-title {
+        max-width: 100%;
+      }
+    }
+  </style>
+
+  <header class="lens-head">
+    <span class="lens-idx">§ 01 · EXPLAINED</span>
+    <h2 class="lens-title">
+      <span class="accent">iii is many things.</span>
+      <span class="mute"
+        ><b style="color: var(--ink); font-weight: 500">one system.</b><br />every description below
+        is the same three primitives seen from a different angle.</span
+      >
+    </h2>
+  </header>
+
+  <div class="lens-body">
+    <ul class="lens-claims" id="lens-claims">
+      <li class="lens-claim" data-on="1" data-i="0" data-prim="trigger">
+        <button type="button" aria-pressed="true">
+          <span class="lens-claim-name"><span class="lens-claim-num">01</span>a protocol</span>
+          <span class="lens-claim-why"
+            ><span
+              >one wire format that every language and every service already speaks.</span
+            ></span
+          >
+        </button>
+      </li>
+      <li class="lens-claim" data-on="0" data-i="1" data-prim="worker trigger function">
+        <button type="button" aria-pressed="false">
+          <span class="lens-claim-name"
+            ><span class="lens-claim-num">02</span>a small set of primitives</span
+          >
+          <span class="lens-claim-why"
+            ><span
+              >worker, trigger, function. everything else is a composition of the three.</span
+            ></span
+          >
+        </button>
+      </li>
+      <li class="lens-claim" data-on="0" data-i="2" data-prim="worker">
+        <button type="button" aria-pressed="false">
+          <span class="lens-claim-name"
+            ><span class="lens-claim-num">03</span>a worker orchestrator</span
+          >
+          <span class="lens-claim-why"
+            ><span>starts, supervises, and restarts every process that connects.</span></span
+          >
+        </button>
+      </li>
+      <li class="lens-claim" data-on="0" data-i="3" data-prim="worker">
+        <button type="button" aria-pressed="false">
+          <span class="lens-claim-name"><span class="lens-claim-num">04</span>a registry</span>
+          <span class="lens-claim-why"
+            ><span>iii worker add stripe. a capability installs like a package.</span></span
+          >
+        </button>
+      </li>
+      <li class="lens-claim" data-on="0" data-i="4" data-prim="worker">
+        <button type="button" aria-pressed="false">
+          <span class="lens-claim-name"
+            ><span class="lens-claim-num">05</span>a compose file, and a swarm</span
+          >
+          <span class="lens-claim-why"
+            ><span>declare the system once, run it on one machine or on a hundred.</span></span
+          >
+        </button>
+      </li>
+      <li class="lens-claim" data-on="0" data-i="5" data-prim="function">
+        <button type="button" aria-pressed="false">
+          <span class="lens-claim-name"
+            ><span class="lens-claim-num">06</span>an agentic development environment</span
+          >
+          <span class="lens-claim-why"
+            ><span
+              >agents read a live system's functions and triggers instead of guessing at them.</span
+            ></span
+          >
+        </button>
+      </li>
+      <li class="lens-claim" data-on="0" data-i="6" data-prim="worker trigger function">
+        <button type="button" aria-pressed="false">
+          <span class="lens-claim-name"
+            ><span class="lens-claim-num">07</span>a self-extensible application</span
+          >
+          <span class="lens-claim-why"
+            ><span>a running system gains capability without being redesigned.</span></span
+          >
+        </button>
+      </li>
+    </ul>
+
+    <div class="lens-stage">
+      <svg
+        class="lens-svg"
+        viewBox="0 0 800 440"
+        role="img"
+        aria-label="Seven descriptions of iii refracting through a lens onto three primitives: worker, trigger, and function."
+      >
+        <text class="lens-cap" x="60" y="24">descriptions</text>
+        <text class="lens-cap" x="332" y="24" text-anchor="middle">iii</text>
+        <text class="lens-cap" x="640" y="24" text-anchor="middle">primitives</text>
+
+        <line class="lens-rail" x1="60" y1="45" x2="60" y2="375" />
+
+        <!-- Beams bend at the lens's left face. The bend x is the face curve
+               sampled at each source height, so the refraction reads true. -->
+        <g id="lens-beams">
+          <path class="lens-beam on" data-i="0" d="M 60 45 L 356.9 45 L 560 210" />
+          <path class="lens-beam" data-i="1" d="M 60 100 L 343.1 100 L 560 210" />
+          <path class="lens-beam" data-i="2" d="M 60 155 L 334.8 155 L 560 210" />
+          <path class="lens-beam" data-i="3" d="M 60 210 L 332 210 L 560 210" />
+          <path class="lens-beam" data-i="4" d="M 60 265 L 334.8 265 L 560 210" />
+          <path class="lens-beam" data-i="5" d="M 60 320 L 343.1 320 L 560 210" />
+          <path class="lens-beam" data-i="6" d="M 60 375 L 356.9 375 L 560 210" />
+        </g>
+
+        <g id="lens-srcs">
+          <circle class="lens-src on" data-i="0" cx="60" cy="45" r="4" />
+          <circle class="lens-src" data-i="1" cx="60" cy="100" r="4" />
+          <circle class="lens-src" data-i="2" cx="60" cy="155" r="4" />
+          <circle class="lens-src" data-i="3" cx="60" cy="210" r="4" />
+          <circle class="lens-src" data-i="4" cx="60" cy="265" r="4" />
+          <circle class="lens-src" data-i="5" cx="60" cy="320" r="4" />
+          <circle class="lens-src" data-i="6" cx="60" cy="375" r="4" />
+        </g>
+
+        <path class="lens-glass" d="M 360 35 Q 388 210 360 385 Q 332 210 360 35 Z" />
+
+        <circle class="lens-focus-halo" cx="560" cy="210" r="18" />
+        <circle class="lens-focus" cx="560" cy="210" r="4" />
+
+        <g class="lens-prim on" data-prim="worker">
+          <path class="lens-exit on" d="M 560 210 L 628 150" />
+          <circle cx="640" cy="140" r="15" fill="#42e7e7" />
+          <text class="lens-prim-label" x="668" y="146">worker</text>
+        </g>
+        <g class="lens-prim on" data-prim="trigger">
+          <path class="lens-exit on" d="M 560 210 L 626 210" />
+          <rect x="626" y="196" width="28" height="28" fill="#f3943d" />
+          <text class="lens-prim-label" x="668" y="216">trigger</text>
+        </g>
+        <g class="lens-prim on" data-prim="function">
+          <path class="lens-exit on" d="M 560 210 L 628 268" />
+          <rect
+            x="626"
+            y="266"
+            width="28"
+            height="28"
+            fill="#ef2e61"
+            transform="rotate(45 640 280)"
+          />
+          <text class="lens-prim-label" x="668" y="286">function</text>
+        </g>
+      </svg>
+    </div>
+  </div>
+</section>
+
+<!-- ONE SURFACE — the same lens, read from its other face. -->
+<section class="surf" id="one-surface" aria-label="One surface">
+  <style>
+    .surf {
+      position: relative;
+      padding: 0 0 96px;
+    }
+    .surf-head {
+      padding: 72px 36px 28px;
+    }
+    .surf-idx {
+      display: block;
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 14px;
+    }
+    .surf-title {
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-weight: 500;
+      font-size: clamp(20px, 4.2vw, 28px);
+      line-height: 1.25;
+      letter-spacing: -0.01em;
+      color: var(--ink);
+      margin: 0;
+      max-width: 80%;
+    }
+    .surf-title .accent {
+      color: var(--accent);
+    }
+    .surf-title .mute {
+      color: var(--ink-faint);
+    }
+    .surf-stage {
+      margin: 0 36px;
+      max-width: 1128px;
+    }
+    .surf-svg {
+      width: 100%;
+      height: auto;
+      display: block;
+    }
+    /* Same as .lens-cap: no uppercase, "with iii" must stay lowercase. */
+    .surf-cap {
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-size: 10px;
+      letter-spacing: 0.14em;
+      fill: var(--ink-ghost);
+    }
+    .surf-stage-label {
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-size: 13px;
+      fill: var(--ink-faint);
+    }
+    .surf-box {
+      fill: none;
+      stroke: var(--rule);
+      stroke-width: 1;
+    }
+    .surf-seam {
+      stroke: var(--ink-ghost);
+      stroke-width: 1;
+      stroke-dasharray: 3 4;
+    }
+    .surf-seam-label {
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-size: 9px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      fill: var(--ink-ghost);
+    }
+    .surf-glass {
+      fill: var(--panel);
+      fill-opacity: 0.55;
+      stroke: var(--ink-faint);
+      stroke-width: 1;
+    }
+    .surf-cone {
+      fill: var(--accent);
+      opacity: 0.1;
+    }
+    .surf-band {
+      fill: var(--accent);
+      opacity: 0.08;
+    }
+    .surf-line {
+      stroke: var(--accent);
+      stroke-width: 1.6;
+      fill: none;
+    }
+    /* One packet runs the full length of the band, never stopping at a
+         boundary. That continuity is the whole point of the section. */
+    .surf-packet {
+      fill: var(--accent);
+    }
+    .surf-packet-path {
+      fill: none;
+      stroke: none;
+    }
+    @media (prefers-reduced-motion: no-preference) {
+      .surf-packet {
+        animation: surf-run 5.4s linear infinite;
+      }
+    }
+    @keyframes surf-run {
+      from {
+        transform: translateX(0);
+      }
+      to {
+        transform: translateX(560px);
+      }
+    }
+    .surf-live-label {
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-size: 13px;
+      fill: var(--ink);
+    }
+    @media (max-width: 900px) {
+      .surf-head {
+        padding: 56px 18px 24px;
+      }
+      .surf-title {
+        max-width: 100%;
+      }
+      .surf-stage {
+        margin: 0 18px;
+      }
+    }
+  </style>
+
+  <header class="surf-head">
+    <span class="surf-idx">§ 02 · ONE SURFACE</span>
+    <h2 class="surf-title">
+      <span class="accent">one system.</span>
+      <span class="mute"
+        ><b style="color: var(--ink); font-weight: 500">one surface.</b><br />
+        development, integration, and production stop being three different places with handoffs
+        between them.</span
+      >
+    </h2>
+  </header>
+
+  <div class="surf-stage">
+    <svg
+      class="surf-svg"
+      viewBox="0 0 800 330"
+      role="img"
+      aria-label="Today, development, integration, and production are three separate boxes with handoffs between them. With iii they sit on one continuous beam leaving the lens."
+    >
+      <!-- today: three places, two handoffs -->
+      <text class="surf-cap" x="100" y="34">today</text>
+
+      <rect class="surf-box" x="100" y="52" width="160" height="66" />
+      <text class="surf-stage-label" x="180" y="90" text-anchor="middle">development</text>
+
+      <line class="surf-seam" x1="290" y1="46" x2="290" y2="124" />
+      <text class="surf-seam-label" x="290" y="140" text-anchor="middle">handoff</text>
+
+      <rect class="surf-box" x="320" y="52" width="160" height="66" />
+      <text class="surf-stage-label" x="400" y="90" text-anchor="middle">integration</text>
+
+      <line class="surf-seam" x1="510" y1="46" x2="510" y2="124" />
+      <text class="surf-seam-label" x="510" y="140" text-anchor="middle">handoff</text>
+
+      <rect class="surf-box" x="540" y="52" width="160" height="66" />
+      <text class="surf-stage-label" x="620" y="90" text-anchor="middle">production</text>
+
+      <!-- iii: the lens's far face, one beam, no seams -->
+      <text class="surf-cap" x="100" y="196">with iii</text>
+
+      <path class="surf-glass" d="M 60 190 Q 78 232 60 274 Q 42 232 60 190 Z" />
+      <path class="surf-cone" d="M 68 232 L 140 202 L 140 262 Z" />
+      <rect class="surf-band" x="140" y="202" width="560" height="60" />
+      <line class="surf-line" x1="140" y1="232" x2="700" y2="232" />
+
+      <circle class="surf-packet" cx="140" cy="232" r="4" />
+
+      <circle cx="240" cy="232" r="9" fill="#42e7e7" />
+      <rect x="391" y="223" width="18" height="18" fill="#f3943d" />
+      <rect x="591" y="223" width="18" height="18" fill="#ef2e61" transform="rotate(45 600 232)" />
+
+      <text class="surf-live-label" x="240" y="292" text-anchor="middle">development</text>
+      <text class="surf-live-label" x="400" y="292" text-anchor="middle">integration</text>
+      <text class="surf-live-label" x="600" y="292" text-anchor="middle">production</text>
+    </svg>
+  </div>
+</section>
+
+<script>
+  (function () {
+    var list = document.getElementById("lens-claims");
+    if (!list) return;
+    var claims = Array.prototype.slice.call(list.querySelectorAll(".lens-claim"));
+    var beams = Array.prototype.slice.call(document.querySelectorAll(".lens-beam"));
+    var srcs = Array.prototype.slice.call(document.querySelectorAll(".lens-src"));
+    var prims = Array.prototype.slice.call(document.querySelectorAll(".lens-prim"));
+    var timer = null;
+    var manual = false;
+
+    function select(i) {
+      var lit = (claims[i].getAttribute("data-prim") || "").split(" ");
+      claims.forEach(function (c, n) {
+        c.setAttribute("data-on", n === i ? "1" : "0");
+        c.querySelector("button").setAttribute("aria-pressed", n === i ? "true" : "false");
+      });
+      beams.forEach(function (b, n) {
+        b.classList.toggle("on", n === i);
+      });
+      srcs.forEach(function (s, n) {
+        s.classList.toggle("on", n === i);
+      });
+      prims.forEach(function (p) {
+        var on = lit.indexOf(p.getAttribute("data-prim")) !== -1;
+        p.classList.toggle("on", on);
+        p.querySelector(".lens-exit").classList.toggle("on", on);
+      });
+    }
+
+    function stop() {
+      manual = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    }
+
+    claims.forEach(function (c, i) {
+      var btn = c.querySelector("button");
+      btn.addEventListener("click", function () {
+        stop();
+        select(i);
+      });
+      btn.addEventListener("focus", function () {
+        stop();
+        select(i);
+      });
+    });
+
+    // Markup ships with every primitive lit so the diagram is complete
+    // without JS; sync it to the active claim as soon as we can drive it.
+    select(0);
+
+    var still = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (still || !("IntersectionObserver" in window)) return;
+
+    var i = 0;
+    new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (e) {
+          if (manual) return;
+          if (e.isIntersecting && !timer) {
+            timer = setInterval(function () {
+              i = (i + 1) % claims.length;
+              select(i);
+            }, 3200);
+          } else if (!e.isIntersecting && timer) {
+            clearInterval(timer);
+            timer = null;
+          }
+        });
+      },
+      { threshold: 0.35 },
+    ).observe(list);
+  })();
+</script>

--- a/website/src/components/landing/sections/02a-friction.html
+++ b/website/src/components/landing/sections/02a-friction.html
@@ -1,0 +1,265 @@
+<!-- FRICTION — the argument in three scenes.
+     scene 01: the tensions iii removes.
+     scene 02: what iii provides (the same claims as "iii is many things").
+     scene 03: what the result is.
+     Self-contained: markup and styles live in this file, no script. -->
+<section class="fric" id="friction" aria-label="What iii removes, provides, and produces">
+  <style>
+    .fric {
+      position: relative;
+      padding: 0 0 40px;
+    }
+    .fric-scene {
+      margin: 0 36px;
+      max-width: 1128px;
+      padding: 64px 0 0;
+    }
+    .fric-idx {
+      display: block;
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 14px;
+    }
+    .fric-title {
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-weight: 500;
+      font-size: clamp(20px, 4.2vw, 28px);
+      line-height: 1.25;
+      letter-spacing: -0.01em;
+      color: var(--ink);
+      margin: 0 0 32px;
+      max-width: 80%;
+    }
+    .fric-title .accent {
+      color: var(--accent);
+    }
+    .fric-title .mute {
+      color: var(--ink-faint);
+    }
+
+    /* ---- scene 01: tension pairs ---- */
+    .fric-pairs {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      border-top: 1px solid var(--rule);
+    }
+    .fric-pair {
+      display: grid;
+      grid-template-columns: 1fr auto 1fr;
+      align-items: center;
+      gap: 20px;
+      padding: 22px 0;
+      border-bottom: 1px solid var(--rule);
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-size: clamp(15px, 2.6vw, 19px);
+      color: var(--ink);
+    }
+    .fric-pair span:first-child {
+      text-align: right;
+    }
+    /* The seam between the two sides: dashed today, the thing iii erases. */
+    .fric-seam {
+      position: relative;
+      width: clamp(56px, 12vw, 120px);
+      height: 1px;
+      background: repeating-linear-gradient(
+        90deg,
+        var(--ink-ghost) 0 3px,
+        transparent 3px 7px
+      );
+    }
+    .fric-seam::after {
+      content: "";
+      position: absolute;
+      inset: -6px auto -6px 50%;
+      width: 1px;
+      background: var(--ink-ghost);
+    }
+
+    /* ---- scene 02: the nine claims ---- */
+    .fric-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1px;
+      background: var(--rule);
+      border: 1px solid var(--rule);
+    }
+    .fric-cell {
+      background: var(--bg);
+      padding: 20px 18px 22px;
+    }
+    .fric-num {
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-size: 10px;
+      letter-spacing: 0.12em;
+      color: var(--accent);
+    }
+    .fric-cell h3 {
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-weight: 500;
+      font-size: 14px;
+      letter-spacing: -0.01em;
+      color: var(--ink);
+      margin: 10px 0 6px;
+    }
+    .fric-cell p {
+      font-size: 13px;
+      line-height: 1.55;
+      color: var(--ink-faint);
+      margin: 0;
+    }
+
+    /* ---- scene 03: the result ---- */
+    .fric-results {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 20px;
+    }
+    .fric-result {
+      border-top: 1px solid var(--accent);
+      padding: 14px 0 0;
+    }
+    .fric-result b {
+      display: block;
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      font-weight: 500;
+      font-size: clamp(15px, 2.4vw, 18px);
+      color: var(--ink);
+      margin-bottom: 8px;
+    }
+    .fric-result span {
+      font-size: 13px;
+      line-height: 1.55;
+      color: var(--ink-faint);
+    }
+
+    @media (max-width: 900px) {
+      .fric-scene {
+        margin: 0 18px;
+        padding-top: 48px;
+      }
+      .fric-title {
+        max-width: 100%;
+      }
+      .fric-grid {
+        grid-template-columns: 1fr;
+      }
+      .fric-results {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
+    @media (max-width: 560px) {
+      .fric-results {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+
+  <div class="fric-scene">
+    <span class="fric-idx">§ 01 · THE FRICTION</span>
+    <h2 class="fric-title">
+      <span class="accent">iii is a system for developing software.</span>
+      <span class="mute"
+        ><br />it removes the friction between the pairs that pull against each other in every
+        stack.</span
+      >
+    </h2>
+
+    <ul class="fric-pairs">
+      <li class="fric-pair">
+        <span>development</span><span class="fric-seam" aria-hidden="true"></span
+        ><span>production</span>
+      </li>
+      <li class="fric-pair">
+        <span>integration</span><span class="fric-seam" aria-hidden="true"></span><span>use</span>
+      </li>
+      <li class="fric-pair">
+        <span>architecture</span><span class="fric-seam" aria-hidden="true"></span
+        ><span>extensibility</span>
+      </li>
+    </ul>
+  </div>
+
+  <div class="fric-scene">
+    <span class="fric-idx">§ 02 · WHAT IT PROVIDES</span>
+    <h2 class="fric-title">
+      <span class="accent">iii does this by being all of these at once.</span>
+      <span class="mute"><br />each one is the same three primitives seen from a new angle.</span>
+    </h2>
+
+    <div class="fric-grid">
+      <div class="fric-cell">
+        <div class="fric-num">01</div>
+        <h3>a protocol</h3>
+        <p>one wire format that every language and every service already speaks.</p>
+      </div>
+      <div class="fric-cell">
+        <div class="fric-num">02</div>
+        <h3>a small set of primitives</h3>
+        <p>worker, trigger, function. everything else is a composition of the three.</p>
+      </div>
+      <div class="fric-cell">
+        <div class="fric-num">03</div>
+        <h3>a worker orchestrator</h3>
+        <p>starts, supervises, and restarts every process that connects.</p>
+      </div>
+      <div class="fric-cell">
+        <div class="fric-num">04</div>
+        <h3>a registry</h3>
+        <p>iii worker add stripe. a capability installs like a package.</p>
+      </div>
+      <div class="fric-cell">
+        <div class="fric-num">05</div>
+        <h3>a compose file, and a swarm</h3>
+        <p>declare the system once, run it on one machine or on a hundred.</p>
+      </div>
+      <div class="fric-cell">
+        <div class="fric-num">06</div>
+        <h3>an agentic development environment</h3>
+        <p>agents read a live system's functions and triggers instead of guessing at them.</p>
+      </div>
+      <div class="fric-cell">
+        <div class="fric-num">07</div>
+        <h3>a self-extensible application</h3>
+        <p>a running system gains capability without being redesigned.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="fric-scene">
+    <span class="fric-idx">§ 03 · THE RESULT</span>
+    <h2 class="fric-title">
+      <span class="accent">everything stays live.</span>
+      <span class="mute"
+        ><br />the system you build is the system you run, and it never stops answering for
+        itself.</span
+      >
+    </h2>
+
+    <ul class="fric-results">
+      <li class="fric-result">
+        <b>live composability</b>
+        <span>any function calls any other function, in any language, on any machine.</span>
+      </li>
+      <li class="fric-result">
+        <b>live extensibility</b>
+        <span>add a worker to a running system without redesigning the architecture.</span>
+      </li>
+      <li class="fric-result">
+        <b>live discoverability</b>
+        <span>what one worker exposes becomes visible across the system in real time.</span>
+      </li>
+      <li class="fric-result">
+        <b>live observability</b>
+        <span>operations, traces, and behavior across the whole connected stack.</span>
+      </li>
+    </ul>
+  </div>
+</section>

--- a/website/src/components/landing/sections/02b-friction-anim.html
+++ b/website/src/components/landing/sections/02b-friction-anim.html
@@ -45,7 +45,8 @@
       font-family: inherit;
       font-size: 15px;
       letter-spacing: 0.14em;
-      text-transform: uppercase;
+      /* Never uppercased: it would render iii as III. */
+      text-transform: lowercase;
       color: var(--ink-ghost);
       transition:
         color 0.35s ease,

--- a/website/src/components/landing/sections/02b-friction-anim.html
+++ b/website/src/components/landing/sections/02b-friction-anim.html
@@ -25,42 +25,47 @@
       display: block;
     }
 
-    .fanim-bar {
+    /* The two states of the story, centred at the top. The marker slides from
+       one to the other when the animation changes state on its own. */
+    .fanim-switch {
       position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
+      top: 26px;
+      left: 50%;
+      transform: translateX(-50%);
       display: flex;
       align-items: center;
-      justify-content: space-between;
-      gap: 24px;
-      padding: 20px 36px;
-      border-bottom: 1px solid var(--rule);
+      gap: 36px;
+      padding-bottom: 12px;
     }
-    .fanim-mark {
-      font-weight: 600;
-      font-size: 18px;
-      letter-spacing: -0.02em;
-    }
-    .fanim-ways {
-      display: flex;
-      align-items: center;
-      gap: 22px;
-    }
-    .fanim-ways button {
+    .fanim-switch button {
       background: none;
       border: 0;
       padding: 0;
       cursor: pointer;
       font-family: inherit;
-      font-size: 14px;
+      font-size: 15px;
       letter-spacing: 0.14em;
       text-transform: uppercase;
       color: var(--ink-ghost);
-      transition: color 0.2s ease;
+      transition:
+        color 0.35s ease,
+        opacity 0.35s ease;
+      opacity: 0.7;
     }
-    .fanim-ways button.on {
+    .fanim-switch button.on {
       color: var(--ink);
+      opacity: 1;
+    }
+    .fanim-switch-marker {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 0;
+      height: 2px;
+      background: var(--accent);
+      transition:
+        transform 0.55s cubic-bezier(0.4, 0, 0.2, 1),
+        width 0.55s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
     /* The three tensions. Each one docks to its moment in the story when it is
@@ -133,12 +138,10 @@
   <div class="fanim-stage" id="fanim-stage">
     <canvas class="fanim-canvas" id="fanim-canvas" aria-hidden="true"></canvas>
 
-    <div class="fanim-bar">
-      <span class="fanim-mark">iii</span>
-      <div class="fanim-ways">
-        <button type="button" class="on" data-way="0">the old way</button>
-        <button type="button" data-way="1">the iii way</button>
-      </div>
+    <div class="fanim-switch" id="fanim-switch">
+      <button type="button" class="on" data-way="0">today</button>
+      <button type="button" data-way="1">with iii</button>
+      <span class="fanim-switch-marker" id="fanim-switch-marker" aria-hidden="true"></span>
     </div>
 
     <div class="fanim-tensions" id="fanim-tensions"></div>

--- a/website/src/components/landing/sections/02b-friction-anim.html
+++ b/website/src/components/landing/sections/02b-friction-anim.html
@@ -1,0 +1,147 @@
+<!-- FRICTION ANIMATION — the old way vs the iii way, drawn on a canvas.
+     The drawing and the copy are driven by scripts/08-friction-anim.html;
+     everything here is the frame it renders into. -->
+<section class="fanim" id="friction-anim" aria-label="From friction to a live system">
+  <style>
+    .fanim {
+      padding: 0 0 40px;
+    }
+    /* Full-bleed: the drawing runs the width of the section, no frame. */
+    .fanim-stage {
+      position: relative;
+      height: min(86vh, 820px);
+      min-height: 600px;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: "Chivo Mono", ui-monospace, monospace;
+      overflow: hidden;
+      user-select: none;
+    }
+    .fanim-canvas {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+
+    .fanim-bar {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 24px;
+      padding: 20px 36px;
+      border-bottom: 1px solid var(--rule);
+    }
+    .fanim-mark {
+      font-weight: 600;
+      font-size: 18px;
+      letter-spacing: -0.02em;
+    }
+    .fanim-ways {
+      display: flex;
+      align-items: center;
+      gap: 22px;
+    }
+    .fanim-ways button {
+      background: none;
+      border: 0;
+      padding: 0;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 14px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--ink-ghost);
+      transition: color 0.2s ease;
+    }
+    .fanim-ways button.on {
+      color: var(--ink);
+    }
+
+    /* The three tensions. Each one docks to its moment in the story when it is
+       the current one, and parks in the right margin when it is not. */
+    .fanim-tensions {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+    }
+    .fanim-tension {
+      position: absolute;
+      pointer-events: auto;
+      cursor: pointer;
+      transition:
+        left 0.8s cubic-bezier(0.4, 0, 0.2, 1),
+        top 0.8s cubic-bezier(0.4, 0, 0.2, 1),
+        opacity 0.5s ease;
+    }
+    .fanim-tension-head {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 17px;
+      letter-spacing: 0.01em;
+      color: var(--ink-ghost);
+    }
+    .fanim-tension.on .fanim-tension-head {
+      color: var(--ink);
+    }
+    .fanim-tension-bar {
+      flex: 0 0 auto;
+      width: 3px;
+      height: 15px;
+      background: transparent;
+    }
+    .fanim-tension.on .fanim-tension-bar {
+      background: var(--accent);
+    }
+    .fanim-tension-body {
+      overflow: hidden;
+      max-height: 0;
+      opacity: 0;
+      transition:
+        max-height 0.55s ease,
+        opacity 0.45s ease;
+    }
+    .fanim-tension.on .fanim-tension-body {
+      max-height: 220px;
+      opacity: 1;
+    }
+    .fanim-tension-body p {
+      margin: 9px 0 0;
+      padding-left: 13px;
+      font-size: 15px;
+      line-height: 1.65;
+      color: var(--ink-faint);
+      text-wrap: pretty;
+    }
+
+    @media (max-width: 900px) {
+      .fanim {
+        padding: 0 18px 32px;
+      }
+      .fanim-stage {
+        height: min(90vh, 720px);
+      }
+    }
+  </style>
+
+  <div class="fanim-stage" id="fanim-stage">
+    <canvas class="fanim-canvas" id="fanim-canvas" aria-hidden="true"></canvas>
+
+    <div class="fanim-bar">
+      <span class="fanim-mark">iii</span>
+      <div class="fanim-ways">
+        <button type="button" class="on" data-way="0">the old way</button>
+        <button type="button" data-way="1">the iii way</button>
+      </div>
+    </div>
+
+    <div class="fanim-tensions" id="fanim-tensions"></div>
+
+  </div>
+</section>

--- a/website/src/components/landing/sections/03-hero.html
+++ b/website/src/components/landing/sections/03-hero.html
@@ -3,24 +3,26 @@
   <div class="hero-inner">
     <div class="hero-left">
       <h1 class="hero-headline" id="hero-headline" aria-live="polite">
-        <!-- One carousel per line. Keeping hero-desc alone on its line stops a
-             long word like "orchestration" from rewrapping the subject above it. -->
-        <span class="line"><span class="desc plain" id="hero-subj">an agentic</span></span>
-        <span class="line"><span class="desc" id="hero-desc">development</span></span>
-        <span class="line mute">environment</span>
-        <!-- Third carousel, held back: three rotating lines at once is too much motion. -->
-        <!-- <span class="line mute">for <span class="desc" id="hero-for">building</span></span> -->
+        <span class="line">build unreasonably <span class="desc" id="hero-desc">simple</span></span>
+        <span class="line mute">software</span>
       </h1>
+
+      <!-- Subheader: only the verb on line one rotates, the rest is static. -->
+      <p class="hero-subhead">
+        <span class="line">effortlessly <span class="desc" id="hero-verb">discover</span></span>
+        <span class="line"
+          ><span class="mute">every service</span> <span class="accent">in real time</span></span
+        >
+        <span class="line">for the first time ever</span>
+      </p>
 
       <p class="hero-sub">Modern software stacks are an exercise in integrating services.</p>
       <p class="hero-sub">
         Every new capability means a new system to learn, configure, deploy, and monitor.
       </p>
-
       <p class="hero-sub">
-        The complexity of actual integrations is
-        <span class="accent">quadratic</span> which is overwhelming for devs and for AI. Leading to
-        both making bad decisions about large codebases.
+        The complexity of actual integrations is <span class="accent">quadratic</span> which is
+        overwhelming for devs and for AI. Leading to both making bad decisions about large codebases.
       </p>
       <p class="hero-sub">
         iii <span class="accent">eliminates this complexity</span> by shipping working services the

--- a/website/src/components/landing/sections/03-hero.html
+++ b/website/src/components/landing/sections/03-hero.html
@@ -26,11 +26,16 @@
       </p>
       <p class="hero-sub">
         The complexity of actual integrations is <span class="accent">quadratic</span> which is
-        overwhelming for devs and for AI. Leading to both making bad decisions about large codebases.
+        overwhelming for devs and for AI. Leading to both making bad decisions about large
+        codebases.
       </p>
       <p class="hero-sub">
         iii <span class="accent">eliminates this complexity</span> by shipping working services the
         same way node ships packages, so using a new service is as easy as importing a new library.
+      </p>
+      <p class="hero-sub">
+        No integration, no gateways, no rearchitecting, no agents guessing at infrastructure, no
+        tracking down logs.
       </p>
     </div>
 
@@ -214,7 +219,7 @@
 
         <div class="hero-viz-foot">
           <span><span id="hv-count" class="hv-count">45</span> <span>integrations</span></span>
-          </div>
+        </div>
       </aside>
     </div>
   </div>

--- a/website/src/components/landing/sections/03-hero.html
+++ b/website/src/components/landing/sections/03-hero.html
@@ -3,8 +3,13 @@
   <div class="hero-inner">
     <div class="hero-left">
       <h1 class="hero-headline" id="hero-headline" aria-live="polite">
-        <span class="line">build unreasonably <span class="desc" id="hero-desc">simple</span></span>
-        <span class="line mute">software</span>
+        <!-- One carousel per line. Keeping hero-desc alone on its line stops a
+             long word like "orchestration" from rewrapping the subject above it. -->
+        <span class="line"><span class="desc plain" id="hero-subj">an agentic</span></span>
+        <span class="line"><span class="desc" id="hero-desc">development</span></span>
+        <span class="line mute">environment</span>
+        <!-- Third carousel, held back: three rotating lines at once is too much motion. -->
+        <!-- <span class="line mute">for <span class="desc" id="hero-for">building</span></span> -->
       </h1>
 
       <p class="hero-sub">Modern software stacks are an exercise in integrating services.</p>

--- a/website/src/components/landing/sections/03-hero.html
+++ b/website/src/components/landing/sections/03-hero.html
@@ -1,7 +1,8 @@
 <!-- HERO -->
 <section class="hero" aria-label="Hero">
   <div class="hero-inner">
-    <div class="hero-left">
+    <!-- Its own grid row: the viz sits beside it and matches its height. -->
+    <div class="hero-head">
       <h1 class="hero-headline" id="hero-headline" aria-live="polite">
         <span class="line">build unreasonably <span class="desc" id="hero-desc">simple</span></span>
         <span class="line mute">software</span>
@@ -15,7 +16,10 @@
         >
         <span class="line">for the first time ever</span>
       </p>
+    </div>
 
+    <!-- The copy takes the column the viz used to hold, beside the headline. -->
+    <div class="hero-copy">
       <p class="hero-sub">Modern software stacks are an exercise in integrating services.</p>
       <p class="hero-sub">
         Every new capability means a new system to learn, configure, deploy, and monitor.
@@ -28,7 +32,9 @@
         iii <span class="accent">eliminates this complexity</span> by shipping working services the
         same way node ships packages, so using a new service is as easy as importing a new library.
       </p>
+    </div>
 
+    <div class="hero-left">
       <div class="hero-cta">
         <div class="hero-actions">
           <div class="hero-actions-row">
@@ -131,80 +137,85 @@
       </div>
     </div>
 
-    <aside
-      class="hero-viz"
-      id="hero-viz"
-      aria-label="From quadratic to linear to ephemeral"
-      data-stage="mesh"
-      data-design="classic"
-    >
-      <div class="hero-viz-head">
-        <span class="label">
-          <span class="pulse"></span>
-          <span class="stage-name" id="hv-stage-name">problem space</span>
-        </span>
-        <div class="hero-viz-tabs" role="tablist" aria-label="Stage">
-          <button type="button" data-stage="mesh" class="on">problem space</button>
-          <button type="button" data-stage="actual">current</button>
-          <button type="button" data-stage="iii">iii</button>
+    <!-- The panel is scaled as a whole to the headline block's height, so this
+         wrapper holds the grid slot and the panel itself contributes no
+         height of its own. -->
+    <div class="hero-viz-fit">
+      <aside
+        class="hero-viz"
+        id="hero-viz"
+        aria-label="From quadratic to linear to ephemeral"
+        data-stage="mesh"
+        data-design="classic"
+      >
+        <div class="hero-viz-head">
+          <span class="label">
+            <span class="pulse"></span>
+            <span class="stage-name" id="hv-stage-name">problem space</span>
+          </span>
+          <div class="hero-viz-tabs" role="tablist" aria-label="Stage">
+            <button type="button" data-stage="mesh" class="on">problem space</button>
+            <button type="button" data-stage="actual">current</button>
+            <button type="button" data-stage="iii">iii</button>
+          </div>
         </div>
-      </div>
 
-      <div class="hero-viz-canvas" id="hv-canvas">
-        <svg
-          class="main"
-          viewBox="0 0 400 400"
-          preserveAspectRatio="xMidYMid meet"
-          aria-hidden="true"
-        >
-          <g id="hv-edges-mesh"></g>
-          <g id="hv-edges-actual"></g>
-          <g id="hv-edges-ephemeral"></g>
-          <g id="hv-packets"></g>
-          <g id="hv-nodes"></g>
-          <g id="hv-labels"></g>
-        </svg>
-      </div>
-
-      <div class="hero-viz-complexity" aria-live="polite">
-        <svg
-          class="hv-complex-chart"
-          viewBox="22 0 186 118"
-          preserveAspectRatio="none"
-          aria-hidden="true"
-        >
-          <line class="hv-cc-axis" x1="22" y1="94" x2="208" y2="94" />
-          <line class="hv-cc-axis" x1="22" y1="94" x2="22" y2="14" />
-          <!-- n(n-1)/2: full pairwise growth. True parabola y = 94 - 74((x-22)/186)^2. -->
-          <path
-            class="hv-cc-q"
-            d="M 22 94 L 45.3 92.8 L 68.5 89.4 L 91.8 83.6 L 115 75.5 L 138.3 65.1 L 161.5 52.4 L 184.8 37.3 L 208 20"
-          />
-          <!-- (n(n-1)/2) / tolerance: same parabola, proportionally damped (k=34). -->
-          <path
-            class="hv-cc-l"
-            d="M 22 94 L 45.3 93.5 L 68.5 91.9 L 91.8 89.2 L 115 85.5 L 138.3 80.7 L 161.5 74.9 L 184.8 67.9 L 208 60"
-          />
-          <!-- 0: constant on the axis -->
-          <path class="hv-cc-f" d="M 22 94 L 208 94" />
-        </svg>
-        <div class="hv-complex-copy">
-          <span class="hv-formula" id="hv-formula"
-            ><math
-              ><mi>O</mi><mo>(</mo
-              ><mfrac
-                ><mrow><mi>n</mi><mo>(</mo><mi>n</mi><mo>&#x2212;</mo><mn>1</mn><mo>)</mo></mrow
-                ><mn>2</mn></mfrac
-              ><mo>)</mo></math
-            ></span
+        <div class="hero-viz-canvas" id="hv-canvas">
+          <svg
+            class="main"
+            viewBox="0 0 400 118"
+            preserveAspectRatio="xMidYMid meet"
+            aria-hidden="true"
           >
-          <span class="hv-formula-sub" id="hv-formula-sub"></span>
+            <g id="hv-edges-mesh"></g>
+            <g id="hv-edges-actual"></g>
+            <g id="hv-edges-ephemeral"></g>
+            <g id="hv-packets"></g>
+            <g id="hv-nodes"></g>
+            <g id="hv-labels"></g>
+          </svg>
         </div>
-      </div>
 
-      <div class="hero-viz-foot">
-        <span><span id="hv-count" class="hv-count">45</span> <span>integrations</span></span>
-      </div>
-    </aside>
+        <div class="hero-viz-complexity" aria-live="polite">
+          <svg
+            class="hv-complex-chart"
+            viewBox="22 0 186 118"
+            preserveAspectRatio="none"
+            aria-hidden="true"
+          >
+            <line class="hv-cc-axis" x1="22" y1="94" x2="208" y2="94" />
+            <line class="hv-cc-axis" x1="22" y1="94" x2="22" y2="14" />
+            <!-- n(n-1)/2: full pairwise growth. True parabola y = 94 - 74((x-22)/186)^2. -->
+            <path
+              class="hv-cc-q"
+              d="M 22 94 L 45.3 92.8 L 68.5 89.4 L 91.8 83.6 L 115 75.5 L 138.3 65.1 L 161.5 52.4 L 184.8 37.3 L 208 20"
+            />
+            <!-- (n(n-1)/2) / tolerance: same parabola, proportionally damped (k=34). -->
+            <path
+              class="hv-cc-l"
+              d="M 22 94 L 45.3 93.5 L 68.5 91.9 L 91.8 89.2 L 115 85.5 L 138.3 80.7 L 161.5 74.9 L 184.8 67.9 L 208 60"
+            />
+            <!-- 0: constant on the axis -->
+            <path class="hv-cc-f" d="M 22 94 L 208 94" />
+          </svg>
+          <div class="hv-complex-copy">
+            <span class="hv-formula" id="hv-formula"
+              ><math
+                ><mi>O</mi><mo>(</mo
+                ><mfrac
+                  ><mrow><mi>n</mi><mo>(</mo><mi>n</mi><mo>&#x2212;</mo><mn>1</mn><mo>)</mo></mrow
+                  ><mn>2</mn></mfrac
+                ><mo>)</mo></math
+              ></span
+            >
+            <span class="hv-formula-sub" id="hv-formula-sub"></span>
+          </div>
+        </div>
+
+        <div class="hero-viz-foot">
+          <span><span id="hv-count" class="hv-count">45</span> <span>integrations</span></span>
+          </div>
+      </aside>
+    </div>
   </div>
 </section>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -14,6 +14,7 @@ import '../styles/landing.css'
 import headExtras from '../components/landing/head-extras.html?raw'
 
 import sheetOpen from '../components/landing/sections/01-sheet-open.html?raw'
+import explained from '../components/landing/sections/02-explained.html?raw'
 import hero from '../components/landing/sections/03-hero.html?raw'
 import experience from '../components/landing/sections/04-experience.html?raw'
 import workers from '../components/landing/sections/05-workers.html?raw'
@@ -66,6 +67,7 @@ const body = [
   <SiteNav />
   <ScrollNav
     links={[
+      { id: 'explained', label: 'what is iii' },
       { id: 'console-live', label: 'agents' },
       { id: 'harness', label: 'harness' },
       { id: 'experience', label: 'why iii' },
@@ -74,6 +76,7 @@ const body = [
     ]}
   />
   <Fragment set:html={hero} />
+  <Fragment set:html={explained} />
   <ConsoleLive />
   <HarnessRace />
   <Fragment set:html={body} />

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -14,6 +14,7 @@ import '../styles/landing.css'
 import headExtras from '../components/landing/head-extras.html?raw'
 
 import sheetOpen from '../components/landing/sections/01-sheet-open.html?raw'
+import friction from '../components/landing/sections/02a-friction.html?raw'
 import explained from '../components/landing/sections/02-explained.html?raw'
 import hero from '../components/landing/sections/03-hero.html?raw'
 import experience from '../components/landing/sections/04-experience.html?raw'
@@ -58,7 +59,7 @@ const body = [
 
 <HtmlShell
   title="iii — Three primitives. Zero integration cost."
-  description="The latest docs on how to use iii, a new paradigm to effortlessly compose, extend, and observe every service in any system in real-time for the first time ever."
+  description="Effortlessly discover, compose, extend, and observe every service in real-time for the first time ever."
   canonicalPath="/"
   keywords="iii, worker, trigger, function, three primitives, distributed systems, durable execution, polyglot runtime, AI agents, agent runtime, TypeScript, Python, Rust, WebSocket, interoperability, live discovery, live observability, queues, cron, http, state, streams, sandbox"
 >
@@ -67,7 +68,8 @@ const body = [
   <SiteNav />
   <ScrollNav
     links={[
-      { id: 'explained', label: 'what is iii' },
+      { id: 'friction', label: 'what is iii' },
+      { id: 'explained', label: 'many things' },
       { id: 'console-live', label: 'agents' },
       { id: 'harness', label: 'harness' },
       { id: 'experience', label: 'why iii' },
@@ -76,6 +78,7 @@ const body = [
     ]}
   />
   <Fragment set:html={hero} />
+  <Fragment set:html={friction} />
   <Fragment set:html={explained} />
   <ConsoleLive />
   <HarnessRace />

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -15,6 +15,7 @@ import headExtras from '../components/landing/head-extras.html?raw'
 
 import sheetOpen from '../components/landing/sections/01-sheet-open.html?raw'
 import friction from '../components/landing/sections/02a-friction.html?raw'
+import frictionAnim from '../components/landing/sections/02b-friction-anim.html?raw'
 import explained from '../components/landing/sections/02-explained.html?raw'
 import hero from '../components/landing/sections/03-hero.html?raw'
 import experience from '../components/landing/sections/04-experience.html?raw'
@@ -33,6 +34,7 @@ import tweaksPanelStyle from '../components/landing/scripts/04-tweaks-panel-styl
 import heroViz from '../components/landing/scripts/05-hero-viz-engine.html?raw'
 import agentSections from '../components/landing/scripts/06-agent-sections-a-harness-collapse-c-.html?raw'
 import tweaksPanel from '../components/landing/scripts/07-tweaks-panel.html?raw'
+import frictionAnimEngine from '../components/landing/scripts/08-friction-anim.html?raw'
 
 // Fragments are consecutive line ranges of the original page; each ends with
 // a newline, so plain concatenation reproduces the source region exactly.
@@ -54,6 +56,7 @@ const body = [
   heroViz,
   agentSections,
   tweaksPanel,
+  frictionAnimEngine,
 ].join('')
 ---
 
@@ -78,6 +81,7 @@ const body = [
     ]}
   />
   <Fragment set:html={hero} />
+  <Fragment set:html={frictionAnim} />
   <Fragment set:html={friction} />
   <Fragment set:html={explained} />
   <ConsoleLive />

--- a/website/src/styles/landing.css
+++ b/website/src/styles/landing.css
@@ -104,8 +104,9 @@
     margin:0 auto;
     display:grid;
     grid-template-columns: 1fr 1fr;
-    gap:64px;
-    align-items:start;
+    column-gap:64px;
+    row-gap:40px;
+    align-items:stretch;
   }
   .hero-left{ min-width:0; }
   .hero-eyebrow{
@@ -136,13 +137,14 @@
   }
   .hero-headline .line{ display:block; }
   .hero-headline .mute{ color:var(--ink-faint); }
+  .hero-headline .accent{ color:var(--accent); }
   .hero-headline .desc{
     display:inline-block;
     color:var(--accent);
     transition: opacity .4s ease, transform .4s ease;
     will-change: opacity, transform;
   }
-  /* Second carousel on the same line — keeps the single-accent look by
+  /* Second carousel on the same headline — keeps the single-accent look by
      rotating in ink rather than a second orange word. */
   .hero-headline .desc.plain{ color:var(--ink); }
   .hero-headline .desc.is-anim{
@@ -150,13 +152,41 @@
     transform: translateY(14px);
   }
 
+  /* Subheader: the same four stacked lines, sized under the headline. */
+  .hero-subhead{
+    font-family:'Chivo Mono', ui-monospace, monospace;
+    font-weight:500;
+    font-size: clamp(20px, 2.1vw, 28px);
+    line-height:1.15;
+    letter-spacing:-0.01em;
+    color:var(--ink);
+    margin:28px 0 0;
+    text-transform:lowercase;
+  }
+  .hero-subhead .line{ display:block; }
+  .hero-subhead .mute{ color:var(--ink-faint); }
+  .hero-subhead .accent{ color:var(--accent); }
+  .hero-subhead .desc{
+    display:inline-block;
+    /* Reserves the longest verb in the rotation ("discover"), so the words
+       after it never shift. Chivo Mono, so 1ch is one glyph. */
+    min-width:8ch;
+    color:var(--accent);
+    transition: opacity .4s ease, transform .4s ease;
+    will-change: opacity, transform;
+  }
+  .hero-subhead .desc.is-anim{
+    opacity:0;
+    transform: translateY(10px);
+  }
+
   .hero-sub{
     font-family:'Chivo Mono', ui-monospace, monospace;
     font-weight:400;
-    font-size:14px;
+    font-size:18px;
     line-height:1.7;
     color:var(--ink-faint);
-    max-width:46ch;
+    max-width:58ch;
     text-wrap:pretty;
     margin:40px 0 0;
   }
@@ -411,7 +441,9 @@
     display:grid;
     grid-template-rows: auto 1fr auto;
     min-width:0;
-    align-self:start;
+    /* Matches the copy column's height: the canvas row absorbs whatever is
+       left, so both columns end on the same line. */
+    align-self:stretch;
     position:relative;
   }
   @media (min-width: 881px){
@@ -462,6 +494,9 @@
     position:relative;
     aspect-ratio: 5 / 4;
     width:100%;
+    /* The stretched grid row wins over the aspect ratio, so the drawing scales
+       down instead of pushing the panel past the copy column. */
+    min-height:0;
     overflow:hidden;
   }
   .hero-viz-canvas svg{
@@ -795,7 +830,7 @@
 
   @media (max-width: 880px){
     .hero{ padding:60px 18px 72px; }
-    .hero-inner{ grid-template-columns: 1fr; gap:48px; }
+    .hero-inner{ grid-template-columns: 1fr; column-gap:48px; row-gap:40px; }
     .hero-headline{ letter-spacing:-0.02em; }
     .hero-cta{ gap:28px; }
     .hero-viz{ min-width:0; max-width:100%; overflow:hidden; }

--- a/website/src/styles/landing.css
+++ b/website/src/styles/landing.css
@@ -108,7 +108,14 @@
     row-gap:40px;
     align-items:stretch;
   }
-  .hero-left{ min-width:0; }
+  /* Row 1 holds the headline block and the viz, so the viz spans exactly from
+     the top of the headline to the bottom of the subheadline. Row 2 is the
+     copy, which runs under the viz in the left column only. */
+  .hero-head{ grid-column:1; grid-row:1; min-width:0; }
+  /* The copy sits beside the headline, in the slot the viz used to hold. */
+  .hero-copy{ grid-column:2; grid-row:1; min-width:0; }
+  .hero-copy > .hero-sub:first-child{ margin-top:0; }
+  .hero-left{ grid-column:1; grid-row:2; min-width:0; }
   .hero-eyebrow{
     display:inline-flex; align-items:center; gap:10px;
     margin:0 0 28px;
@@ -441,10 +448,15 @@
     display:grid;
     grid-template-rows: auto 1fr auto;
     min-width:0;
-    /* Matches the copy column's height: the canvas row absorbs whatever is
-       left, so both columns end on the same line. */
-    align-self:stretch;
     position:relative;
+  }
+  /* Hidden for now: the hero copy holds this column instead. The panel and its
+     engine stay in place for when it comes back. */
+  .hero-viz-fit{
+    display:none;
+    grid-column:2; grid-row:1 / span 2;
+    align-self:start;
+    min-width:0;
   }
   @media (min-width: 881px){
     .hero-viz:not([data-design="triptych"]){
@@ -492,11 +504,9 @@
 
   .hero-viz-canvas{
     position:relative;
-    aspect-ratio: 5 / 4;
+    /* Matches the drawing's 400 x 118 viewBox. */
+    aspect-ratio: 200 / 59;
     width:100%;
-    /* The stretched grid row wins over the aspect ratio, so the drawing scales
-       down instead of pushing the panel past the copy column. */
-    min-height:0;
     overflow:hidden;
   }
   .hero-viz-canvas svg{
@@ -617,8 +627,9 @@
     font-family:'Chivo Mono', ui-monospace, monospace;
   }
   .hv-complex-chart{
+    /* preserveAspectRatio="none": the curves stretch to whatever box they get. */
     width:100%;
-    height:80px;
+    height:56px;
     display:block;
     overflow:visible;
   }
@@ -831,6 +842,9 @@
   @media (max-width: 880px){
     .hero{ padding:60px 18px 72px; }
     .hero-inner{ grid-template-columns: 1fr; column-gap:48px; row-gap:40px; }
+    /* One column: the blocks stack in source order and the panel runs at its
+       natural size again. */
+    .hero-head, .hero-copy, .hero-left, .hero-viz-fit{ grid-column:1; grid-row:auto; }
     .hero-headline{ letter-spacing:-0.02em; }
     .hero-cta{ gap:28px; }
     .hero-viz{ min-width:0; max-width:100%; overflow:hidden; }

--- a/website/src/styles/landing.css
+++ b/website/src/styles/landing.css
@@ -208,10 +208,11 @@
     max-width:100%;
     min-width:0;
     display:flex;
-    flex-direction:column;
+    /* One row: the buttons on the left, the email signup pushed to the right. */
+    flex-direction:row;
     flex-wrap:nowrap;
-    gap:20px;
-    align-items:flex-start;
+    gap:24px;
+    align-items:center;
   }
   /* Reference solid + ghost buttons */
   .cta-get-started{
@@ -787,9 +788,9 @@
     max-width:240px;
   }
   .hero-cta .cta-email{
-    width:100%;
-    max-width:min(100%, 420px);
-    flex:none;
+    /* Sits right after the buttons and takes the rest of the row. */
+    max-width:min(100%, 480px);
+    flex:1 1 380px;
   }
   .email-row{
     position:relative;
@@ -846,7 +847,9 @@
        natural size again. */
     .hero-head, .hero-copy, .hero-left, .hero-viz-fit{ grid-column:1; grid-row:auto; }
     .hero-headline{ letter-spacing:-0.02em; }
-    .hero-cta{ gap:28px; }
+    /* Narrow: back to a stack, the email under the buttons. */
+    .hero-cta{ flex-direction:column; align-items:flex-start; gap:28px; }
+    .hero-cta .cta-email{ flex:none; }
     .hero-viz{ min-width:0; max-width:100%; overflow:hidden; }
     .hero-viz-canvas{ overflow:hidden; max-width:100%; }
     .hero-viz-head .label{ display:none; }

--- a/website/src/styles/landing.css
+++ b/website/src/styles/landing.css
@@ -142,6 +142,9 @@
     transition: opacity .4s ease, transform .4s ease;
     will-change: opacity, transform;
   }
+  /* Second carousel on the same line — keeps the single-accent look by
+     rotating in ink rather than a second orange word. */
+  .hero-headline .desc.plain{ color:var(--ink); }
   .hero-headline .desc.is-anim{
     opacity:0;
     transform: translateY(14px);


### PR DESCRIPTION
Adds an "iii explained" area to the landing page, directly below the hero, that answers *what is iii* before the console and harness demos make their case.

## §01 · explained

iii gets described seven different ways, so the section treats those descriptions as what they are: one object seen from seven standpoints.

Seven claims leave a rail on the left, bend at a lens, and converge on a single focus that resolves into **worker**, **trigger**, and **function**. Selecting a claim lights its beam and only the primitives it reduces to. The geometry never changes between claims, and that invariance is the argument the section is making.

Beam bend points are sampled off the lens's own face curve rather than eyeballed, so the refraction reads true.

## §02 · one surface

A riff on the same lens, read from its far face. A ghosted top rail shows today: development, integration, and production as three boxed places with dashed handoff seams. Below it, the lens emits one continuous band carrying all three, with a single packet running its full length without stopping at any boundary.

## Notes

- All seven explanations stay expanded. Selecting a claim only moves a highlight, so the list never reflows while the beams switch.
- The claim list is a real button list: keyboard and screen-reader navigable, with `aria-pressed` tracking the active claim.
- The beam cycle stops permanently on first interaction and never starts under `prefers-reduced-motion`.
- Styles use only existing tokens (`--accent`, `--rule`, `--ink-faint`, `--panel`), so dark theme comes free. The three primitive colors match `09-nutshell.html` exactly.
- Self-contained fragment (markup, styles, script in one file), following the `10-tech-specs.html` precedent.
- No `text-transform: uppercase` on any caption containing `iii`, so it never renders as `III`.

Also adds a `what is iii` entry to `ScrollNav`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “What is iii” and “One Surface” sections with selectable claims, interactive diagrams, and workflow comparisons.
  * Added friction-focused scenes and animations contrasting current workflows with iii.
  * Added responsive interactions, animated visuals, keyboard focus support, automatic cycling, and reduced-motion handling.
  * Added scroll navigation linking directly to the new sections.
* **Improvements**
  * Updated the hero layout, visualization, calls to action, and rotating messaging to better present product concepts and workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->