### PR TITLE
fix(sdk): keep engine invocations in default namespace

### DIFF
--- a/sdk/packages/go/iii/client.go
+++ b/sdk/packages/go/iii/client.go
@@ -338,6 +338,16 @@ func refuseBlankCallNamespace(namespace, source string) error {
 	return nil
 }
 
+// invocationNamespace keeps engine-owned builtins in the engine's default
+// namespace. An explicit namespace always wins. Go does not yet inherit the
+// worker namespace for other calls, so their absent namespace stays absent.
+func invocationNamespace(functionID, explicit string) string {
+	if explicit == "" && strings.HasPrefix(functionID, "engine::") {
+		return "default"
+	}
+	return explicit
+}
+
 // RegisterTrigger registers a trigger instance: fire functionID when a trigger of
 // triggerType matches config. config and optional metadata are raw JSON (may be nil).
 func (c *Client) RegisterTrigger(id, triggerType, functionID string, config json.RawMessage, metadata ...json.RawMessage) error {
@@ -410,6 +420,7 @@ func (c *Client) Trigger(ctx context.Context, req TriggerRequest) (json.RawMessa
 	if err := refuseBlankCallNamespace(req.Namespace, "TriggerRequest.Namespace"); err != nil {
 		return nil, err
 	}
+	namespace := invocationNamespace(req.FunctionID, req.Namespace)
 	data := req.Data
 	if data == nil {
 		data = json.RawMessage("{}")
@@ -425,7 +436,7 @@ func (c *Client) Trigger(ctx context.Context, req TriggerRequest) (json.RawMessa
 			Action:      req.Action,
 			Traceparent: tc.traceparent,
 			Baggage:     tc.baggage,
-			Namespace:   req.Namespace,
+			Namespace:   namespace,
 		})
 		if err != nil {
 			return nil, err
@@ -451,7 +462,7 @@ func (c *Client) Trigger(ctx context.Context, req TriggerRequest) (json.RawMessa
 		Action:       req.Action,
 		Traceparent:  tc.traceparent,
 		Baggage:      tc.baggage,
-		Namespace:    req.Namespace,
+		Namespace:    namespace,
 	})
 	if err != nil {
 		c.clearPending(id)

--- a/sdk/packages/go/iii/namespace_test.go
+++ b/sdk/packages/go/iii/namespace_test.go
@@ -123,6 +123,63 @@ func TestTriggerOmitsNamespaceWhenAbsent(t *testing.T) {
 	}
 }
 
+// TestEngineTriggerDefaultsToDefaultNamespace verifies that an engine-owned
+// builtin cannot inherit or otherwise leak into a project namespace.
+func TestEngineTriggerDefaultsToDefaultNamespace(t *testing.T) {
+	m := newMockEngine(t)
+	c := connectClient(t, m, WithNamespace("orders"))
+
+	_, _ = c.Trigger(context.Background(), TriggerRequest{
+		FunctionID: FnCreateChannel,
+		Action:     VoidAction(),
+	})
+
+	got := m.waitFor(func(msgs []map[string]json.RawMessage) bool {
+		return firstWhere(msgs, func(msg map[string]json.RawMessage) bool {
+			return stringField(msg, "function_id") == FnCreateChannel
+		}) != nil
+	}, 2*time.Second)
+
+	inv := firstWhere(got, func(msg map[string]json.RawMessage) bool {
+		return stringField(msg, "function_id") == FnCreateChannel
+	})
+	if inv == nil {
+		t.Fatal("no invokefunction frame for engine::channels::create")
+	}
+	if ns := stringField(inv, "namespace"); ns != "default" {
+		t.Errorf("namespace = %q, want default", ns)
+	}
+}
+
+// TestExplicitNamespaceWinsForEngineTrigger preserves strict explicit routing
+// for callers that deliberately target a test or proxy namespace.
+func TestExplicitNamespaceWinsForEngineTrigger(t *testing.T) {
+	m := newMockEngine(t)
+	c := connectClient(t, m, WithNamespace("orders"))
+
+	_, _ = c.Trigger(context.Background(), TriggerRequest{
+		FunctionID: FnCreateChannel,
+		Action:     VoidAction(),
+		Namespace:  "sandbox",
+	})
+
+	got := m.waitFor(func(msgs []map[string]json.RawMessage) bool {
+		return firstWhere(msgs, func(msg map[string]json.RawMessage) bool {
+			return stringField(msg, "function_id") == FnCreateChannel
+		}) != nil
+	}, 2*time.Second)
+
+	inv := firstWhere(got, func(msg map[string]json.RawMessage) bool {
+		return stringField(msg, "function_id") == FnCreateChannel
+	})
+	if inv == nil {
+		t.Fatal("no invokefunction frame for engine::channels::create")
+	}
+	if ns := stringField(inv, "namespace"); ns != "sandbox" {
+		t.Errorf("namespace = %q, want sandbox", ns)
+	}
+}
+
 // TestRegistrationRejectedIsFatal verifies a WORKER_NAMESPACE_CONFLICT is
 // terminal: the client records the typed error, enters StateFailed, fails pending
 // invocations, and does not reconnect (which would loop forever under the default

--- a/sdk/packages/node/iii-browser/src/iii.ts
+++ b/sdk/packages/node/iii-browser/src/iii.ts
@@ -131,6 +131,16 @@ function callNamespace(
   return explicit ?? worker
 }
 
+/** Resolve one function invocation without leaking engine builtins into a worker namespace. */
+function invocationNamespace(
+  explicit: string | undefined,
+  worker: string | undefined,
+  functionId: string,
+): string | undefined {
+  const namespace = callNamespace(explicit, worker, 'TriggerRequest.namespace')
+  return explicit === undefined && functionId.startsWith('engine::') ? 'default' : namespace
+}
+
 function resolveNamespace(optionNamespace?: string): string | undefined {
   if (optionNamespace !== undefined && optionNamespace.trim() === '') {
     throw new Error(
@@ -430,11 +440,9 @@ class Sdk implements ISdk {
     request: TriggerRequest<TInput>,
   ): Promise<TOutput> => {
     const { function_id, payload, action, timeoutMs } = request
-    // Same rule as `registerTrigger`: a call with no namespace stays in the
-    // caller's. Reaching a worker that lives elsewhere -- an engine builtin in
-    // `default`, a neighbour in another project -- is done by naming that
-    // namespace.
-    const namespace = callNamespace(request.namespace, this.namespace, 'TriggerRequest.namespace')
+    // Engine-owned builtins stay in `default`. Other implicit calls stay in
+    // this worker's namespace. An explicit request namespace always wins.
+    const namespace = invocationNamespace(request.namespace, this.namespace, function_id)
     const effectiveTimeout = timeoutMs ?? this.invocationTimeoutMs
 
     if (action?.type === 'void') {

--- a/sdk/packages/node/iii-browser/tests/namespace-inheritance.test.ts
+++ b/sdk/packages/node/iii-browser/tests/namespace-inheritance.test.ts
@@ -83,6 +83,31 @@ describe('namespace inheritance', () => {
     expect(call).toMatchObject({ namespace: 'orders' })
   })
 
+  it('keeps an implicit engine invocation in default', async () => {
+    await connect('orders')
+    void sdk.trigger({
+      function_id: 'engine::channels::create',
+      payload: {},
+      action: { type: 'void' },
+    })
+
+    const call = engine.findAllSent('invokefunction').find((f) => f.function_id === 'engine::channels::create')
+    expect(call).toMatchObject({ namespace: 'default' })
+  })
+
+  it('lets an explicit namespace win for an engine invocation', async () => {
+    await connect('orders')
+    void sdk.trigger({
+      function_id: 'engine::channels::create',
+      payload: {},
+      action: { type: 'void' },
+      namespace: 'sandbox',
+    })
+
+    const call = engine.findAllSent('invokefunction').find((f) => f.function_id === 'engine::channels::create')
+    expect(call).toMatchObject({ namespace: 'sandbox' })
+  })
+
   /**
    * The regression the Node SDK hit when it adopted this rule.
    *

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -139,6 +139,16 @@ function callNamespace(
   return explicit ?? worker
 }
 
+/** Resolve one function invocation without leaking engine builtins into a worker namespace. */
+function invocationNamespace(
+  explicit: string | undefined,
+  worker: string | undefined,
+  functionId: string,
+): string | undefined {
+  const namespace = callNamespace(explicit, worker, 'TriggerRequest.namespace')
+  return explicit === undefined && functionId.startsWith('engine::') ? 'default' : namespace
+}
+
 function resolveNamespace(optionNamespace?: string): string | undefined {
   // III_NAMESPACE carries the namespace for managed workers (set by iii-worker
   // at spawn), mirroring III_WORKER_NAME. An explicit option wins; otherwise
@@ -618,11 +628,9 @@ class Sdk implements IIIClient {
     request: TriggerRequest<TInput>,
   ): Promise<TOutput> => {
     const { function_id, payload, action, timeoutMs, metadata } = request
-    // Same rule as `registerTrigger`: a call with no namespace stays in the
-    // caller's. Reaching a worker that lives elsewhere -- an engine builtin in
-    // `default`, a neighbour in another project -- is done by naming that
-    // namespace.
-    const namespace = callNamespace(request.namespace, this.namespace, 'TriggerRequest.namespace')
+    // Engine-owned builtins stay in `default`. Other implicit calls stay in
+    // this worker's namespace. An explicit request namespace always wins.
+    const namespace = invocationNamespace(request.namespace, this.namespace, function_id)
     const effectiveTimeout = timeoutMs ?? this.invocationTimeoutMs
 
     // Void is fire-and-forget, no invocation_id, no response
@@ -696,12 +704,6 @@ class Sdk implements IIIClient {
 
     this.trigger({
       function_id: EngineFunctions.REGISTER_WORKER,
-      // Named, because `trigger` now defaults to this worker's namespace and
-      // this one call must not follow it: `engine::workers::register` is
-      // compiled into the engine and served in `default` only. Routed into the
-      // worker's own namespace, the announcement reaches nothing and the worker
-      // never registers -- every function it offers then appears missing.
-      namespace: 'default',
       payload: {
         runtime: 'node',
         version: SDK_VERSION,

--- a/sdk/packages/node/iii/tests/namespace-inheritance.test.ts
+++ b/sdk/packages/node/iii/tests/namespace-inheritance.test.ts
@@ -95,15 +95,41 @@ describe('namespace inheritance', () => {
     expect(call).toMatchObject({ namespace: 'orders' })
   })
 
+  it('keeps an implicit engine invocation in default', async () => {
+    sdk = registerWorker(url, { workerName: 'tester', namespace: 'orders', otel: { enabled: false } })
+    await settle()
+    void sdk.trigger({
+      function_id: 'engine::channels::create',
+      payload: {},
+      action: { type: 'void' },
+    } as never)
+    await settle()
+
+    const call = frames.find((f) => f.type === 'invokefunction' && f.function_id === 'engine::channels::create')
+    expect(call).toMatchObject({ namespace: 'default' })
+  })
+
+  it('lets an explicit namespace win for an engine invocation', async () => {
+    sdk = registerWorker(url, { workerName: 'tester', namespace: 'orders', otel: { enabled: false } })
+    await settle()
+    void sdk.trigger({
+      function_id: 'engine::channels::create',
+      payload: {},
+      action: { type: 'void' },
+      namespace: 'sandbox',
+    } as never)
+    await settle()
+
+    const call = frames.find((f) => f.type === 'invokefunction' && f.function_id === 'engine::channels::create')
+    expect(call).toMatchObject({ namespace: 'sandbox' })
+  })
+
   /**
    * The regression this file exists for.
    *
    * The SDK announces itself with `engine::workers::register`, and it does so
-   * through `trigger`. Once `trigger` inherited, the announcement followed the
-   * worker into its own namespace — where the engine does not serve that
-   * function — so the worker never registered and every function it offered
-   * looked missing. The namespace smoke suite caught it as eight scenarios
-   * failing with `function_not_found`.
+   * through `trigger`. The generic engine-builtin rule must keep the
+   * announcement in `default`; callers must not need a one-off override.
    */
   it('never redirects the workers own registration', async () => {
     sdk = registerWorker(url, { workerName: 'tester', namespace: 'orders', otel: { enabled: false } })

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -206,6 +206,19 @@ class III:
             )
         return explicit if explicit is not None else self._worker_namespace()
 
+    def _invocation_namespace(
+        self, explicit: str | None, function_id: str
+    ) -> str | None:
+        """Resolve one invocation namespace.
+
+        An explicit namespace wins. Otherwise, engine-owned builtins resolve in
+        ``default`` and all other calls inherit this worker's namespace.
+        """
+        namespace = self._call_namespace(explicit, "TriggerRequest.namespace")
+        if explicit is None and function_id.startswith("engine::"):
+            return "default"
+        return namespace
+
     def _worker_namespace(self) -> str | None:
         """Effective worker namespace: explicit option, then ``III_NAMESPACE`` env,
         else ``None`` (the engine applies its ``default`` namespace).
@@ -1437,11 +1450,9 @@ class III:
         payload = req.get("payload")
         action = req.get("action")
         metadata = req.get("metadata")
-        # Same rule as ``register_trigger``: a call with no namespace stays in
-        # the caller's. Reaching a worker that lives elsewhere -- an engine
-        # builtin in ``default``, a neighbour in another project -- is done by
-        # naming that namespace.
-        namespace = self._call_namespace(req.get("namespace"), "TriggerRequest.namespace")
+        # Engine-owned builtins stay in ``default``. Other implicit calls stay
+        # in this worker's namespace. An explicit request namespace wins.
+        namespace = self._invocation_namespace(req.get("namespace"), function_id)
 
         timeout_ms = req.get("timeout_ms") or self._options.invocation_timeout_ms
 

--- a/sdk/packages/python/iii/tests/test_blank_namespace.py
+++ b/sdk/packages/python/iii/tests/test_blank_namespace.py
@@ -86,3 +86,20 @@ class TestBlankCallNamespace:
     def test_an_explicit_one_still_wins(self) -> None:
         client = _client("orders")
         assert client._call_namespace("billing", "TriggerRequest.namespace") == "billing"
+
+
+class TestInvocationNamespace:
+    def test_an_implicit_engine_call_stays_in_default(self) -> None:
+        client = _client("orders")
+        assert client._invocation_namespace(None, "engine::channels::create") == "default"
+
+    def test_an_explicit_namespace_wins_for_an_engine_call(self) -> None:
+        client = _client("orders")
+        assert (
+            client._invocation_namespace("sandbox", "engine::channels::create")
+            == "sandbox"
+        )
+
+    def test_a_non_engine_call_inherits_the_worker_namespace(self) -> None:
+        client = _client("orders")
+        assert client._invocation_namespace(None, "router::chat") == "orders"

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -398,6 +398,26 @@ pub(crate) fn call_namespace(
     }
 }
 
+/// The namespace in which one function invocation resolves.
+///
+/// An explicit namespace always wins. Without one, engine-owned builtins stay
+/// in `default`; all other calls inherit the worker's namespace.
+pub(crate) fn invocation_namespace(
+    explicit: Option<String>,
+    worker: Option<String>,
+    function_id: &str,
+    source: &str,
+) -> Result<Option<String>, Error> {
+    let is_implicit = explicit.is_none();
+    let namespace = call_namespace(explicit, worker, source)?;
+
+    if is_implicit && function_id.starts_with("engine::") {
+        Ok(Some("default".to_string()))
+    } else {
+        Ok(namespace)
+    }
+}
+
 pub(crate) fn resolve_namespace(explicit: Option<String>) -> Option<String> {
     if let Some(declared) = explicit {
         reject_blank_namespace(&declared, "InitOptions.namespace");
@@ -1438,13 +1458,12 @@ impl IIIClient {
         let request = request.into();
         let req = request.request;
         let metadata = request.metadata;
-        // Same rule as `register_trigger`: a call with no namespace stays in
-        // the caller's. Reaching a worker that lives elsewhere -- an engine
-        // builtin in `default`, a neighbour in another project -- is done by
-        // naming that namespace.
-        let namespace = call_namespace(
+        // Engine-owned builtins always live in `default`. Other implicit calls
+        // stay in the caller's namespace. An explicit request namespace wins.
+        let namespace = invocation_namespace(
             request.namespace,
             self.namespace(),
+            &req.function_id,
             "TriggerRequest.namespace",
         )?;
         let (tp, bg) = inject_trace_headers();

--- a/sdk/packages/rust/iii/tests/namespace_inheritance.rs
+++ b/sdk/packages/rust/iii/tests/namespace_inheritance.rs
@@ -42,6 +42,24 @@ async fn namespace_of(mock: &MockEngine, kind: &str) -> Option<Value> {
         .and_then(|m| m.get("namespace").cloned())
 }
 
+async fn invocation_namespace_of(mock: &MockEngine, function_id: &str) -> Option<Value> {
+    let frames = mock
+        .wait_for(
+            |messages| {
+                messages.iter().any(|message| {
+                    message.get("function_id").and_then(Value::as_str) == Some(function_id)
+                })
+            },
+            Duration::from_secs(3),
+        )
+        .await;
+
+    frames
+        .into_iter()
+        .find(|message| message.get("function_id").and_then(Value::as_str) == Some(function_id))
+        .and_then(|message| message.get("namespace").cloned())
+}
+
 #[tokio::test]
 async fn a_trigger_registers_in_the_workers_namespace() {
     let mock = MockEngine::start().await;
@@ -117,6 +135,49 @@ async fn an_invocation_stays_in_the_callers_namespace() {
     assert_eq!(
         namespace_of(&mock, "invokefunction").await,
         Some(json!("orders"))
+    );
+}
+
+#[tokio::test]
+async fn an_engine_invocation_stays_in_default() {
+    let mock = MockEngine::start().await;
+    let iii = worker_in(&mock, Some("orders"));
+
+    let _ = iii
+        .trigger(TriggerRequest {
+            function_id: "engine::channels::create".to_string(),
+            payload: json!({}),
+            action: Some(TriggerAction::Void),
+            timeout_ms: None,
+        })
+        .await;
+
+    assert_eq!(
+        invocation_namespace_of(&mock, "engine::channels::create").await,
+        Some(json!("default"))
+    );
+}
+
+#[tokio::test]
+async fn an_explicit_namespace_wins_for_an_engine_invocation() {
+    let mock = MockEngine::start().await;
+    let iii = worker_in(&mock, Some("orders"));
+
+    let _ = iii
+        .trigger(
+            TriggerRequest {
+                function_id: "engine::channels::create".to_string(),
+                payload: json!({}),
+                action: Some(TriggerAction::Void),
+                timeout_ms: None,
+            }
+            .namespace("sandbox"),
+        )
+        .await;
+
+    assert_eq!(
+        invocation_namespace_of(&mock, "engine::channels::create").await,
+        Some(json!("sandbox"))
     );
 }
 


### PR DESCRIPTION
## Summary

- route implicit `engine::*` invocations to the engine's `default` namespace in the Rust, Node, Browser, Python, and Go SDKs
- preserve explicit namespace routing and each SDK's existing behavior for non-engine functions
- remove the Node SDK's one-off namespace override for worker registration
- add regression coverage for implicit and explicit engine invocation routing

## Why

SDK 0.23 introduced worker namespace inheritance. Engine-owned functions are only available in `default`, so helpers such as channel creation and other `engine::*` calls could incorrectly follow a namespaced worker into its project namespace.

The SDK should own this routing rule so workers do not need local `.namespace("default")` workarounds.

## Impact

Namespaced workers can call SDK helpers and engine functions without manual namespace routing. A namespace explicitly supplied by the caller still wins.

## Validation

- `cargo test -p iii-sdk --test namespace_inheritance` — 15 passed
- Node namespace inheritance suite — 11 passed
- Browser namespace inheritance suite — 15 passed
- Python blank/invocation namespace suite — 15 passed
- `go test ./...` in the Go SDK — passed
- `cargo fmt --all -- --check`
- targeted Biome check completed with one existing Browser SDK warning

The repository-wide `pnpm fmt` command currently stops because the root and nested Biome configurations are both marked as roots. The four changed TypeScript files were checked directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Engine function invocations without an explicit namespace now route to the `default` namespace.
  * Explicit namespaces continue to take precedence.
  * Other invocations continue inheriting the worker’s namespace.

* **Tests**
  * Added coverage across Go, Node.js, Python, and Rust SDKs for default and explicit namespace behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->