### PR TITLE
feat(compose): manage engine lifecycle in compose up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,6 +2809,7 @@ dependencies = [
  "colored",
  "dirs 6.0.0",
  "flate2",
+ "fslock",
  "futures",
  "hex",
  "iii-sdk",

--- a/crates/iii-compose/Cargo.toml
+++ b/crates/iii-compose/Cargo.toml
@@ -44,6 +44,9 @@ indexmap = { version = "2", features = ["serde"] }
 # to be stable across machines and rust versions, so DefaultHasher is out.
 sha2 = "0.10"
 hex = "0.4"
+# One managed engine owns a compose namespace at a time. The kernel-backed
+# lock is released automatically if the foreground compose process crashes.
+fslock = "0.2"
 
 # Teardown signals whole process groups, which std cannot express.
 [target.'cfg(unix)'.dependencies]

--- a/crates/iii-compose/src/cli.rs
+++ b/crates/iii-compose/src/cli.rs
@@ -6,20 +6,20 @@
 
 //! `iii compose` command surface.
 //!
-//! `iii compose` connects to an engine and serves `compose::*` in the
-//! foreground; everything an operator does to a project goes through `iii
-//! trigger` from there, naming the project with `file=`.
+//! Bare `iii compose` connects to an existing engine and serves `compose::*`
+//! in the foreground; everything an operator does to a project goes through
+//! `iii trigger` from there, naming the project with `file=`.
 //!
-//! `iii compose up` is the same daemon with the first call already made. A
-//! daemon that serves nothing is not what an operator wants in a project
-//! directory: they want the project running, and the daemon is how it stays
-//! running. Two commands to reach one state is a step that exists only because
-//! of how compose is built.
+//! `iii compose up` is the same daemon with the first call already made and a
+//! managed engine started first by default. A daemon that serves nothing is
+//! not what an operator wants in a project directory: they want the project
+//! running, and the daemon is how it stays running. `--no-engine` keeps the
+//! external-engine workflow for an engine the operator already owns.
 //!
-//! It never backgrounds itself. That is the shape a process supervisor already
-//! wants, and it hands log rotation and restart-on-failure to systemd, launchd
-//! or a shell redirect rather than to a rotation policy compose would have to
-//! grow. Argument parsing stays separated from execution
+//! The compose process never backgrounds itself; only the managed engine child
+//! does. That is the shape a process supervisor already wants, and it hands
+//! restart-on-failure for compose to systemd, launchd or a shell redirect.
+//! Argument parsing stays separated from execution
 //! ([`ComposeCli::plan`]) so the resolved invocation is testable without
 //! touching a socket.
 
@@ -65,13 +65,27 @@ pub struct ComposeCli {
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum ComposeSub {
-    /// Serve, with one project brought up first.
+    /// Start an engine, then serve with one project brought up first.
     Up {
         /// The compose file. Defaults to `./worker-compose.yaml`, the same
         /// fallback `compose::up` uses when a call names no file.
         #[arg(short = 'f', long, value_name = "PATH")]
         file: Option<PathBuf>,
+
+        /// Connect to an engine that is already running instead of starting
+        /// and stopping one with this compose invocation.
+        #[arg(long)]
+        no_engine: bool,
     },
+}
+
+/// Who owns the engine lifecycle for this invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EngineOwnership {
+    /// Compose starts the engine and stops it after every project is down.
+    Managed,
+    /// The operator owns the engine; compose only connects to it.
+    External,
 }
 
 /// What an invocation resolved to, after the flag combination is checked.
@@ -81,6 +95,7 @@ pub enum ComposeCommand {
     Serve {
         engine_url: String,
         daemon_namespace: String,
+        engine_ownership: EngineOwnership,
         /// A project to bring up before the first call arrives. `None` is a
         /// daemon that starts holding nothing.
         start: Option<PathBuf>,
@@ -94,14 +109,24 @@ impl ComposeCli {
 
         // A missing `--file` is not "no file": it is the same fallback a call
         // with no `file=` gets, the compose file in the working directory.
-        let start = self.command.as_ref().map(|ComposeSub::Up { file }| {
+        let start = self.command.as_ref().map(|ComposeSub::Up { file, .. }| {
             file.clone()
                 .unwrap_or_else(|| PathBuf::from(DEFAULT_COMPOSE_FILE))
         });
+        let engine_ownership = match &self.command {
+            Some(ComposeSub::Up {
+                no_engine: false, ..
+            }) => EngineOwnership::Managed,
+            Some(ComposeSub::Up {
+                no_engine: true, ..
+            })
+            | None => EngineOwnership::External,
+        };
 
         Ok(ComposeCommand::Serve {
             engine_url: self.engine_url(),
             daemon_namespace,
+            engine_ownership,
             start,
         })
     }

--- a/crates/iii-compose/src/error.rs
+++ b/crates/iii-compose/src/error.rs
@@ -391,6 +391,12 @@ pub enum ComposeError {
     )]
     DaemonAlreadyServing { engine_url: String, detail: String },
 
+    #[error(
+        "another managed compose invocation already owns namespace '{namespace}'. \
+         Stop it, wait for it to finish, or choose a different --namespace"
+    )]
+    DaemonNamespaceTaken { namespace: String },
+
     /// The id is the daemon's namespace *and* its state directory, so it is
     /// checked at parse time: the alternative is a daemon that starts, answers
     /// nothing an operator can address, and fails at its first write.
@@ -472,6 +478,7 @@ impl ComposeError {
             Self::UnknownProject { .. } => "UNKNOWN_PROJECT",
             Self::RelativeFileMissing { .. } => "COMPOSE_FILE_UNREADABLE",
             Self::DaemonAlreadyServing { .. } => "DAEMON_ALREADY_SERVING",
+            Self::DaemonNamespaceTaken { .. } => "DAEMON_NAMESPACE_TAKEN",
             Self::InvalidNamespace { .. } => "INVALID_NAMESPACE",
             Self::StateDirUnavailable => "STATE_DIR_UNAVAILABLE",
             Self::NoComposeFileHere { .. } => "NO_COMPOSE_FILE",

--- a/crates/iii-compose/src/error.rs
+++ b/crates/iii-compose/src/error.rs
@@ -250,6 +250,31 @@ pub enum ComposeError {
     #[error("engine call {function} failed: {message}")]
     EngineCallFailed { function: String, message: String },
 
+    #[error("managed engine could not start: {message}")]
+    EngineSpawnFailed { message: String },
+
+    #[error(
+        "managed engine exited with {code}{}",
+        match .tail {
+            Some(tail) => format!(". It last said:\n{tail}"),
+            None => String::new(),
+        }
+    )]
+    EngineExited { code: i32, tail: Option<String> },
+
+    #[error(
+        "managed engine at {engine_url} was not ready after {seconds}s{}",
+        match .tail {
+            Some(tail) => format!(". It last said:\n{tail}"),
+            None => String::new(),
+        }
+    )]
+    EngineReadinessTimeout {
+        engine_url: String,
+        seconds: u64,
+        tail: Option<String>,
+    },
+
     #[error(
         "container '{container}' registered in '{expected}', but its function '{function}' \
          landed in '{found_in}': the function registrations reached the engine before the \
@@ -431,6 +456,9 @@ impl ComposeError {
             Self::ConfigFetchFailed { .. } => "CONFIG_FETCH_FAILED",
             Self::ConfigPublishFailed { .. } => "CONFIG_PUBLISH_FAILED",
             Self::EngineCallFailed { .. } => "ENGINE_CALL_FAILED",
+            Self::EngineSpawnFailed { .. } => "ENGINE_SPAWN_FAILED",
+            Self::EngineExited { .. } => "ENGINE_EXITED",
+            Self::EngineReadinessTimeout { .. } => "ENGINE_STARTUP_TIMEOUT",
             Self::FunctionsInWrongNamespace { .. } => "FUNCTIONS_IN_WRONG_NAMESPACE",
             Self::ReadinessTimeout { .. } => "STARTUP_TIMEOUT",
             Self::WorkerIgnoredNamespace { .. } => "WORKER_IGNORED_NAMESPACE",

--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -29,6 +29,7 @@ pub mod error;
 pub mod hooks;
 pub mod interpolate;
 pub mod lifecycle;
+mod managed_engine;
 pub mod manifest;
 pub mod name;
 pub mod namespace;
@@ -40,7 +41,7 @@ pub mod report;
 pub mod spawn;
 pub mod state;
 
-pub use cli::{ComposeCli, ComposeCommand, ComposeSub};
+pub use cli::{ComposeCli, ComposeCommand, ComposeSub, EngineOwnership};
 pub use config::{ComposeFile, Container, WorkerSource};
 pub use error::{ComposeError, Result};
 pub use manifest::{StartSpec, ValidationReport};
@@ -60,6 +61,20 @@ pub fn validate_project(
 /// Entry point behind `iii compose`. Returns the process exit code, matching
 /// the other `iii` subcommands.
 pub async fn run(cli: ComposeCli) -> i32 {
+    run_with_config(
+        cli,
+        std::path::PathBuf::from(managed_engine::DEFAULT_ENGINE_CONFIG),
+    )
+    .await
+}
+
+/// Runs compose with the engine config selected by the root `iii` CLI.
+///
+/// The compose crate deliberately does not parse or create this file. A
+/// managed engine receives the path and follows the same startup behavior as
+/// a manually launched `iii`, including creating the starter file when it is
+/// absent and stdin is not interactive.
+pub async fn run_with_config(cli: ComposeCli, engine_config: std::path::PathBuf) -> i32 {
     let command = match cli.plan() {
         Ok(command) => command,
         Err(err) => return report_error(&err),
@@ -69,8 +84,17 @@ pub async fn run(cli: ComposeCli) -> i32 {
         ComposeCommand::Serve {
             engine_url,
             daemon_namespace,
+            engine_ownership,
             start,
-        } => match serve(engine_url, daemon_namespace, start).await {
+        } => match serve(
+            engine_url,
+            daemon_namespace,
+            engine_ownership,
+            engine_config,
+            start,
+        )
+        .await
+        {
             Ok(()) => 0,
             Err(err) => report_error(&err),
         },
@@ -86,7 +110,46 @@ pub async fn run(cli: ComposeCli) -> i32 {
 async fn serve(
     engine_url: String,
     daemon_namespace: String,
+    engine_ownership: EngineOwnership,
+    engine_config: std::path::PathBuf,
     start: Option<std::path::PathBuf>,
+) -> Result<()> {
+    use colored::Colorize;
+
+    let managed_engine = match engine_ownership {
+        EngineOwnership::Managed => {
+            let engine =
+                managed_engine::ManagedEngine::start(engine_config, &daemon_namespace).await?;
+            println!("engine {}", "started".green());
+            println!("  {} {}", "pid:".dimmed(), engine.pid());
+            println!(
+                "  {} {}",
+                "config:".dimmed(),
+                engine.config_path().display()
+            );
+            println!("  {} {}", "logs:".dimmed(), engine.log_path().display());
+            println!("  {} {}", "follow logs:".dimmed(), engine.follow_command());
+            println!();
+            Some(engine)
+        }
+        EngineOwnership::External => None,
+    };
+
+    let result = serve_daemon(engine_url, daemon_namespace, start, managed_engine.as_ref()).await;
+
+    if let Some(engine) = &managed_engine {
+        println!("{}", "stopping engine...".dimmed());
+        engine.stop_with_default_grace().await;
+    }
+
+    result
+}
+
+async fn serve_daemon(
+    engine_url: String,
+    daemon_namespace: String,
+    start: Option<std::path::PathBuf>,
+    managed_engine: Option<&managed_engine::ManagedEngine>,
 ) -> Result<()> {
     use colored::Colorize;
 
@@ -100,8 +163,14 @@ async fn serve(
     // Bounded, because not being connected yet is not a failure: a daemon
     // started before its engine waits and reconnects, and should say it is
     // there rather than sit silent until the engine appears.
-    const ACCEPTED_WITHIN: std::time::Duration = std::time::Duration::from_secs(2);
-    let deadline = tokio::time::Instant::now() + ACCEPTED_WITHIN;
+    const EXTERNAL_ACCEPTED_WITHIN: std::time::Duration = std::time::Duration::from_secs(2);
+    const MANAGED_READY_WITHIN: std::time::Duration = std::time::Duration::from_secs(30);
+    let accepted_within = if managed_engine.is_some() {
+        MANAGED_READY_WITHIN
+    } else {
+        EXTERNAL_ACCEPTED_WITHIN
+    };
+    let deadline = tokio::time::Instant::now() + accepted_within;
     while tokio::time::Instant::now() < deadline {
         if let Some(error) = daemon.fatal_error() {
             daemon.abandon().await;
@@ -110,7 +179,24 @@ async fn serve(
         if daemon.engine().is_connected() {
             break;
         }
+        if let Some(engine) = managed_engine
+            && let process::Outcome::Exited(status) = engine.poll()
+        {
+            daemon.shutdown().await;
+            return Err(engine_exited(engine, status).await);
+        }
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    if let Some(engine) = managed_engine
+        && !daemon.engine().is_connected()
+    {
+        daemon.shutdown().await;
+        return Err(ComposeError::EngineReadinessTimeout {
+            engine_url: daemon.engine_url.clone(),
+            seconds: accepted_within.as_secs(),
+            tail: engine.log_tail(),
+        });
     }
 
     println!("compose {}", "serving".green());
@@ -161,11 +247,17 @@ async fn serve(
     let interrupted = tokio::signal::ctrl_c();
     tokio::pin!(interrupted);
     #[cfg(unix)]
-    let mut terminated = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-        .map_err(|err| ComposeError::SpawnFailed {
-            container: "<daemon>".to_string(),
-            message: format!("could not listen for SIGTERM: {err}"),
-        })?;
+    let mut terminated =
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(terminated) => terminated,
+            Err(err) => {
+                daemon.shutdown().await;
+                return Err(ComposeError::SpawnFailed {
+                    container: "<daemon>".to_string(),
+                    message: format!("could not listen for SIGTERM: {err}"),
+                });
+            }
+        };
 
     loop {
         #[cfg(unix)]
@@ -186,6 +278,17 @@ async fn serve(
             break;
         }
 
+        if let Some(engine) = managed_engine
+            && let process::Outcome::Exited(status) = engine.poll()
+        {
+            println!(
+                "{}",
+                "managed engine exited; stopping every project...".dimmed()
+            );
+            daemon.shutdown().await;
+            return Err(engine_exited(engine, status).await);
+        }
+
         if let Some(error) = daemon.fatal_error() {
             // Not `shutdown`: children recorded under these ids may belong to
             // the daemon that already holds them.
@@ -197,6 +300,17 @@ async fn serve(
     println!("{}", "stopping every project...".dimmed());
     daemon.shutdown().await;
     Ok(())
+}
+
+async fn engine_exited(
+    engine: &managed_engine::ManagedEngine,
+    status: std::process::ExitStatus,
+) -> ComposeError {
+    engine.finish_logging().await;
+    ComposeError::EngineExited {
+        code: status.code().unwrap_or(-1),
+        tail: engine.log_tail(),
+    }
 }
 
 /// A registration rejection, as the thing it always is in practice.

--- a/crates/iii-compose/src/managed_engine.rs
+++ b/crates/iii-compose/src/managed_engine.rs
@@ -64,12 +64,18 @@ impl ManagedEngine {
             source,
         })?;
 
-        let log = RotatingLog::open(log_path, ENGINE_LOG_MAX_BYTES, ENGINE_LOG_ARCHIVES).map_err(
-            |source| ComposeError::Io {
-                path: log_path.to_path_buf(),
-                source,
-            },
-        )?;
+        let owned_log_path = log_path.to_path_buf();
+        let log = tokio::task::spawn_blocking(move || {
+            RotatingLog::open(&owned_log_path, ENGINE_LOG_MAX_BYTES, ENGINE_LOG_ARCHIVES)
+        })
+        .await
+        .map_err(|source| ComposeError::EngineSpawnFailed {
+            message: format!("could not prepare the engine log: {source}"),
+        })?
+        .map_err(|source| ComposeError::Io {
+            path: log_path.to_path_buf(),
+            source,
+        })?;
 
         let mut command = tokio::process::Command::new(executable);
         command
@@ -165,8 +171,8 @@ fn capture_output(output: ChildOutput, log: RotatingLog) -> LogCapture {
             .map(|stream| Box::new(stream) as Box<dyn tokio::io::AsyncRead + Unpin + Send>),
     ]
     .into_iter()
-    .flatten()
     .enumerate()
+    .filter_map(|(stream_id, stream)| stream.map(|stream| (stream_id, stream)))
     {
         let chunks_tx = chunks_tx.clone();
         tokio::spawn(async move {
@@ -237,69 +243,79 @@ impl TerminalSanitizer {
     fn sanitize(&mut self, bytes: &[u8]) -> Vec<u8> {
         let mut clean = Vec::with_capacity(bytes.len());
 
-        for &byte in bytes {
-            if self.state == TerminalState::Ground && !self.utf8.is_empty() {
-                self.utf8.push(byte);
-                if self.utf8.len() == self.utf8_expected {
-                    if let Ok(text) = std::str::from_utf8(&self.utf8)
-                        && text.chars().all(|character| !character.is_control())
-                    {
-                        clean.extend_from_slice(&self.utf8);
+        for &input in bytes {
+            let mut pending = Some(input);
+            while let Some(byte) = pending.take() {
+                if self.state == TerminalState::Ground && !self.utf8.is_empty() {
+                    if !(0x80..=0xbf).contains(&byte) {
+                        self.utf8.clear();
+                        self.utf8_expected = 0;
+                        pending = Some(byte);
+                        continue;
                     }
-                    self.utf8.clear();
-                    self.utf8_expected = 0;
-                }
-                continue;
-            }
 
-            match self.state {
-                TerminalState::Ground => match byte {
-                    0x1b => self.state = TerminalState::Escape,
-                    b'\n' | b'\t' | 0x20..=0x7e => clean.push(byte),
-                    0xc2..=0xdf => self.start_utf8(byte, 2),
-                    0xe0..=0xef => self.start_utf8(byte, 3),
-                    0xf0..=0xf4 => self.start_utf8(byte, 4),
-                    _ => {}
-                },
-                TerminalState::Escape => {
-                    self.state = match byte {
-                        0x1b => TerminalState::Escape,
-                        b'[' => TerminalState::Csi,
-                        b']' => TerminalState::Osc,
-                        b'P' | b'X' | b'^' | b'_' => TerminalState::ControlString,
-                        _ => TerminalState::Ground,
-                    };
-                }
-                TerminalState::Csi => {
-                    if byte == 0x1b {
-                        self.state = TerminalState::Escape;
-                    } else if (0x40..=0x7e).contains(&byte) {
-                        self.state = TerminalState::Ground;
+                    self.utf8.push(byte);
+                    if self.utf8.len() == self.utf8_expected {
+                        if let Ok(text) = std::str::from_utf8(&self.utf8)
+                            && text.chars().all(is_safe_log_character)
+                        {
+                            clean.extend_from_slice(&self.utf8);
+                        }
+                        self.utf8.clear();
+                        self.utf8_expected = 0;
                     }
+                    continue;
                 }
-                TerminalState::Osc => match byte {
-                    0x07 => self.state = TerminalState::Ground,
-                    0x1b => self.state = TerminalState::OscEscape,
-                    _ => {}
-                },
-                TerminalState::OscEscape => {
-                    self.state = match byte {
-                        b'\\' => TerminalState::Ground,
-                        0x1b => TerminalState::OscEscape,
-                        _ => TerminalState::Osc,
-                    };
-                }
-                TerminalState::ControlString => {
-                    if byte == 0x1b {
-                        self.state = TerminalState::ControlStringEscape;
+
+                match self.state {
+                    TerminalState::Ground => match byte {
+                        0x1b => self.state = TerminalState::Escape,
+                        b'\n' | b'\t' | 0x20..=0x7e => clean.push(byte),
+                        0xc2..=0xdf => self.start_utf8(byte, 2),
+                        0xe0..=0xef => self.start_utf8(byte, 3),
+                        0xf0..=0xf4 => self.start_utf8(byte, 4),
+                        _ => {}
+                    },
+                    TerminalState::Escape => {
+                        self.state = match byte {
+                            0x1b => TerminalState::Escape,
+                            b'[' => TerminalState::Csi,
+                            b']' => TerminalState::Osc,
+                            b'P' | b'X' | b'^' | b'_' => TerminalState::ControlString,
+                            _ => TerminalState::Ground,
+                        };
                     }
-                }
-                TerminalState::ControlStringEscape => {
-                    self.state = match byte {
-                        b'\\' => TerminalState::Ground,
-                        0x1b => TerminalState::ControlStringEscape,
-                        _ => TerminalState::ControlString,
-                    };
+                    TerminalState::Csi => {
+                        if byte == 0x1b {
+                            self.state = TerminalState::Escape;
+                        } else if (0x40..=0x7e).contains(&byte) {
+                            self.state = TerminalState::Ground;
+                        }
+                    }
+                    TerminalState::Osc => match byte {
+                        0x07 => self.state = TerminalState::Ground,
+                        0x1b => self.state = TerminalState::OscEscape,
+                        _ => {}
+                    },
+                    TerminalState::OscEscape => {
+                        self.state = match byte {
+                            b'\\' => TerminalState::Ground,
+                            0x1b => TerminalState::OscEscape,
+                            _ => TerminalState::Osc,
+                        };
+                    }
+                    TerminalState::ControlString => {
+                        if byte == 0x1b {
+                            self.state = TerminalState::ControlStringEscape;
+                        }
+                    }
+                    TerminalState::ControlStringEscape => {
+                        self.state = match byte {
+                            b'\\' => TerminalState::Ground,
+                            0x1b => TerminalState::ControlStringEscape,
+                            _ => TerminalState::ControlString,
+                        };
+                    }
                 }
             }
         }
@@ -311,6 +327,18 @@ impl TerminalSanitizer {
         self.utf8.push(byte);
         self.utf8_expected = expected;
     }
+}
+
+fn is_safe_log_character(character: char) -> bool {
+    !character.is_control()
+        && !matches!(
+            character,
+            '\u{061c}'
+                | '\u{200e}'
+                | '\u{200f}'
+                | '\u{202a}'..='\u{202e}'
+                | '\u{2066}'..='\u{2069}'
+        )
 }
 
 fn sanitize_terminal_output(bytes: &[u8]) -> Vec<u8> {
@@ -454,10 +482,21 @@ fn follow_command(path: &Path) -> String {
 fn log_tail(path: &Path) -> Option<String> {
     const LINES: usize = 5;
     const WIDTH: usize = 240;
+    const MAX_TAIL_BYTES: u64 = 64 * 1024;
 
-    let bytes = std::fs::read(path).ok()?;
+    let mut file = std::fs::File::open(path).ok()?;
+    let length = file.metadata().ok()?.len();
+    let start = length.saturating_sub(MAX_TAIL_BYTES);
+    file.seek(SeekFrom::Start(start)).ok()?;
+    let mut bytes = Vec::with_capacity((length - start) as usize);
+    file.take(MAX_TAIL_BYTES).read_to_end(&mut bytes).ok()?;
     let clean = sanitize_terminal_output(&bytes);
     let text = String::from_utf8_lossy(&clean);
+    let text = if start > 0 {
+        text.split_once('\n')?.1
+    } else {
+        text.as_ref()
+    };
     let tail: Vec<&str> = text
         .lines()
         .filter(|line| !line.trim().is_empty())
@@ -537,6 +576,20 @@ mod tests {
     }
 
     #[test]
+    fn log_tail_reads_a_bounded_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("engine.log");
+        let mut contents = "x".repeat(70 * 1024);
+        contents.push_str("\none\ntwo\nthree\nfour\nfive\nsix\n");
+        std::fs::write(&log, contents).unwrap();
+
+        assert_eq!(
+            log_tail(&log).as_deref(),
+            Some("  two\n  three\n  four\n  five\n  six")
+        );
+    }
+
+    #[test]
     fn log_tail_strips_terminal_escape_sequences_from_existing_logs() {
         let dir = tempfile::tempdir().unwrap();
         let log = dir.path().join("engine.log");
@@ -565,6 +618,13 @@ mod tests {
         }
 
         assert_eq!(String::from_utf8(clean).unwrap(), "red visible café\n");
+    }
+
+    #[test]
+    fn terminal_sanitizer_reprocesses_invalid_utf8_and_strips_bidi_controls() {
+        let clean = sanitize_terminal_output(b"\xc3\x1b[31mred\x1b[0m \xe2\x80\xaespoof\n");
+
+        assert_eq!(String::from_utf8(clean).unwrap(), "red spoof\n");
     }
 
     #[cfg(unix)]

--- a/crates/iii-compose/src/managed_engine.rs
+++ b/crates/iii-compose/src/managed_engine.rs
@@ -336,6 +336,8 @@ fn is_safe_log_character(character: char) -> bool {
             '\u{061c}'
                 | '\u{200e}'
                 | '\u{200f}'
+                | '\u{2028}'
+                | '\u{2029}'
                 | '\u{202a}'..='\u{202e}'
                 | '\u{2066}'..='\u{2069}'
         )
@@ -355,6 +357,7 @@ struct RotatingLog {
 
 impl RotatingLog {
     fn open(path: &Path, max_bytes: u64, archives: usize) -> std::io::Result<Self> {
+        let max_bytes = max_bytes.max(1);
         let mut options = std::fs::OpenOptions::new();
         options.create(true).read(true).append(true);
         #[cfg(unix)]
@@ -493,7 +496,8 @@ fn log_tail(path: &Path) -> Option<String> {
     let clean = sanitize_terminal_output(&bytes);
     let text = String::from_utf8_lossy(&clean);
     let text = if start > 0 {
-        text.split_once('\n')?.1
+        text.split_once('\n')
+            .map_or(text.as_ref(), |(_, rest)| rest)
     } else {
         text.as_ref()
     };
@@ -590,6 +594,16 @@ mod tests {
     }
 
     #[test]
+    fn log_tail_keeps_a_bounded_fragment_of_one_long_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("engine.log");
+        std::fs::write(&log, "x".repeat(70 * 1024)).unwrap();
+        let expected = format!("  {}", "x".repeat(240));
+
+        assert_eq!(log_tail(&log).as_deref(), Some(expected.as_str()));
+    }
+
+    #[test]
     fn log_tail_strips_terminal_escape_sequences_from_existing_logs() {
         let dir = tempfile::tempdir().unwrap();
         let log = dir.path().join("engine.log");
@@ -622,9 +636,21 @@ mod tests {
 
     #[test]
     fn terminal_sanitizer_reprocesses_invalid_utf8_and_strips_bidi_controls() {
-        let clean = sanitize_terminal_output(b"\xc3\x1b[31mred\x1b[0m \xe2\x80\xaespoof\n");
+        let clean = sanitize_terminal_output(
+            b"\xc3\x1b[31mred\x1b[0m \xe2\x80\xaespoof\xe2\x80\xa8forged\xe2\x80\xa9line\n",
+        );
 
-        assert_eq!(String::from_utf8(clean).unwrap(), "red spoof\n");
+        assert_eq!(String::from_utf8(clean).unwrap(), "red spoofforgedline\n");
+    }
+
+    #[test]
+    fn rotating_log_clamps_a_zero_size_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("engine.log");
+
+        let log = RotatingLog::open(&log, 0, 0).unwrap();
+
+        assert_eq!(log.max_bytes, 1);
     }
 
     #[cfg(unix)]

--- a/crates/iii-compose/src/managed_engine.rs
+++ b/crates/iii-compose/src/managed_engine.rs
@@ -178,9 +178,9 @@ fn capture_output(output: ChildOutput, log: RotatingLog) -> LogCapture {
     drop(chunks_tx);
 
     let (done_tx, done_rx) = tokio::sync::watch::channel(false);
-    tokio::spawn(async move {
+    tokio::task::spawn_blocking(move || {
         let mut log = Some(log);
-        while let Some(chunk) = chunks_rx.recv().await {
+        while let Some(chunk) = chunks_rx.blocking_recv() {
             if let Some(sink) = log.as_mut()
                 && sink.write_bounded(&chunk).is_err()
             {
@@ -462,8 +462,13 @@ mod tests {
             std::fs::metadata(&log).unwrap().len() <= EXPECTED_LIMIT,
             "current log exceeded its size limit"
         );
+        let archive = log.with_file_name("engine.log.1");
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while !archive.exists() && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
         assert!(
-            log.with_file_name("engine.log.1").exists(),
+            archive.exists(),
             "the previous log segment was not archived"
         );
     }

--- a/crates/iii-compose/src/managed_engine.rs
+++ b/crates/iii-compose/src/managed_engine.rs
@@ -59,7 +59,10 @@ impl ManagedEngine {
             path: parent.to_path_buf(),
             source,
         })?;
-        owner_only(parent);
+        owner_only(parent).map_err(|source| ComposeError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
 
         let log = RotatingLog::open(log_path, ENGINE_LOG_MAX_BYTES, ENGINE_LOG_ARCHIVES).map_err(
             |source| ComposeError::Io {
@@ -152,8 +155,8 @@ impl LogCapture {
 /// stdout. Readers keep draining even if disk writes fail, avoiding a full pipe
 /// that would otherwise stall the engine itself.
 fn capture_output(output: ChildOutput, log: RotatingLog) -> LogCapture {
-    let (chunks_tx, mut chunks_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
-    for stream in [
+    let (chunks_tx, mut chunks_rx) = tokio::sync::mpsc::channel::<(usize, Vec<u8>)>(64);
+    for (stream_id, stream) in [
         output
             .stdout
             .map(|stream| Box::new(stream) as Box<dyn tokio::io::AsyncRead + Unpin + Send>),
@@ -163,13 +166,19 @@ fn capture_output(output: ChildOutput, log: RotatingLog) -> LogCapture {
     ]
     .into_iter()
     .flatten()
+    .enumerate()
     {
         let chunks_tx = chunks_tx.clone();
         tokio::spawn(async move {
             let mut stream = stream;
             let mut buffer = vec![0_u8; 8 * 1024];
             while let Ok(read) = stream.read(&mut buffer).await {
-                if read == 0 || chunks_tx.send(buffer[..read].to_vec()).await.is_err() {
+                if read == 0
+                    || chunks_tx
+                        .send((stream_id, buffer[..read].to_vec()))
+                        .await
+                        .is_err()
+                {
                     break;
                 }
             }
@@ -180,8 +189,11 @@ fn capture_output(output: ChildOutput, log: RotatingLog) -> LogCapture {
     let (done_tx, done_rx) = tokio::sync::watch::channel(false);
     tokio::task::spawn_blocking(move || {
         let mut log = Some(log);
-        while let Some(chunk) = chunks_rx.blocking_recv() {
+        let mut sanitizers = [TerminalSanitizer::default(), TerminalSanitizer::default()];
+        while let Some((stream_id, chunk)) = chunks_rx.blocking_recv() {
+            let chunk = sanitizers[stream_id].sanitize(&chunk);
             if let Some(sink) = log.as_mut()
+                && !chunk.is_empty()
                 && sink.write_bounded(&chunk).is_err()
             {
                 log = None;
@@ -194,6 +206,115 @@ fn capture_output(output: ChildOutput, log: RotatingLog) -> LogCapture {
     });
 
     LogCapture(done_rx)
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum TerminalState {
+    #[default]
+    Ground,
+    Escape,
+    Csi,
+    Osc,
+    OscEscape,
+    ControlString,
+    ControlStringEscape,
+}
+
+/// Removes terminal control sequences while preserving ordinary UTF-8 output.
+///
+/// State is retained across pipe reads because an ANSI/OSC sequence or a UTF-8
+/// scalar can be split at any byte boundary. Unterminated control strings stay
+/// suppressed, which fails closed instead of letting their payload reach a
+/// terminal through `tail -f` or an error summary.
+#[derive(Debug, Default)]
+struct TerminalSanitizer {
+    state: TerminalState,
+    utf8: Vec<u8>,
+    utf8_expected: usize,
+}
+
+impl TerminalSanitizer {
+    fn sanitize(&mut self, bytes: &[u8]) -> Vec<u8> {
+        let mut clean = Vec::with_capacity(bytes.len());
+
+        for &byte in bytes {
+            if self.state == TerminalState::Ground && !self.utf8.is_empty() {
+                self.utf8.push(byte);
+                if self.utf8.len() == self.utf8_expected {
+                    if let Ok(text) = std::str::from_utf8(&self.utf8)
+                        && text.chars().all(|character| !character.is_control())
+                    {
+                        clean.extend_from_slice(&self.utf8);
+                    }
+                    self.utf8.clear();
+                    self.utf8_expected = 0;
+                }
+                continue;
+            }
+
+            match self.state {
+                TerminalState::Ground => match byte {
+                    0x1b => self.state = TerminalState::Escape,
+                    b'\n' | b'\t' | 0x20..=0x7e => clean.push(byte),
+                    0xc2..=0xdf => self.start_utf8(byte, 2),
+                    0xe0..=0xef => self.start_utf8(byte, 3),
+                    0xf0..=0xf4 => self.start_utf8(byte, 4),
+                    _ => {}
+                },
+                TerminalState::Escape => {
+                    self.state = match byte {
+                        0x1b => TerminalState::Escape,
+                        b'[' => TerminalState::Csi,
+                        b']' => TerminalState::Osc,
+                        b'P' | b'X' | b'^' | b'_' => TerminalState::ControlString,
+                        _ => TerminalState::Ground,
+                    };
+                }
+                TerminalState::Csi => {
+                    if byte == 0x1b {
+                        self.state = TerminalState::Escape;
+                    } else if (0x40..=0x7e).contains(&byte) {
+                        self.state = TerminalState::Ground;
+                    }
+                }
+                TerminalState::Osc => match byte {
+                    0x07 => self.state = TerminalState::Ground,
+                    0x1b => self.state = TerminalState::OscEscape,
+                    _ => {}
+                },
+                TerminalState::OscEscape => {
+                    self.state = match byte {
+                        b'\\' => TerminalState::Ground,
+                        0x1b => TerminalState::OscEscape,
+                        _ => TerminalState::Osc,
+                    };
+                }
+                TerminalState::ControlString => {
+                    if byte == 0x1b {
+                        self.state = TerminalState::ControlStringEscape;
+                    }
+                }
+                TerminalState::ControlStringEscape => {
+                    self.state = match byte {
+                        b'\\' => TerminalState::Ground,
+                        0x1b => TerminalState::ControlStringEscape,
+                        _ => TerminalState::ControlString,
+                    };
+                }
+            }
+        }
+
+        clean
+    }
+
+    fn start_utf8(&mut self, byte: u8, expected: usize) {
+        self.utf8.push(byte);
+        self.utf8_expected = expected;
+    }
+}
+
+fn sanitize_terminal_output(bytes: &[u8]) -> Vec<u8> {
+    TerminalSanitizer::default().sanitize(bytes)
 }
 
 struct RotatingLog {
@@ -213,9 +334,22 @@ impl RotatingLog {
             use std::os::unix::fs::OpenOptionsExt;
             options.mode(0o600);
         }
-        let file = options.open(path)?;
-        owner_only(path);
-        let size = file.metadata()?.len();
+        let mut file = options.open(path)?;
+        owner_only(path)?;
+        let mut size = file.metadata()?.len();
+        if size > 0 && size < max_bytes {
+            file.seek(SeekFrom::Start(0))?;
+            let mut existing = Vec::with_capacity(size as usize);
+            file.read_to_end(&mut existing)?;
+            let clean = sanitize_terminal_output(&existing);
+            if clean != existing {
+                file.set_len(0)?;
+                file.seek(SeekFrom::Start(0))?;
+                file.write_all(&clean)?;
+                file.flush()?;
+                size = clean.len() as u64;
+            }
+        }
         let mut log = Self {
             path: path.to_path_buf(),
             file,
@@ -267,19 +401,20 @@ impl RotatingLog {
                 options.mode(0o600);
             }
             let mut archive_file = options.open(&archive)?;
-            owner_only(&archive);
+            owner_only(&archive)?;
 
             let start = self.size.saturating_sub(self.max_bytes);
             self.file.seek(SeekFrom::Start(start))?;
             let mut remaining = self.max_bytes.min(self.size);
             let mut buffer = [0_u8; 8 * 1024];
+            let mut sanitizer = TerminalSanitizer::default();
             while remaining > 0 {
                 let limit = remaining.min(buffer.len() as u64) as usize;
                 let count = self.file.read(&mut buffer[..limit])?;
                 if count == 0 {
                     break;
                 }
-                archive_file.write_all(&buffer[..count])?;
+                archive_file.write_all(&sanitizer.sanitize(&buffer[..count]))?;
                 remaining -= count as u64;
             }
             archive_file.flush()?;
@@ -320,7 +455,9 @@ fn log_tail(path: &Path) -> Option<String> {
     const LINES: usize = 5;
     const WIDTH: usize = 240;
 
-    let text = std::fs::read_to_string(path).ok()?;
+    let bytes = std::fs::read(path).ok()?;
+    let clean = sanitize_terminal_output(&bytes);
+    let text = String::from_utf8_lossy(&clean);
     let tail: Vec<&str> = text
         .lines()
         .filter(|line| !line.trim().is_empty())
@@ -341,17 +478,19 @@ fn log_tail(path: &Path) -> Option<String> {
 }
 
 #[cfg(unix)]
-fn owner_only(path: &Path) {
+fn owner_only(path: &Path) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
-    let _ = std::fs::set_permissions(
+    std::fs::set_permissions(
         path,
         std::fs::Permissions::from_mode(if path.is_dir() { 0o700 } else { 0o600 }),
-    );
+    )
 }
 
 #[cfg(not(unix))]
-fn owner_only(_path: &Path) {}
+fn owner_only(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
 
 #[cfg(test)]
 mod tests {
@@ -397,6 +536,61 @@ mod tests {
         );
     }
 
+    #[test]
+    fn log_tail_strips_terminal_escape_sequences_from_existing_logs() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("engine.log");
+        std::fs::write(
+            &log,
+            "\u{1b}[31mred\u{1b}[0m\n\u{1b}]2;forged title\u{7}visible\n",
+        )
+        .unwrap();
+
+        assert_eq!(log_tail(&log).as_deref(), Some("  red\n  visible"));
+    }
+
+    #[test]
+    fn terminal_sanitizer_tracks_escape_and_utf8_state_across_chunks() {
+        let mut sanitizer = TerminalSanitizer::default();
+        let mut clean = Vec::new();
+        for chunk in [
+            b"\x1b[3".as_slice(),
+            b"1mred\x1b".as_slice(),
+            b"[0m \x1b]2;forged".as_slice(),
+            b" title\x1b".as_slice(),
+            b"\\visible caf\xc3".as_slice(),
+            b"\xa9\n".as_slice(),
+        ] {
+            clean.extend(sanitizer.sanitize(chunk));
+        }
+
+        assert_eq!(String::from_utf8(clean).unwrap(), "red visible café\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opening_an_existing_log_hardens_its_permissions() {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("engine.log");
+        std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o644)
+            .open(&log)
+            .unwrap();
+        std::fs::set_permissions(&log, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let _log = RotatingLog::open(&log, ENGINE_LOG_MAX_BYTES, ENGINE_LOG_ARCHIVES).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(log).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn engine_receives_config_and_captures_both_output_streams() {
@@ -408,7 +602,7 @@ mod tests {
         let log = dir.path().join("engine.log");
         std::fs::write(
             &script,
-            "#!/bin/sh\nprintf 'args:%s\\n' \"$*\"\nprintf 'engine stderr\\n' >&2\nexit 7\n",
+            "#!/bin/sh\nprintf 'args:%s\\n' \"$*\"\nprintf '\\033[31mengine stdout\\033[0m\\n'\nprintf '\\033]2;forged title\\007engine stderr\\n' >&2\nexit 7\n",
         )
         .unwrap();
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
@@ -430,6 +624,14 @@ mod tests {
             output.contains("engine stderr"),
             "stderr missing from {output:?}"
         );
+        assert!(
+            output.contains("engine stdout"),
+            "stdout missing from {output:?}"
+        );
+        assert!(
+            !output.contains('\u{1b}') && !output.contains("forged title"),
+            "terminal escape sequence was persisted in {output:?}"
+        );
     }
 
     #[cfg(unix)]
@@ -445,7 +647,7 @@ mod tests {
         let log = dir.path().join("engine.log");
         std::fs::write(
             &script,
-            "#!/bin/sh\ndd if=/dev/zero bs=1048576 count=11 2>/dev/null\n",
+            "#!/bin/sh\ndd if=/dev/zero bs=1048576 count=11 2>/dev/null | tr '\\000' x\n",
         )
         .unwrap();
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();

--- a/crates/iii-compose/src/managed_engine.rs
+++ b/crates/iii-compose/src/managed_engine.rs
@@ -28,6 +28,7 @@ pub const DEFAULT_ENGINE_CONFIG: &str = "config.yaml";
 const ENGINE_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
 /// Number of old engine log segments retained beside `engine.log`.
 const ENGINE_LOG_ARCHIVES: usize = 3;
+const ENGINE_LOCK_FILE: &str = "engine.lock";
 
 /// The engine process owned by one foreground compose invocation.
 pub struct ManagedEngine {
@@ -35,6 +36,7 @@ pub struct ManagedEngine {
     logs: LogCapture,
     config_path: PathBuf,
     log_path: PathBuf,
+    _namespace_lock: Option<NamespaceLock>,
 }
 
 impl ManagedEngine {
@@ -45,8 +47,20 @@ impl ManagedEngine {
             std::env::current_exe().map_err(|err| ComposeError::EngineSpawnFailed {
                 message: format!("could not locate the current iii executable: {err}"),
             })?;
-        let log_path = engine_log_path(&StateStore::root()?, daemon_namespace);
-        Self::spawn_with_paths(&executable, &config_path.into(), &log_path).await
+        let state_root = StateStore::root()?;
+        let namespace_dir = state_root.join(daemon_namespace);
+        let namespace = daemon_namespace.to_string();
+        let namespace_lock =
+            tokio::task::spawn_blocking(move || NamespaceLock::acquire(&namespace_dir, &namespace))
+                .await
+                .map_err(|source| ComposeError::EngineSpawnFailed {
+                    message: format!("could not claim the managed engine namespace: {source}"),
+                })??;
+        let log_path = engine_log_path(&state_root, daemon_namespace);
+        let mut engine =
+            Self::spawn_with_paths(&executable, &config_path.into(), &log_path).await?;
+        engine._namespace_lock = Some(namespace_lock);
+        Ok(engine)
     }
 
     async fn spawn_with_paths(
@@ -94,6 +108,7 @@ impl ManagedEngine {
             logs,
             config_path: config_path.to_path_buf(),
             log_path: log_path.to_path_buf(),
+            _namespace_lock: None,
         })
     }
 
@@ -141,6 +156,56 @@ impl ManagedEngine {
     /// Lets the output readers flush the final bytes after the child exits.
     pub async fn finish_logging(&self) {
         let _ = tokio::time::timeout(Duration::from_secs(2), self.logs.wait()).await;
+    }
+}
+
+/// Cross-process ownership of one managed engine namespace.
+///
+/// The lock file persists, but the kernel lock is released with this guard or
+/// when the process exits, so a crash cannot strand the namespace.
+struct NamespaceLock {
+    _lock: fslock::LockFile,
+}
+
+impl NamespaceLock {
+    fn acquire(namespace_dir: &Path, namespace: &str) -> Result<Self> {
+        std::fs::create_dir_all(namespace_dir).map_err(|source| ComposeError::Io {
+            path: namespace_dir.to_path_buf(),
+            source,
+        })?;
+        owner_only(namespace_dir).map_err(|source| ComposeError::Io {
+            path: namespace_dir.to_path_buf(),
+            source,
+        })?;
+
+        let path = namespace_dir.join(ENGINE_LOCK_FILE);
+        let mut options = std::fs::OpenOptions::new();
+        options.create(true).read(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        options.open(&path).map_err(|source| ComposeError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        owner_only(&path).map_err(|source| ComposeError::Io {
+            path: path.clone(),
+            source,
+        })?;
+
+        let mut lock = fslock::LockFile::open(&path).map_err(|source| ComposeError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        match lock.try_lock_with_pid() {
+            Ok(true) => Ok(Self { _lock: lock }),
+            Ok(false) => Err(ComposeError::DaemonNamespaceTaken {
+                namespace: namespace.to_string(),
+            }),
+            Err(source) => Err(ComposeError::Io { path, source }),
+        }
     }
 }
 
@@ -541,12 +606,65 @@ mod tests {
 
     use super::*;
 
+    #[cfg(unix)]
+    fn write_executable(path: &Path, contents: &str) {
+        use std::{io::Write as _, os::unix::fs::PermissionsExt};
+
+        let staging = path.with_extension("tmp");
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&staging)
+            .unwrap();
+        file.write_all(contents.as_bytes()).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+        std::fs::set_permissions(&staging, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::rename(staging, path).unwrap();
+    }
+
     #[test]
     fn engine_log_lives_under_the_daemon_namespace() {
         assert_eq!(
             engine_log_path(Path::new("/state"), "blue-whale"),
             Path::new("/state/blue-whale/engine.log")
         );
+    }
+
+    #[test]
+    fn concurrent_managed_engines_cannot_claim_the_same_namespace() {
+        let dir = tempfile::tempdir().unwrap();
+        let namespace_dir = dir.path().join("orders");
+        std::fs::create_dir(&namespace_dir).unwrap();
+        let start = std::sync::Arc::new(std::sync::Barrier::new(3));
+        let attempted = std::sync::Arc::new(std::sync::Barrier::new(3));
+        let mut handles = Vec::new();
+
+        for _ in 0..2 {
+            let namespace_dir = namespace_dir.clone();
+            let start = std::sync::Arc::clone(&start);
+            let attempted = std::sync::Arc::clone(&attempted);
+            handles.push(std::thread::spawn(move || {
+                start.wait();
+                let claim = NamespaceLock::acquire(&namespace_dir, "orders");
+                let acquired = claim.is_ok();
+                attempted.wait();
+                acquired
+            }));
+        }
+
+        start.wait();
+        attempted.wait();
+        let acquired = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .filter(|acquired| *acquired)
+            .count();
+
+        assert_eq!(acquired, 1);
+        NamespaceLock::acquire(&namespace_dir, "orders")
+            .expect("the namespace lock must be released with its owner");
     }
 
     #[cfg(unix)]
@@ -680,18 +798,14 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn engine_receives_config_and_captures_both_output_streams() {
-        use std::os::unix::fs::PermissionsExt;
-
         let dir = tempfile::tempdir().unwrap();
         let script = dir.path().join("fake iii");
         let config = dir.path().join("project config.yaml");
         let log = dir.path().join("engine.log");
-        std::fs::write(
+        write_executable(
             &script,
             "#!/bin/sh\nprintf 'args:%s\\n' \"$*\"\nprintf '\\033[31mengine stdout\\033[0m\\n'\nprintf '\\033]2;forged title\\007engine stderr\\n' >&2\nexit 7\n",
-        )
-        .unwrap();
-        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+        );
 
         let engine = ManagedEngine::spawn_with_paths(&script, &config, &log)
             .await
@@ -723,20 +837,16 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn engine_log_rotates_before_it_can_grow_without_bound() {
-        use std::os::unix::fs::PermissionsExt;
-
         const EXPECTED_LIMIT: u64 = 10 * 1024 * 1024;
 
         let dir = tempfile::tempdir().unwrap();
         let script = dir.path().join("noisy-iii");
         let config = dir.path().join("config.yaml");
         let log = dir.path().join("engine.log");
-        std::fs::write(
+        write_executable(
             &script,
             "#!/bin/sh\ndd if=/dev/zero bs=1048576 count=11 2>/dev/null | tr '\\000' x\n",
-        )
-        .unwrap();
-        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+        );
 
         let engine = ManagedEngine::spawn_with_paths(&script, &config, &log)
             .await
@@ -764,18 +874,14 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn stopping_the_engine_stops_its_process_group() {
-        use std::os::unix::fs::PermissionsExt;
-
         let dir = tempfile::tempdir().unwrap();
         let script = dir.path().join("fake-iii");
         let config = dir.path().join("config.yaml");
         let log = dir.path().join("engine.log");
-        std::fs::write(
+        write_executable(
             &script,
             "#!/bin/sh\ntrap 'exit 0' TERM INT\nwhile :; do sleep 1; done\n",
-        )
-        .unwrap();
-        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+        );
 
         let engine = ManagedEngine::spawn_with_paths(&script, &config, &log)
             .await

--- a/crates/iii-compose/src/managed_engine.rs
+++ b/crates/iii-compose/src/managed_engine.rs
@@ -1,0 +1,497 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Lifecycle of the engine process owned by `iii compose up`.
+
+use std::{
+    io::{Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    process::{ExitStatus, Stdio},
+    time::Duration,
+};
+
+use tokio::io::AsyncReadExt;
+
+use crate::{
+    error::{ComposeError, Result},
+    process::{ChildOutput, DEFAULT_STOP_GRACE, Supervised, spawn_supervised_piped},
+    state::StateStore,
+};
+
+/// The config selected by the root `iii` CLI when `--config` is absent.
+pub const DEFAULT_ENGINE_CONFIG: &str = "config.yaml";
+
+/// Maximum size of the active engine log before it rolls into an archive.
+const ENGINE_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
+/// Number of old engine log segments retained beside `engine.log`.
+const ENGINE_LOG_ARCHIVES: usize = 3;
+
+/// The engine process owned by one foreground compose invocation.
+pub struct ManagedEngine {
+    process: Supervised,
+    logs: LogCapture,
+    config_path: PathBuf,
+    log_path: PathBuf,
+}
+
+impl ManagedEngine {
+    /// Starts the current `iii` executable with output detached from compose's
+    /// terminal and captured below this daemon namespace's state directory.
+    pub async fn start(config_path: impl Into<PathBuf>, daemon_namespace: &str) -> Result<Self> {
+        let executable =
+            std::env::current_exe().map_err(|err| ComposeError::EngineSpawnFailed {
+                message: format!("could not locate the current iii executable: {err}"),
+            })?;
+        let log_path = engine_log_path(&StateStore::root()?, daemon_namespace);
+        Self::spawn_with_paths(&executable, &config_path.into(), &log_path).await
+    }
+
+    async fn spawn_with_paths(
+        executable: &Path,
+        config_path: &Path,
+        log_path: &Path,
+    ) -> Result<Self> {
+        let parent = log_path.parent().unwrap_or_else(|| Path::new("."));
+        std::fs::create_dir_all(parent).map_err(|source| ComposeError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+        owner_only(parent);
+
+        let log = RotatingLog::open(log_path, ENGINE_LOG_MAX_BYTES, ENGINE_LOG_ARCHIVES).map_err(
+            |source| ComposeError::Io {
+                path: log_path.to_path_buf(),
+                source,
+            },
+        )?;
+
+        let mut command = tokio::process::Command::new(executable);
+        command
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null());
+
+        let (process, output) =
+            spawn_supervised_piped(command).map_err(|err| ComposeError::EngineSpawnFailed {
+                message: format!("could not start {}: {err}", executable.display()),
+            })?;
+        let logs = capture_output(output, log);
+
+        Ok(Self {
+            process,
+            logs,
+            config_path: config_path.to_path_buf(),
+            log_path: log_path.to_path_buf(),
+        })
+    }
+
+    pub fn pid(&self) -> u32 {
+        self.process.pid
+    }
+
+    pub fn config_path(&self) -> &Path {
+        &self.config_path
+    }
+
+    pub fn log_path(&self) -> &Path {
+        &self.log_path
+    }
+
+    pub fn follow_command(&self) -> String {
+        follow_command(&self.log_path)
+    }
+
+    pub fn log_tail(&self) -> Option<String> {
+        log_tail(&self.log_path)
+    }
+
+    #[cfg(test)]
+    async fn wait(&self) -> ExitStatus {
+        let status = self.process.wait().await;
+        self.finish_logging().await;
+        status
+    }
+
+    pub fn poll(&self) -> crate::process::Outcome {
+        self.process.poll()
+    }
+
+    pub async fn stop(&self, grace: Duration) -> ExitStatus {
+        let status = self.process.stop(grace).await;
+        self.finish_logging().await;
+        status
+    }
+
+    pub async fn stop_with_default_grace(&self) -> ExitStatus {
+        self.stop(DEFAULT_STOP_GRACE).await
+    }
+
+    /// Lets the output readers flush the final bytes after the child exits.
+    pub async fn finish_logging(&self) {
+        let _ = tokio::time::timeout(Duration::from_secs(2), self.logs.wait()).await;
+    }
+}
+
+struct LogCapture(tokio::sync::watch::Receiver<bool>);
+
+impl LogCapture {
+    async fn wait(&self) {
+        let mut done = self.0.clone();
+        while !*done.borrow_and_update() {
+            if done.changed().await.is_err() {
+                break;
+            }
+        }
+    }
+}
+
+/// One writer owns both child streams, so rotation cannot race stderr against
+/// stdout. Readers keep draining even if disk writes fail, avoiding a full pipe
+/// that would otherwise stall the engine itself.
+fn capture_output(output: ChildOutput, log: RotatingLog) -> LogCapture {
+    let (chunks_tx, mut chunks_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+    for stream in [
+        output
+            .stdout
+            .map(|stream| Box::new(stream) as Box<dyn tokio::io::AsyncRead + Unpin + Send>),
+        output
+            .stderr
+            .map(|stream| Box::new(stream) as Box<dyn tokio::io::AsyncRead + Unpin + Send>),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        let chunks_tx = chunks_tx.clone();
+        tokio::spawn(async move {
+            let mut stream = stream;
+            let mut buffer = vec![0_u8; 8 * 1024];
+            while let Ok(read) = stream.read(&mut buffer).await {
+                if read == 0 || chunks_tx.send(buffer[..read].to_vec()).await.is_err() {
+                    break;
+                }
+            }
+        });
+    }
+    drop(chunks_tx);
+
+    let (done_tx, done_rx) = tokio::sync::watch::channel(false);
+    tokio::spawn(async move {
+        let mut log = Some(log);
+        while let Some(chunk) = chunks_rx.recv().await {
+            if let Some(sink) = log.as_mut()
+                && sink.write_bounded(&chunk).is_err()
+            {
+                log = None;
+            }
+        }
+        if let Some(mut sink) = log {
+            let _ = sink.file.flush();
+        }
+        let _ = done_tx.send(true);
+    });
+
+    LogCapture(done_rx)
+}
+
+struct RotatingLog {
+    path: PathBuf,
+    file: std::fs::File,
+    size: u64,
+    max_bytes: u64,
+    archives: usize,
+}
+
+impl RotatingLog {
+    fn open(path: &Path, max_bytes: u64, archives: usize) -> std::io::Result<Self> {
+        let mut options = std::fs::OpenOptions::new();
+        options.create(true).read(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options.open(path)?;
+        owner_only(path);
+        let size = file.metadata()?.len();
+        let mut log = Self {
+            path: path.to_path_buf(),
+            file,
+            size,
+            max_bytes,
+            archives,
+        };
+        if log.size >= log.max_bytes {
+            log.rotate()?;
+        }
+        Ok(log)
+    }
+
+    fn write_bounded(&mut self, mut bytes: &[u8]) -> std::io::Result<()> {
+        while !bytes.is_empty() {
+            if self.size >= self.max_bytes {
+                self.rotate()?;
+            }
+            let available = (self.max_bytes - self.size) as usize;
+            let count = available.min(bytes.len());
+            self.file.write_all(&bytes[..count])?;
+            self.size += count as u64;
+            bytes = &bytes[count..];
+        }
+        Ok(())
+    }
+
+    fn rotate(&mut self) -> std::io::Result<()> {
+        self.file.flush()?;
+
+        if self.archives > 0 {
+            let oldest = archive_path(&self.path, self.archives);
+            if oldest.exists() {
+                std::fs::remove_file(oldest)?;
+            }
+            for index in (1..self.archives).rev() {
+                let source = archive_path(&self.path, index);
+                if source.exists() {
+                    std::fs::rename(source, archive_path(&self.path, index + 1))?;
+                }
+            }
+
+            let archive = archive_path(&self.path, 1);
+            let mut options = std::fs::OpenOptions::new();
+            options.create(true).write(true).truncate(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            let mut archive_file = options.open(&archive)?;
+            owner_only(&archive);
+
+            let start = self.size.saturating_sub(self.max_bytes);
+            self.file.seek(SeekFrom::Start(start))?;
+            let mut remaining = self.max_bytes.min(self.size);
+            let mut buffer = [0_u8; 8 * 1024];
+            while remaining > 0 {
+                let limit = remaining.min(buffer.len() as u64) as usize;
+                let count = self.file.read(&mut buffer[..limit])?;
+                if count == 0 {
+                    break;
+                }
+                archive_file.write_all(&buffer[..count])?;
+                remaining -= count as u64;
+            }
+            archive_file.flush()?;
+        }
+
+        // Keep the active path and inode stable so `tail -f engine.log` keeps
+        // following across rotations on Unix and PowerShell keeps its handle.
+        self.file.set_len(0)?;
+        self.file.seek(SeekFrom::Start(0))?;
+        self.size = 0;
+        Ok(())
+    }
+}
+
+fn archive_path(path: &Path, index: usize) -> PathBuf {
+    let mut archive = path.as_os_str().to_os_string();
+    archive.push(format!(".{index}"));
+    PathBuf::from(archive)
+}
+
+fn engine_log_path(root: &Path, daemon_namespace: &str) -> PathBuf {
+    root.join(daemon_namespace).join("engine.log")
+}
+
+#[cfg(unix)]
+fn follow_command(path: &Path) -> String {
+    let quoted = path.to_string_lossy().replace('\'', "'\"'\"'");
+    format!("tail -f '{quoted}'")
+}
+
+#[cfg(windows)]
+fn follow_command(path: &Path) -> String {
+    let quoted = path.to_string_lossy().replace('\'', "''");
+    format!("Get-Content -LiteralPath '{quoted}' -Wait")
+}
+
+fn log_tail(path: &Path) -> Option<String> {
+    const LINES: usize = 5;
+    const WIDTH: usize = 240;
+
+    let text = std::fs::read_to_string(path).ok()?;
+    let tail: Vec<&str> = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .rev()
+        .take(LINES)
+        .collect();
+    if tail.is_empty() {
+        return None;
+    }
+
+    Some(
+        tail.into_iter()
+            .rev()
+            .map(|line| format!("  {}", line.chars().take(WIDTH).collect::<String>()))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+}
+
+#[cfg(unix)]
+fn owner_only(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _ = std::fs::set_permissions(
+        path,
+        std::fs::Permissions::from_mode(if path.is_dir() { 0o700 } else { 0o600 }),
+    );
+}
+
+#[cfg(not(unix))]
+fn owner_only(_path: &Path) {}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::Path, time::Duration};
+
+    use super::*;
+
+    #[test]
+    fn engine_log_lives_under_the_daemon_namespace() {
+        assert_eq!(
+            engine_log_path(Path::new("/state"), "blue-whale"),
+            Path::new("/state/blue-whale/engine.log")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn follow_command_quotes_paths_for_a_shell() {
+        assert_eq!(
+            follow_command(Path::new("/tmp/my project's/engine.log")),
+            "tail -f '/tmp/my project'\"'\"'s/engine.log'"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn follow_command_quotes_paths_for_powershell() {
+        assert_eq!(
+            follow_command(Path::new("C:\\my project's\\engine.log")),
+            "Get-Content -LiteralPath 'C:\\my project''s\\engine.log' -Wait"
+        );
+    }
+
+    #[test]
+    fn log_tail_is_bounded_to_the_last_five_non_empty_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("engine.log");
+        std::fs::write(&log, "one\n\ntwo\nthree\nfour\nfive\nsix\n").unwrap();
+
+        assert_eq!(
+            log_tail(&log).as_deref(),
+            Some("  two\n  three\n  four\n  five\n  six")
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn engine_receives_config_and_captures_both_output_streams() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("fake iii");
+        let config = dir.path().join("project config.yaml");
+        let log = dir.path().join("engine.log");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\nprintf 'args:%s\\n' \"$*\"\nprintf 'engine stderr\\n' >&2\nexit 7\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let engine = ManagedEngine::spawn_with_paths(&script, &config, &log)
+            .await
+            .unwrap();
+        let status = tokio::time::timeout(Duration::from_secs(5), engine.wait())
+            .await
+            .expect("fake engine should exit");
+
+        assert_eq!(status.code(), Some(7));
+        let output = std::fs::read_to_string(&log).unwrap();
+        assert!(
+            output.contains(&format!("args:--config {}", config.display())),
+            "config argument missing from {output:?}"
+        );
+        assert!(
+            output.contains("engine stderr"),
+            "stderr missing from {output:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn engine_log_rotates_before_it_can_grow_without_bound() {
+        use std::os::unix::fs::PermissionsExt;
+
+        const EXPECTED_LIMIT: u64 = 10 * 1024 * 1024;
+
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("noisy-iii");
+        let config = dir.path().join("config.yaml");
+        let log = dir.path().join("engine.log");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\ndd if=/dev/zero bs=1048576 count=11 2>/dev/null\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let engine = ManagedEngine::spawn_with_paths(&script, &config, &log)
+            .await
+            .unwrap();
+        let status = tokio::time::timeout(Duration::from_secs(10), engine.wait())
+            .await
+            .expect("noisy engine should exit");
+
+        assert!(status.success());
+        assert!(
+            std::fs::metadata(&log).unwrap().len() <= EXPECTED_LIMIT,
+            "current log exceeded its size limit"
+        );
+        assert!(
+            log.with_file_name("engine.log.1").exists(),
+            "the previous log segment was not archived"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stopping_the_engine_stops_its_process_group() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("fake-iii");
+        let config = dir.path().join("config.yaml");
+        let log = dir.path().join("engine.log");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\ntrap 'exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let engine = ManagedEngine::spawn_with_paths(&script, &config, &log)
+            .await
+            .unwrap();
+        let pid = engine.pid();
+        assert!(crate::process::is_running(pid));
+
+        let _status = engine.stop(Duration::from_secs(2)).await;
+
+        assert!(!crate::process::is_running(pid));
+    }
+}

--- a/crates/iii-compose/tests/cli.rs
+++ b/crates/iii-compose/tests/cli.rs
@@ -5,7 +5,7 @@
 //! starts holding a project or holding nothing.
 
 use clap::Parser;
-use iii_compose::{ComposeCli, ComposeCommand};
+use iii_compose::{ComposeCli, ComposeCommand, EngineOwnership};
 
 /// Mirrors how the engine mounts the subcommand, so parsing is exercised
 /// through the same shape the real binary uses.
@@ -175,21 +175,45 @@ fn a_project_namespace_still_comes_from_the_file_or_default() {
 
 #[test]
 fn bare_compose_starts_holding_nothing() {
-    let ComposeCommand::Serve { start, .. } = parse(&["iii", "compose"]).plan().unwrap();
+    let ComposeCommand::Serve {
+        start,
+        engine_ownership,
+        ..
+    } = parse(&["iii", "compose"]).plan().unwrap();
     assert_eq!(
         start, None,
         "a bare daemon learns about a project from a call"
     );
+    assert_eq!(engine_ownership, EngineOwnership::External);
 }
 
 #[test]
 fn up_names_the_file_in_the_current_directory() {
     // The point of the command: in a project directory, one word starts it.
-    let ComposeCommand::Serve { start, .. } = parse(&["iii", "compose", "up"]).plan().unwrap();
+    let ComposeCommand::Serve {
+        start,
+        engine_ownership,
+        ..
+    } = parse(&["iii", "compose", "up"]).plan().unwrap();
     assert_eq!(
         start.as_deref(),
         Some(std::path::Path::new("worker-compose.yaml"))
     );
+    assert_eq!(engine_ownership, EngineOwnership::Managed);
+}
+
+#[test]
+fn up_can_leave_engine_ownership_to_the_operator() {
+    let ComposeCommand::Serve {
+        start,
+        engine_ownership,
+        ..
+    } = parse(&["iii", "compose", "up", "--no-engine"])
+        .plan()
+        .unwrap();
+
+    assert!(start.is_some());
+    assert_eq!(engine_ownership, EngineOwnership::External);
 }
 
 #[test]

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -52,7 +52,7 @@ iii compose [OPTIONS] [COMMAND]
 
 #### `iii compose up`
 
-Serve, with one project brought up first
+Start an engine, then serve with one project brought up first
 
 ```text
 iii compose up [OPTIONS]
@@ -61,6 +61,7 @@ iii compose up [OPTIONS]
 | Option | Description |
 | ------ | ----------- |
 | `-f, --file <PATH>` | The compose file. Defaults to `./worker-compose.yaml`, the same fallback `compose::up` uses when a call names no file |
+| `--no-engine` | Connect to an engine that is already running instead of starting and stopping one with this compose invocation |
 | `--engine <URL>` | Engine WebSocket address. Falls back to III_URL, then ws://127.0.0.1:49134 |
 | `-n, --namespace <NS>` | Namespace this daemon answers `compose::*` in. Several attach to one engine; this is what tells them apart |
 

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -50,7 +50,7 @@ iii compose [OPTIONS] [COMMAND]
 
 #### `iii compose up`
 
-Serve, with one project brought up first
+Start an engine, then serve with one project brought up first
 
 ```text
 iii compose up [OPTIONS]
@@ -59,6 +59,7 @@ iii compose up [OPTIONS]
 | Option | Description |
 | ------ | ----------- |
 | `-f, --file <PATH>` | The compose file. Defaults to `./worker-compose.yaml`, the same fallback `compose::up` uses when a call names no file |
+| `--no-engine` | Connect to an engine that is already running instead of starting and stopping one with this compose invocation |
 | `--engine <URL>` | Engine WebSocket address. Falls back to III_URL, then ws://127.0.0.1:49134 |
 | `-n, --namespace <NS>` | Namespace this daemon answers `compose::*` in. Several attach to one engine; this is what tells them apart |
 

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -50,22 +50,36 @@ compose serving
 </Warning>
 
 `SIGINT` and `SIGTERM` both stop the daemon and take every project down with it. `compose::stop`
-does the same over the engine.
+does the same over the engine. When `up` owns the engine, every project and worker stops before the
+engine process is stopped.
 
 ### Starting a project with the daemon
 
-`iii compose up` serves and brings one project up, without waiting for a call to name it.
+`iii compose up` starts an engine in the background, waits for it to be ready, and then serves and
+brings one project up without waiting for a call to name it. The compose daemon stays in the
+foreground so it can supervise both the project and the engine.
 
 ```text
-iii compose up [-f, --file <PATH>]
+iii compose up [-f, --file <PATH>] [--no-engine]
 ```
 
 `--file` defaults to `./worker-compose.yaml`, the same fallback a `compose::*` call gets when it
 names no file. The daemon then stays in the foreground and serves, so every other operation is a
 `compose::*` call as usual.
 
+The managed engine uses `./config.yaml`, or the path selected before the subcommand with
+`iii --config <PATH> compose up`. If the file does not exist, the engine creates its standard
+minimal `workers: []` config. This is the same startup contract as running `iii` manually, so config
+reload and `iii worker add` continue to operate on a real project file.
+
 ```text
 $ iii compose up -n orders
+engine started
+  pid: 42042
+  config: config.yaml
+  logs: /home/me/.iii/compose/orders/engine.log
+  follow logs: tail -f '/home/me/.iii/compose/orders/engine.log'
+
 compose serving
   engine: ws://127.0.0.1:49134
   namespace: orders
@@ -75,14 +89,26 @@ compose serving
 up: 1 of 1 changed in 250ms
 ```
 
+The active engine log rotates at 10 MiB. Compose keeps `engine.log.1` through `engine.log.3`, so one
+namespace uses at most about 40 MiB for engine logs. The printed follow command keeps reading the
+active `engine.log` across rotations.
+
 A project that does not start ends the command with `PROJECT_DID_NOT_START`. Rollback has already
 stopped whatever came up, so there is nothing left to supervise.
 
+Use `--no-engine` when the engine is already running. In that mode compose only connects to
+`--engine`, `III_URL`, or the default address, and never stops that external process.
+
+```bash
+iii compose up --no-engine --engine ws://127.0.0.1:49134
+```
+
 ### Running it in the background
 
-Compose never backgrounds itself. It serves in the foreground and writes to stdout, which is the
-shape every process supervisor already expects, and it leaves log rotation and restart-on-failure
-to something that already does both.
+Compose never backgrounds itself. Even when `up` runs its managed engine in the background, the
+compose daemon serves in the foreground and writes its own output to stdout. This is the shape every
+process supervisor already expects, and it leaves log rotation and restart-on-failure to something
+that already does both.
 
 For a quick session, a shell redirect is enough:
 

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -94,7 +94,8 @@ up: 1 of 1 changed in 250ms
 
 The active engine log rotates at 10 MiB. Compose keeps `engine.log.1` through `engine.log.3`, so one
 namespace uses at most about 40 MiB for engine logs. The printed follow command keeps reading the
-active `engine.log` across rotations.
+active `engine.log` across rotations. Compose strips terminal control sequences before persisting
+the engine output.
 
 A project that does not start ends the command with `PROJECT_DID_NOT_START`. Rollback has already
 stopped whatever came up, so there is nothing left to supervise.

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -15,6 +15,9 @@ The daemon is itself a worker. It registers under the name `compose` in a namesp
 exposes the `compose::*` functions there, so every project operation is a normal
 [trigger](./triggers), addressed to one daemon with `--namespace`.
 
+`iii compose` is intentionally a verbless top-level daemon command, analogous to `iii console`.
+The `up` subcommand is the convenience path that also starts a project and, by default, its engine.
+
 ## The daemon
 
 ```text

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -44,22 +44,36 @@ compose serving
 </Warning>
 
 `SIGINT` and `SIGTERM` both stop the daemon and take every project down with it. `compose::stop`
-does the same over the engine.
+does the same over the engine. When `up` owns the engine, every project and worker stops before the
+engine process is stopped.
 
 ### Starting a project with the daemon
 
-`iii compose up` serves and brings one project up, without waiting for a call to name it.
+`iii compose up` starts an engine in the background, waits for it to be ready, and then serves and
+brings one project up without waiting for a call to name it. The compose daemon stays in the
+foreground so it can supervise both the project and the engine.
 
 ```text
-iii compose up [-f, --file <PATH>]
+iii compose up [-f, --file <PATH>] [--no-engine]
 ```
 
 `--file` defaults to `./worker-compose.yaml`, the same fallback a `compose::*` call gets when it
 names no file. The daemon then stays in the foreground and serves, so every other operation is a
 `compose::*` call as usual.
 
+The managed engine uses `./config.yaml`, or the path selected before the subcommand with
+`iii --config <PATH> compose up`. If the file does not exist, the engine creates its standard
+minimal `workers: []` config. This is the same startup contract as running `iii` manually, so config
+reload and `iii worker add` continue to operate on a real project file.
+
 ```text
 $ iii compose up -n orders
+engine started
+  pid: 42042
+  config: config.yaml
+  logs: /home/me/.iii/compose/orders/engine.log
+  follow logs: tail -f '/home/me/.iii/compose/orders/engine.log'
+
 compose serving
   engine: ws://127.0.0.1:49134
   namespace: orders
@@ -69,14 +83,26 @@ compose serving
 up: 1 of 1 changed in 250ms
 ```
 
+The active engine log rotates at 10 MiB. Compose keeps `engine.log.1` through `engine.log.3`, so one
+namespace uses at most about 40 MiB for engine logs. The printed follow command keeps reading the
+active `engine.log` across rotations.
+
 A project that does not start ends the command with `PROJECT_DID_NOT_START`. Rollback has already
 stopped whatever came up, so there is nothing left to supervise.
 
+Use `--no-engine` when the engine is already running. In that mode compose only connects to
+`--engine`, `III_URL`, or the default address, and never stops that external process.
+
+```bash
+iii compose up --no-engine --engine ws://127.0.0.1:49134
+```
+
 ### Running it in the background
 
-Compose never backgrounds itself. It serves in the foreground and writes to stdout, which is the
-shape every process supervisor already expects, and it leaves log rotation and restart-on-failure
-to something that already does both.
+Compose never backgrounds itself. Even when `up` runs its managed engine in the background, the
+compose daemon serves in the foreground and writes its own output to stdout. This is the shape every
+process supervisor already expects, and it leaves log rotation and restart-on-failure to something
+that already does both.
 
 For a quick session, a shell redirect is enough:
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -88,7 +88,8 @@ up: 1 of 1 changed in 250ms
 
 The active engine log rotates at 10 MiB. Compose keeps `engine.log.1` through `engine.log.3`, so one
 namespace uses at most about 40 MiB for engine logs. The printed follow command keeps reading the
-active `engine.log` across rotations.
+active `engine.log` across rotations. Compose strips terminal control sequences before persisting
+the engine output.
 
 A project that does not start ends the command with `PROJECT_DID_NOT_START`. Rollback has already
 stopped whatever came up, so there is nothing left to supervise.

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -9,6 +9,9 @@ The daemon is itself a worker. It registers under the name `compose` in a namesp
 exposes the `compose::*` functions there, so every project operation is a normal
 [trigger](./triggers), addressed to one daemon with `--namespace`.
 
+`iii compose` is intentionally a verbless top-level daemon command, analogous to `iii console`.
+The `up` subcommand is the convenience path that also starts a project and, by default, its engine.
+
 ## The daemon
 
 ```text

--- a/engine/src/cli/platform.rs
+++ b/engine/src/cli/platform.rs
@@ -285,6 +285,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_data_dir_opt_agrees_with_data_dir() {
         // Wherever the platform dirs resolve, the option-returning variant
         // must agree with data_dir(). When they don't resolve it is None,

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -401,10 +401,15 @@ async fn main() -> anyhow::Result<()> {
             let exit_code = cli::project::run(args.clone()).await;
             std::process::exit(exit_code);
         }
-        // Compose owns its own lifecycle and never builds an engine: it is a
-        // client of one, exactly like any other worker.
+        // Compose owns its own lifecycle. `up` starts a managed engine unless
+        // --no-engine was selected; the root config flag is the engine child's
+        // config path, just as it is on the ordinary serve path.
         Some(Commands::Compose(args)) => {
-            let exit_code = iii_compose::run(args.clone()).await;
+            let exit_code = iii_compose::run_with_config(
+                args.clone(),
+                std::path::PathBuf::from(config_path_of(&cli_args)),
+            )
+            .await;
             std::process::exit(exit_code);
         }
         // Handled before telemetry above.
@@ -902,11 +907,21 @@ mod tests {
     /// before a call can reach it.
     #[test]
     fn compose_up_reaches_the_subcommand() {
-        let cli = Cli::try_parse_from(["iii", "compose", "up", "-n", "dev"]).expect("should parse");
+        let cli = Cli::try_parse_from(["iii", "compose", "up", "-n", "dev", "--no-engine"])
+            .expect("should parse");
         match cli.command {
             Some(Commands::Compose(args)) => {
                 assert_eq!(args.ns.as_deref(), Some("dev"));
-                assert!(args.command.is_some(), "up should reach the subcommand");
+                assert!(
+                    matches!(
+                        args.command,
+                        Some(iii_compose::ComposeSub::Up {
+                            no_engine: true,
+                            ..
+                        })
+                    ),
+                    "up --no-engine should reach the subcommand"
+                );
             }
             _ => panic!("expected Compose subcommand"),
         }
@@ -1058,6 +1073,16 @@ mod tests {
         assert_eq!(envs[0].0, "III_CONFIG_PATH");
         assert!(std::path::Path::new(&envs[0].1).is_absolute());
         assert!(envs[0].1.ends_with("foo.yaml"));
+    }
+
+    #[test]
+    fn compose_uses_the_root_engine_config_selection() {
+        let explicit =
+            Cli::try_parse_from(["iii", "--config", "custom.yaml", "compose", "up"]).unwrap();
+        let default = Cli::try_parse_from(["iii", "compose", "up"]).unwrap();
+
+        assert_eq!(config_path_of(&explicit), "custom.yaml");
+        assert_eq!(config_path_of(&default), "config.yaml");
     }
 
     #[test]

--- a/engine/tests/compose_managed_engine_e2e.rs
+++ b/engine/tests/compose_managed_engine_e2e.rs
@@ -122,7 +122,11 @@ fn compose_up_starts_logs_and_stops_the_engine_it_owns() {
     );
 
     // The child had to bind this custom port for compose to reach the invalid
-    // project, and cleanup must release it before the foreground CLI returns.
+    // project. On Unix, cleanup must release it before the foreground CLI
+    // returns. Windows can keep the address unavailable in TIME_WAIT after the
+    // process has exited, so an immediate rebind is not a reliable lifecycle
+    // probe there; that path still exercises startup, logging, and cleanup.
+    #[cfg(unix)]
     TcpListener::bind(("127.0.0.1", port)).expect("managed engine should be stopped");
 }
 

--- a/engine/tests/compose_managed_engine_e2e.rs
+++ b/engine/tests/compose_managed_engine_e2e.rs
@@ -1,0 +1,229 @@
+//! Managed-engine lifecycle exercised through the installed CLI shape.
+
+use std::{net::TcpListener, process::Command};
+
+#[cfg(unix)]
+use std::{process::Stdio, time::Duration, time::Instant};
+
+fn iii_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_iii"))
+}
+
+#[cfg(unix)]
+fn shell_quote(value: &std::path::Path) -> String {
+    format!("'{}'", value.to_string_lossy().replace('\'', "'\"'\"'"))
+}
+
+#[cfg(unix)]
+fn wait_for_file(path: &std::path::Path, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    false
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore]
+fn managed_worker_fixture() {
+    let ready = std::env::var_os("READY_MARKER").expect("READY_MARKER");
+    let client = iii_sdk::register_worker_from_env(iii_sdk::InitOptions::default());
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < deadline {
+        if matches!(
+            client.get_connection_state(),
+            iii_sdk::runtime::IIIConnectionState::Connected
+        ) {
+            std::fs::write(ready, "ready").unwrap();
+            loop {
+                std::thread::park_timeout(Duration::from_secs(1));
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("fixture worker never connected");
+}
+
+#[test]
+fn compose_up_starts_logs_and_stops_the_engine_it_owns() {
+    let project = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let probe = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = probe.local_addr().unwrap().port();
+    drop(probe);
+
+    let config = project.path().join("custom-engine.yaml");
+    std::fs::write(
+        &config,
+        format!(
+            "workers:\n  - name: iii-worker-manager\n    config:\n      host: 127.0.0.1\n      port: {port}\nmodules: []\n"
+        ),
+    )
+    .unwrap();
+    // The project is deliberately invalid after the engine becomes ready. It
+    // makes the command leave through its error cleanup path without needing
+    // a language SDK fixture, and that path must still stop the owned engine.
+    std::fs::write(
+        project.path().join("worker-compose.yaml"),
+        "namespace: managed-test\ncontainers: {}\n",
+    )
+    .unwrap();
+
+    let output = iii_bin()
+        .current_dir(project.path())
+        .env("III_COMPOSE_STATE_DIR", state.path())
+        .args([
+            "--config",
+            config.to_str().unwrap(),
+            "compose",
+            "--engine",
+            &format!("ws://127.0.0.1:{port}"),
+            "--namespace",
+            "managed-e2e",
+            "up",
+        ])
+        .output()
+        .expect("run iii compose up");
+
+    assert!(!output.status.success(), "invalid project must fail");
+    let terminal = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        terminal.contains("engine started"),
+        "unexpected output:\n{terminal}"
+    );
+    assert!(
+        terminal.contains(config.to_str().unwrap()),
+        "config not announced:\n{terminal}"
+    );
+
+    let engine_log = state.path().join("managed-e2e/engine.log");
+    assert!(
+        engine_log.exists(),
+        "no engine log at {}",
+        engine_log.display()
+    );
+    #[cfg(unix)]
+    assert!(
+        terminal.contains(&format!("tail -f '{}'", engine_log.display())),
+        "copyable log command missing:\n{terminal}"
+    );
+    #[cfg(windows)]
+    assert!(
+        terminal.contains("Get-Content -LiteralPath") && terminal.contains("-Wait"),
+        "copyable log command missing:\n{terminal}"
+    );
+
+    // The child had to bind this custom port for compose to reach the invalid
+    // project, and cleanup must release it before the foreground CLI returns.
+    TcpListener::bind(("127.0.0.1", port)).expect("managed engine should be stopped");
+}
+
+#[cfg(unix)]
+#[test]
+fn ctrl_c_stops_the_worker_before_the_managed_engine() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let project = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let probe = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = probe.local_addr().unwrap().port();
+    drop(probe);
+
+    let config = project.path().join("config.yaml");
+    std::fs::write(
+        &config,
+        format!(
+            "workers:\n  - name: iii-worker-manager\n    config:\n      host: 127.0.0.1\n      port: {port}\nmodules: []\n"
+        ),
+    )
+    .unwrap();
+
+    let ready = project.path().join("worker.ready");
+    let stopped = project.path().join("worker.stopped");
+    let worker_script = project.path().join("worker.sh");
+    let test_binary = std::env::current_exe().unwrap();
+    std::fs::write(
+        &worker_script,
+        format!(
+            "#!/bin/sh\nREADY_MARKER={}\nSTOPPED_MARKER={}\nTEST_BINARY={}\nexport READY_MARKER\non_stop() {{\n  kill \"$worker\" 2>/dev/null || true\n  wait \"$worker\" 2>/dev/null || true\n  printf stopped > \"$STOPPED_MARKER\"\n  exit 0\n}}\ntrap on_stop TERM INT\n\"$TEST_BINARY\" --ignored --exact managed_worker_fixture --nocapture &\nworker=$!\nwait \"$worker\"\n",
+            shell_quote(&ready),
+            shell_quote(&stopped),
+            shell_quote(&test_binary),
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&worker_script, std::fs::Permissions::from_mode(0o700)).unwrap();
+    std::fs::write(
+        project.path().join("worker-compose.yaml"),
+        "namespace: managed-test\nstartup_timeout: 20s\nstop_timeout: 5s\ncontainers:\n  probe:\n    worker: path://.\n    scripts:\n      run: ./worker.sh\n",
+    )
+    .unwrap();
+
+    let mut child = iii_bin()
+        .current_dir(project.path())
+        .env("III_COMPOSE_STATE_DIR", state.path())
+        .args([
+            "--config",
+            config.to_str().unwrap(),
+            "compose",
+            "--engine",
+            &format!("ws://127.0.0.1:{port}"),
+            "--namespace",
+            "managed-signal-e2e",
+            "up",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run iii compose up");
+
+    if !wait_for_file(&ready, Duration::from_secs(30)) {
+        let _ = nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(child.id() as i32),
+            nix::sys::signal::Signal::SIGTERM,
+        );
+        let _ = child.wait();
+        panic!("worker never became ready");
+    }
+    std::thread::sleep(Duration::from_millis(500));
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(child.id() as i32),
+        nix::sys::signal::Signal::SIGINT,
+    )
+    .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < deadline && child.try_wait().unwrap().is_none() {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    if child.try_wait().unwrap().is_none() {
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("compose did not exit after SIGINT");
+    }
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success(), "compose exited with {output:?}");
+    assert!(stopped.exists(), "worker shutdown trap did not run");
+
+    let terminal = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let workers = terminal
+        .find("stopping every project...")
+        .unwrap_or_else(|| panic!("worker shutdown missing:\n{terminal}"));
+    let engine = terminal
+        .find("stopping engine...")
+        .unwrap_or_else(|| panic!("engine shutdown missing:\n{terminal}"));
+    assert!(workers < engine, "shutdown order was reversed:\n{terminal}");
+    TcpListener::bind(("127.0.0.1", port)).expect("managed engine should be stopped");
+}


### PR DESCRIPTION
## What

- start and supervise a background engine before `iii compose up` starts project workers
- stop project workers before the managed engine on SIGINT or SIGTERM
- add `--no-engine` for externally managed engines
- forward the root `--config` path and preserve the existing automatic minimal config creation
- capture engine output with a copyable follow command and rotate it at 10 MiB with three archives
- add CLI, lifecycle, rotation, cleanup, and Ctrl+C coverage

## Why

`iii compose up` should provide the complete local runtime lifecycle while keeping an explicit escape hatch for users that already run an engine.

## Notes

The compose layer does not duplicate config creation. It starts the same `iii` executable with the selected config path, so the existing engine startup contract creates `config.yaml` when needed.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy -p iii-compose --all-targets -- -D warnings`
- `cargo test -p iii-compose`
- `cargo test -p iii --all-features`
- `./scripts/generate-cli-docs.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `iii compose up` now starts, monitors, and shuts down an engine automatically.
  * Added `--no-engine` to connect to an existing engine without managing its lifecycle.
  * Bare `iii compose` continues using an external engine.
  * Added engine status, configuration, log-path, and follow-command output.
  * Added rotating, sanitized engine logs and clearer startup, exit, readiness, and namespace-conflict errors.
  * Default engine configuration is created when needed.

* **Documentation**
  * Updated Compose usage and CLI references with managed-engine behavior, configuration, logging, lifecycle details, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->