### PR TITLE
feat(compose): add remove worker operation

### DIFF
--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -475,6 +475,52 @@ impl Daemon {
         }))
     }
 
+    /// Removes one declared worker and restarts the whole project.
+    ///
+    /// This is a literal edit, not a graph operation. It does not ask the
+    /// registry what the worker brought with it, remove dependencies, or
+    /// rewrite another container's `depends_on`. The restart re-reads the
+    /// result and reports if the remaining declaration cannot start.
+    pub async fn remove(
+        &self,
+        file: Option<&Path>,
+        worker: Option<&str>,
+        operation_id: String,
+    ) -> Result<Value> {
+        let Some(worker) = worker.map(str::trim).filter(|worker| !worker.is_empty()) else {
+            return Err(ComposeError::InvalidWorkerSpec {
+                spec: String::new(),
+                reason: "no worker was named. Pass worker=<name>".to_string(),
+            });
+        };
+
+        let path = self.resolve_file(file)?;
+        let text = std::fs::read_to_string(path).map_err(|source| ComposeError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let Some(edited) = crate::edit::remove_container(&text, worker)? else {
+            return Err(ComposeError::UnknownContainer {
+                container: worker.to_string(),
+            });
+        };
+
+        // Unlike add and update, removal intentionally does not parse the
+        // edited declaration first. Parsing validates the dependency graph,
+        // which would turn a literal removal into a graph-aware operation.
+        write_atomically(path, &edited)?;
+
+        let (down, up) = self.restart_project(file, None, &operation_id).await?;
+        Ok(serde_json::json!({
+            "status": up.status,
+            "container": worker,
+            "changed": true,
+            "detail": format!("removed {worker}"),
+            "down": serde_json::to_value(&down).unwrap_or(Value::Null),
+            "up": serde_json::to_value(&up).unwrap_or(Value::Null),
+        }))
+    }
+
     /// Stops a project and starts it again, or bounces one container of it.
     ///
     /// Named, the container is the only thing that stops and starts: not what
@@ -674,7 +720,7 @@ pub const DAEMON_WORKER_NAME: &str = "compose";
 /// with no copy of what it said before. The rename is atomic within a
 /// filesystem, so a reader sees the old file or the new one.
 fn write_atomically(path: &Path, text: &str) -> Result<()> {
-    let temp = path.with_extension("compose-add-tmp");
+    let temp = path.with_extension("compose-edit-tmp");
     std::fs::write(&temp, text).map_err(|source| ComposeError::Io {
         path: temp.clone(),
         source,

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -57,6 +57,10 @@ pub struct Daemon {
     /// their own. Two `Project::open` calls on one file both adopt the same
     /// surviving children, and the loser of the insert is still handed out.
     projects: Mutex<BTreeMap<PathBuf, Arc<OnceCell<Arc<Project>>>>>,
+    /// Serialises read-edit-write-restart operations for each compose file.
+    /// Different projects can still change in parallel, while two edits to one
+    /// file cannot overwrite each other after reading the same source text.
+    mutations: Mutex<BTreeMap<PathBuf, Arc<Mutex<()>>>>,
     /// Set by `compose::stop`. The serve loop reads it and leaves through the
     /// same path a SIGTERM takes, so a remote stop and a local one cannot
     /// diverge in what they tear down.
@@ -84,6 +88,7 @@ impl Daemon {
             engine_url,
             engine,
             projects: Mutex::new(BTreeMap::new()),
+            mutations: Mutex::new(BTreeMap::new()),
             stop_requested: std::sync::atomic::AtomicBool::new(false),
         });
 
@@ -224,6 +229,7 @@ impl Daemon {
         // after the things it calls.
         let wanted = self.expand(&asked).await?;
 
+        let _mutation = self.lock_mutation(path).await;
         let text = std::fs::read_to_string(path).map_err(|source| ComposeError::Io {
             path: path.to_path_buf(),
             source,
@@ -396,6 +402,7 @@ impl Daemon {
             });
         };
 
+        let _mutation = self.lock_mutation(path).await;
         let text = std::fs::read_to_string(path).map_err(|source| ComposeError::Io {
             path: path.to_path_buf(),
             source,
@@ -495,6 +502,7 @@ impl Daemon {
         };
 
         let path = self.resolve_file(file)?;
+        let _mutation = self.lock_mutation(path).await;
         let text = std::fs::read_to_string(path).map_err(|source| ComposeError::Io {
             path: path.to_path_buf(),
             source,
@@ -590,6 +598,20 @@ impl Daemon {
     async fn forget(&self, file: &Path) {
         let key = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
         self.projects.lock().await.remove(&key);
+    }
+
+    /// Acquires the mutation lock for one canonical compose-file path.
+    async fn lock_mutation(&self, file: &Path) -> tokio::sync::OwnedMutexGuard<()> {
+        let key = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
+        let lock = {
+            let mut mutations = self.mutations.lock().await;
+            Arc::clone(
+                mutations
+                    .entry(key)
+                    .or_insert_with(|| Arc::new(Mutex::new(()))),
+            )
+        };
+        lock.lock_owned().await
     }
 
     /// Takes a project down.
@@ -720,13 +742,16 @@ pub const DAEMON_WORKER_NAME: &str = "compose";
 /// with no copy of what it said before. The rename is atomic within a
 /// filesystem, so a reader sees the old file or the new one.
 fn write_atomically(path: &Path, text: &str) -> Result<()> {
-    let temp = path.with_extension("compose-edit-tmp");
+    let temp = path.with_extension(format!("compose-edit-{}.tmp", uuid::Uuid::new_v4()));
     std::fs::write(&temp, text).map_err(|source| ComposeError::Io {
         path: temp.clone(),
         source,
     })?;
-    std::fs::rename(&temp, path).map_err(|source| ComposeError::Io {
-        path: path.to_path_buf(),
-        source,
+    std::fs::rename(&temp, path).map_err(|source| {
+        let _ = std::fs::remove_file(&temp);
+        ComposeError::Io {
+            path: path.to_path_buf(),
+            source,
+        }
     })
 }

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -742,6 +742,8 @@ pub const DAEMON_WORKER_NAME: &str = "compose";
 /// with no copy of what it said before. The rename is atomic within a
 /// filesystem, so a reader sees the old file or the new one.
 fn write_atomically(path: &Path, text: &str) -> Result<()> {
+    use std::io::Write;
+
     let permissions = std::fs::metadata(path)
         .map_err(|source| ComposeError::Io {
             path: path.to_path_buf(),
@@ -749,14 +751,21 @@ fn write_atomically(path: &Path, text: &str) -> Result<()> {
         })?
         .permissions();
     let temp = path.with_extension(format!("compose-edit-{}.tmp", uuid::Uuid::new_v4()));
-    if let Err(source) = std::fs::write(&temp, text) {
+    let mut file = open_private_temp(&temp).map_err(|source| ComposeError::Io {
+        path: temp.clone(),
+        source,
+    })?;
+    if let Err(source) = file.set_permissions(permissions) {
+        drop(file);
         let _ = std::fs::remove_file(&temp);
         return Err(ComposeError::Io { path: temp, source });
     }
-    if let Err(source) = std::fs::set_permissions(&temp, permissions) {
+    if let Err(source) = file.write_all(text.as_bytes()) {
+        drop(file);
         let _ = std::fs::remove_file(&temp);
         return Err(ComposeError::Io { path: temp, source });
     }
+    drop(file);
     std::fs::rename(&temp, path).map_err(|source| {
         let _ = std::fs::remove_file(&temp);
         ComposeError::Io {
@@ -764,6 +773,18 @@ fn write_atomically(path: &Path, text: &str) -> Result<()> {
             source,
         }
     })
+}
+
+/// Creates an empty, collision-safe staging file, with mode 0600 on Unix.
+fn open_private_temp(path: &Path) -> std::io::Result<std::fs::File> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
 }
 
 #[cfg(test)]
@@ -785,5 +806,19 @@ mod tests {
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
         assert_eq!(std::fs::read_to_string(path).unwrap(), "after\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_staging_file_is_private_from_creation() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("worker-compose.staging");
+
+        let file = open_private_temp(&path).unwrap();
+
+        let mode = file.metadata().unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
     }
 }

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -742,11 +742,21 @@ pub const DAEMON_WORKER_NAME: &str = "compose";
 /// with no copy of what it said before. The rename is atomic within a
 /// filesystem, so a reader sees the old file or the new one.
 fn write_atomically(path: &Path, text: &str) -> Result<()> {
+    let permissions = std::fs::metadata(path)
+        .map_err(|source| ComposeError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?
+        .permissions();
     let temp = path.with_extension(format!("compose-edit-{}.tmp", uuid::Uuid::new_v4()));
-    std::fs::write(&temp, text).map_err(|source| ComposeError::Io {
-        path: temp.clone(),
-        source,
-    })?;
+    if let Err(source) = std::fs::write(&temp, text) {
+        let _ = std::fs::remove_file(&temp);
+        return Err(ComposeError::Io { path: temp, source });
+    }
+    if let Err(source) = std::fs::set_permissions(&temp, permissions) {
+        let _ = std::fs::remove_file(&temp);
+        return Err(ComposeError::Io { path: temp, source });
+    }
     std::fs::rename(&temp, path).map_err(|source| {
         let _ = std::fs::remove_file(&temp);
         ComposeError::Io {
@@ -754,4 +764,26 @@ fn write_atomically(path: &Path, text: &str) -> Result<()> {
             source,
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_preserves_the_source_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("worker-compose.yaml");
+        std::fs::write(&path, "before\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        write_atomically(&path, "after\n").unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "after\n");
+    }
 }

--- a/crates/iii-compose/src/edit.rs
+++ b/crates/iii-compose/src/edit.rs
@@ -220,19 +220,25 @@ pub fn upsert_container(text: &str, new: &NewContainer) -> Result<Outcome> {
 /// used to refuse the edit. The following project restart reports any problem
 /// in the resulting declaration.
 pub fn remove_container(text: &str, key: &str) -> Result<Option<String>> {
-    let lines: Vec<&str> = text.lines().collect();
+    // Keep terminators in the slices. Rebuilding from `str::lines()` would
+    // silently turn every surviving CRLF into LF.
+    let lines: Vec<&str> = text.split_inclusive('\n').collect();
     let containers = find_containers(&lines)?;
     let indent = entry_indent(&lines, &containers);
     let Some(entry) = find_entry(&lines, &containers, &indent, key) else {
         return Ok(None);
     };
 
-    let mut out: Vec<String> = lines[..entry.start]
-        .iter()
-        .map(|line| line.to_string())
-        .collect();
-    out.extend(lines[entry.end..].iter().map(|line| line.to_string()));
-    Ok(Some(join(&out, text)))
+    let start = lines[..entry.start].iter().map(|line| line.len()).sum();
+    let end = start
+        + lines[entry.clone()]
+            .iter()
+            .map(|line| line.len())
+            .sum::<usize>();
+    let mut out = String::with_capacity(text.len() - (end - start));
+    out.push_str(&text[..start]);
+    out.push_str(&text[end..]);
+    Ok(Some(out))
 }
 
 /// Keeps the file's final newline as it was: adding one to a file without it,
@@ -785,6 +791,17 @@ containers:
     #[test]
     fn removing_an_unknown_entry_changes_nothing() {
         assert_eq!(remove_container(FILE, "missing").unwrap(), None);
+    }
+
+    #[test]
+    fn removing_preserves_crlf_in_the_surviving_bytes() {
+        let text = "containers:\r\n  keep:\r\n    worker: path://./keep\r\n  remove:\r\n    worker: path://./remove\r\n  after:\r\n    worker: path://./after\r\n";
+        let expected = "containers:\r\n  keep:\r\n    worker: path://./keep\r\n  after:\r\n    worker: path://./after\r\n";
+
+        assert_eq!(
+            remove_container(text, "remove").unwrap().as_deref(),
+            Some(expected)
+        );
     }
 
     #[test]

--- a/crates/iii-compose/src/edit.rs
+++ b/crates/iii-compose/src/edit.rs
@@ -4,17 +4,18 @@
 // This software is patent protected. We welcome discussions - reach out at team@iii.dev
 // See LICENSE and PATENTS files for details.
 
-//! Adding a container to a compose file the operator wrote.
+//! Editing containers in a compose file the operator wrote.
 //!
 //! The file is edited as text, not parsed and re-serialised. A round trip
 //! through serde would return valid YAML and lose everything that is not data:
 //! the comments explaining why a container is pinned where it is, the blank
 //! lines grouping it, the quoting style. That file belongs to whoever wrote it,
-//! and `compose::add` is not entitled to reformat it.
+//! and compose edit operations are not entitled to reformat it.
 //!
-//! So the block is spliced in, matched to the indentation already in use, and
-//! the result is parsed before it is written. A file that would not load is not
-//! written at all.
+//! So each block is spliced in or out and matched to the indentation already in
+//! use. Add and update parse the result before it is written. Remove is the
+//! deliberate exception: it must remove only the named entry without making a
+//! decision about the resulting dependency graph.
 
 use crate::error::{ComposeError, Result};
 
@@ -209,6 +210,29 @@ pub fn upsert_container(text: &str, new: &NewContainer) -> Result<Outcome> {
             Ok(Outcome::Added(join(&out, text)))
         }
     }
+}
+
+/// Removes one container entry without reading or changing its dependency graph.
+///
+/// `compose::remove` is deliberately literal: it removes the named entry and
+/// leaves every other entry byte-for-byte as the operator wrote it. In
+/// particular, a `depends_on` that names this container is not rewritten or
+/// used to refuse the edit. The following project restart reports any problem
+/// in the resulting declaration.
+pub fn remove_container(text: &str, key: &str) -> Result<Option<String>> {
+    let lines: Vec<&str> = text.lines().collect();
+    let containers = find_containers(&lines)?;
+    let indent = entry_indent(&lines, &containers);
+    let Some(entry) = find_entry(&lines, &containers, &indent, key) else {
+        return Ok(None);
+    };
+
+    let mut out: Vec<String> = lines[..entry.start]
+        .iter()
+        .map(|line| line.to_string())
+        .collect();
+    out.extend(lines[entry.end..].iter().map(|line| line.to_string()));
+    Ok(Some(join(&out, text)))
 }
 
 /// Keeps the file's final newline as it was: adding one to a file without it,
@@ -714,6 +738,55 @@ containers:
         let out = added(FILE.trim_end());
         assert!(!out.ends_with('\n'), "gained a trailing newline");
     }
+
+    #[test]
+    fn removing_an_entry_keeps_the_rest_of_the_file() {
+        let out = remove_container(FILE, "todo")
+            .unwrap()
+            .expect("todo should be removed");
+
+        assert!(!out.contains("todo:"), "todo survived: {out}");
+        assert!(
+            !out.contains("# the local one"),
+            "its comment survived: {out}"
+        );
+        assert!(
+            !out.contains("run: ./bin/todo-worker"),
+            "its body survived: {out}"
+        );
+        assert!(out.contains("pi:"), "the other worker was removed: {out}");
+        assert!(
+            out.contains("version: \"0.1.12\""),
+            "the other worker changed: {out}"
+        );
+    }
+
+    #[test]
+    fn removing_does_not_check_or_rewrite_the_graph() {
+        let text = r#"containers:
+  database:
+    worker: path://./workers/database
+  api:
+    worker: path://./workers/api
+    depends_on: [database]
+"#;
+
+        let out = remove_container(text, "database")
+            .unwrap()
+            .expect("database should be removed");
+
+        assert!(!out.contains("database:"), "database survived: {out}");
+        assert!(
+            out.contains("depends_on: [database]"),
+            "the dependent was rewritten: {out}"
+        );
+    }
+
+    #[test]
+    fn removing_an_unknown_entry_changes_nothing() {
+        assert_eq!(remove_container(FILE, "missing").unwrap(), None);
+    }
+
     #[test]
     fn a_package_never_replaces_a_local_worker_of_the_same_name() {
         // The hazard is quiet: `path://` carries no version, so comparing

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -50,9 +50,10 @@ pub struct ComposeRequest {
     /// The worker a call is about.
     ///
     /// `compose::add` and `compose::update` read a spec: `name`,
-    /// `name@version`, or a path. `compose::restart` reads a container key,
-    /// where it is the spelling for `container` — an operator naming a worker
-    /// should not have to know which of the two words this call wanted.
+    /// `name@version`, or a path. `compose::remove` and `compose::restart` read
+    /// a container key, where it is the spelling for `container` — an operator
+    /// naming a worker should not have to know which of the two words this call
+    /// wanted.
     pub worker: Option<String>,
 }
 
@@ -69,6 +70,7 @@ pub fn register(daemon: &Arc<Daemon>) {
         ("stop", Operation::Stop),
         ("validate", Operation::Validate),
         ("add", Operation::Add),
+        ("remove", Operation::Remove),
         ("restart", Operation::Restart),
         ("update", Operation::Update),
     ] {
@@ -96,6 +98,7 @@ enum Operation {
     Stop,
     Validate,
     Add,
+    Remove,
     Restart,
     Update,
 }
@@ -139,6 +142,13 @@ async fn dispatch(
         },
         Operation::Add => match daemon
             .add(file.as_deref(), request.worker.as_deref(), operation_id())
+            .await
+        {
+            Ok(result) => Ok(result),
+            Err(err) => Err(compose_error(&err)),
+        },
+        Operation::Remove => match daemon
+            .remove(file.as_deref(), request.worker.as_deref(), operation_id())
             .await
         {
             Ok(result) => Ok(result),

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -144,14 +144,14 @@ WantedBy=multi-user.target
 
 ## The `compose::*` functions
 
-All eight functions accept the same payload.
+All functions accept the same payload.
 
 | Field       | Type   | Description                                                                       |
 | ----------- | ------ | --------------------------------------------------------------------------------- |
 | `file`      | string | Which project: the path to its compose file.                                      |
 | `container` | string | Restricts the operation to one container and the containers it depends on.        |
 | `namespace` | string | Which daemon the caller believed they were reaching. A guard, see below.          |
-| `worker`    | string | `compose::add` only: the worker to declare. Ignored by the rest.                  |
+| `worker`    | string | The worker used by `add`, `remove`, `restart`, and `update`.                      |
 
 A project is its compose file, and nothing else names one. The same file reached twice is the same
 project however it was spelled, so there is no second identity to keep in sync and no way to point
@@ -172,6 +172,7 @@ one at the wrong file.
 | `compose::list`     | nothing   | The daemon name, its namespace, its pid, and every project it holds.           |
 | `compose::validate` | `file`    | A validation report.                                                           |
 | `compose::add`      | `file`, `worker` | What the edit did, and the `down` and `up` that followed.               |
+| `compose::remove`   | `file`, `worker` | The worker removed, and the `down` and `up` that followed.              |
 | `compose::restart`  | `file`, `worker` | The `down` and the `up`, or one container's restart.                    |
 | `compose::update`   | `file`, `worker` | Both versions, and the restart that followed.                           |
 | `compose::stop`     | nothing   | The daemon name, its pid, and the projects it is about to stop.                |
@@ -218,6 +219,7 @@ iii trigger compose::status --namespace dev file=./worker-compose.yaml
 iii trigger compose::down   --namespace dev file=./worker-compose.yaml
 iii trigger compose::list   --namespace dev
 iii trigger compose::add    --namespace dev file=./worker-compose.yaml worker=state
+iii trigger compose::remove --namespace dev file=./worker-compose.yaml worker=state
 iii trigger compose::restart --namespace dev file=./worker-compose.yaml
 iii trigger compose::stop   --namespace dev
 ```
@@ -236,6 +238,15 @@ did not change.
 `compose::validate` answers for a file and holds nothing: a CI job that only ever validates leaves
 the daemon owning nothing. Validation is offline, so `package://` containers are reported under
 `deferred_packages` instead of being resolved.
+
+### Removing a worker
+
+`compose::remove worker=state` removes only the named container from the compose file and restarts
+the whole project. It does not resolve or rewrite the dependency graph. It does not remove workers
+that were added with this worker, and it leaves other containers' `depends_on` fields unchanged.
+
+If the remaining file has an invalid dependency, the removal stays in the file and the restart
+reports that validation error. Edit or remove the stale dependency before the next `up`.
 
 ### Restarting one worker
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -138,14 +138,14 @@ WantedBy=multi-user.target
 
 ## The `compose::*` functions
 
-All eight functions accept the same payload.
+All functions accept the same payload.
 
 | Field       | Type   | Description                                                                       |
 | ----------- | ------ | --------------------------------------------------------------------------------- |
 | `file`      | string | Which project: the path to its compose file.                                      |
 | `container` | string | Restricts the operation to one container and the containers it depends on.        |
 | `namespace` | string | Which daemon the caller believed they were reaching. A guard, see below.          |
-| `worker`    | string | `compose::add` only: the worker to declare. Ignored by the rest.                  |
+| `worker`    | string | The worker used by `add`, `remove`, `restart`, and `update`.                      |
 
 A project is its compose file, and nothing else names one. The same file reached twice is the same
 project however it was spelled, so there is no second identity to keep in sync and no way to point
@@ -166,6 +166,7 @@ one at the wrong file.
 | `compose::list`     | nothing   | The daemon name, its namespace, its pid, and every project it holds.           |
 | `compose::validate` | `file`    | A validation report.                                                           |
 | `compose::add`      | `file`, `worker` | What the edit did, and the `down` and `up` that followed.               |
+| `compose::remove`   | `file`, `worker` | The worker removed, and the `down` and `up` that followed.              |
 | `compose::restart`  | `file`, `worker` | The `down` and the `up`, or one container's restart.                    |
 | `compose::update`   | `file`, `worker` | Both versions, and the restart that followed.                           |
 | `compose::stop`     | nothing   | The daemon name, its pid, and the projects it is about to stop.                |
@@ -212,6 +213,7 @@ iii trigger compose::status --namespace dev file=./worker-compose.yaml
 iii trigger compose::down   --namespace dev file=./worker-compose.yaml
 iii trigger compose::list   --namespace dev
 iii trigger compose::add    --namespace dev file=./worker-compose.yaml worker=state
+iii trigger compose::remove --namespace dev file=./worker-compose.yaml worker=state
 iii trigger compose::restart --namespace dev file=./worker-compose.yaml
 iii trigger compose::stop   --namespace dev
 ```
@@ -230,6 +232,15 @@ did not change.
 `compose::validate` answers for a file and holds nothing: a CI job that only ever validates leaves
 the daemon owning nothing. Validation is offline, so `package://` containers are reported under
 `deferred_packages` instead of being resolved.
+
+### Removing a worker
+
+`compose::remove worker=state` removes only the named container from the compose file and restarts
+the whole project. It does not resolve or rewrite the dependency graph. It does not remove workers
+that were added with this worker, and it leaves other containers' `depends_on` fields unchanged.
+
+If the remaining file has an invalid dependency, the removal stays in the file and the restart
+reports that validation error. Edit or remove the stale dependency before the next `up`.
 
 ### Restarting one worker
 

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -149,6 +149,24 @@ async fn start_daemon_named(port: u16, daemon_namespace: &str) -> Arc<Daemon> {
     daemon
 }
 
+/// Registers the readiness identity for a test child process.
+fn register_test_worker(port: u16, namespace: &str, name: &str) -> iii_sdk::IIIClient {
+    let mut metadata = iii_sdk::iii::WorkerMetadata {
+        name: name.to_string(),
+        ..Default::default()
+    };
+    metadata.namespace = Some(namespace.to_string());
+
+    register_worker(
+        &format!("ws://127.0.0.1:{port}"),
+        InitOptions {
+            metadata: Some(metadata),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+    )
+}
+
 const TWO_WORKERS: &str = r#"
 namespace: orders
 startup_timeout: 2s
@@ -327,7 +345,7 @@ async fn remove_edits_only_the_named_worker_and_restarts_the_project() {
         tmp.path(),
         r#"
 namespace: removal
-startup_timeout: 100ms
+startup_timeout: 3s
 stop_timeout: 100ms
 containers:
   keep:
@@ -342,21 +360,51 @@ containers:
         &["keep", "discard"],
     );
 
-    let result = call(
+    // The path workers are ordinary long-running child processes. Register
+    // their readiness identities after compose has taken its baseline, so the
+    // project becomes active before removal begins.
+    let up = call(
+        port,
+        "compose::up",
+        json!({ "file": file.to_str().unwrap() }),
+    );
+    let ready = async {
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        (
+            register_test_worker(port, "removal", "keep"),
+            register_test_worker(port, "removal", "discard"),
+        )
+    };
+    let (up, (keep, discard)) = tokio::join!(up, ready);
+    let up = up.expect("compose::up should answer");
+    assert_eq!(up["status"], "ok", "project did not start: {up}");
+
+    // Let the engine release the readiness identities. The child processes
+    // remain active and are the processes remove must stop during its down.
+    keep.shutdown_async().await;
+    discard.shutdown_async().await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let remove = call(
         port,
         "compose::remove",
         json!({
             "file": file.to_str().unwrap(),
             "worker": "discard",
         }),
-    )
-    .await
-    .expect("compose::remove should answer");
+    );
+    let ready = async {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        register_test_worker(port, "removal", "keep")
+    };
+    let (result, keep) = tokio::join!(remove, ready);
+    let result = result.expect("compose::remove should answer");
 
+    assert_eq!(result["status"], "ok", "{result}");
     assert_eq!(result["container"], "discard", "{result}");
     assert_eq!(result["changed"], true, "{result}");
-    assert!(result["down"].is_object(), "down was not run: {result}");
-    assert!(result["up"].is_object(), "up was not run: {result}");
+    assert_eq!(result["down"]["status"], "ok", "{result}");
+    assert_eq!(result["up"]["status"], "ok", "{result}");
 
     let edited = std::fs::read_to_string(&file).expect("read edited compose file");
     assert!(
@@ -368,6 +416,7 @@ containers:
         "named worker survived: {edited}"
     );
 
+    keep.shutdown_async().await;
     daemon.shutdown().await;
 }
 

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -317,6 +317,61 @@ async fn validating_a_file_does_not_take_the_project_on() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn remove_edits_only_the_named_worker_and_restarts_the_project() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: removal
+startup_timeout: 100ms
+stop_timeout: 100ms
+containers:
+  keep:
+    worker: path://./workers/keep
+    scripts:
+      run: "sleep 30"
+  discard:
+    worker: path://./workers/discard
+    scripts:
+      run: "sleep 30"
+"#,
+        &["keep", "discard"],
+    );
+
+    let result = call(
+        port,
+        "compose::remove",
+        json!({
+            "file": file.to_str().unwrap(),
+            "worker": "discard",
+        }),
+    )
+    .await
+    .expect("compose::remove should answer");
+
+    assert_eq!(result["container"], "discard", "{result}");
+    assert_eq!(result["changed"], true, "{result}");
+    assert!(result["down"].is_object(), "down was not run: {result}");
+    assert!(result["up"].is_object(), "up was not run: {result}");
+
+    let edited = std::fs::read_to_string(&file).expect("read edited compose file");
+    assert!(
+        edited.contains("  keep:"),
+        "kept worker was removed: {edited}"
+    );
+    assert!(
+        !edited.contains("  discard:"),
+        "named worker survived: {edited}"
+    );
+
+    daemon.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn one_file_is_one_project_however_it_is_spelled() {
     isolate_state();
     let port = spawn_engine().await;

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -167,6 +167,34 @@ fn register_test_worker(port: u16, namespace: &str, name: &str) -> iii_sdk::IIIC
     )
 }
 
+/// Waits until every child has crossed an explicit process-start barrier.
+async fn wait_for_start_markers(paths: &[&std::path::Path]) {
+    tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            if paths.iter().all(|path| path.exists()) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("children did not reach their start barriers");
+}
+
+/// Waits for the engine to observe a worker registration or its removal.
+async fn wait_for_worker_state(daemon: &Daemon, namespace: &str, name: &str, registered: bool) {
+    tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            if daemon.engine().is_registered(namespace, name).await.ok() == Some(registered) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("worker {namespace}/{name} did not reach registered={registered}"));
+}
+
 const TWO_WORKERS: &str = r#"
 namespace: orders
 startup_timeout: 2s
@@ -341,6 +369,8 @@ async fn remove_edits_only_the_named_worker_and_restarts_the_project() {
     let daemon = start_daemon(port).await;
 
     let tmp = tempfile::tempdir().unwrap();
+    let keep_started = tmp.path().join("workers/keep/started");
+    let discard_started = tmp.path().join("workers/discard/started");
     let file = project(
         tmp.path(),
         r#"
@@ -351,29 +381,30 @@ containers:
   keep:
     worker: path://./workers/keep
     scripts:
-      run: "sleep 30"
+      run: "touch started && sleep 30"
   discard:
     worker: path://./workers/discard
     scripts:
-      run: "sleep 30"
+      run: "touch started && sleep 30"
 "#,
         &["keep", "discard"],
     );
 
-    // The path workers are ordinary long-running child processes. Register
-    // their readiness identities after compose has taken its baseline, so the
-    // project becomes active before removal begins.
+    // Each child creates its marker only after compose has captured the
+    // readiness baseline and spawned it. Registration therefore cannot race
+    // with baseline capture.
     let up = call(
         port,
         "compose::up",
         json!({ "file": file.to_str().unwrap() }),
     );
     let ready = async {
-        tokio::time::sleep(Duration::from_millis(300)).await;
-        (
-            register_test_worker(port, "removal", "keep"),
-            register_test_worker(port, "removal", "discard"),
-        )
+        wait_for_start_markers(&[keep_started.as_path(), discard_started.as_path()]).await;
+        let keep = register_test_worker(port, "removal", "keep");
+        let discard = register_test_worker(port, "removal", "discard");
+        wait_for_worker_state(&daemon, "removal", "keep", true).await;
+        wait_for_worker_state(&daemon, "removal", "discard", true).await;
+        (keep, discard)
     };
     let (up, (keep, discard)) = tokio::join!(up, ready);
     let up = up.expect("compose::up should answer");
@@ -383,7 +414,11 @@ containers:
     // remain active and are the processes remove must stop during its down.
     keep.shutdown_async().await;
     discard.shutdown_async().await;
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    wait_for_worker_state(&daemon, "removal", "keep", false).await;
+    wait_for_worker_state(&daemon, "removal", "discard", false).await;
+
+    // The next marker can only come from the process started by remove's up.
+    std::fs::remove_file(&keep_started).expect("remove first keep start marker");
 
     let remove = call(
         port,
@@ -394,8 +429,10 @@ containers:
         }),
     );
     let ready = async {
-        tokio::time::sleep(Duration::from_millis(500)).await;
-        register_test_worker(port, "removal", "keep")
+        wait_for_start_markers(&[keep_started.as_path()]).await;
+        let keep = register_test_worker(port, "removal", "keep");
+        wait_for_worker_state(&daemon, "removal", "keep", true).await;
+        keep
     };
     let (result, keep) = tokio::join!(remove, ready);
     let result = result.expect("compose::remove should answer");

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -195,6 +195,21 @@ async fn wait_for_worker_state(daemon: &Daemon, namespace: &str, name: &str, reg
     .unwrap_or_else(|_| panic!("worker {namespace}/{name} did not reach registered={registered}"));
 }
 
+fn operation_containers(operation: &Value) -> Vec<&str> {
+    let mut names = operation["containers"]
+        .as_array()
+        .expect("operation should report containers")
+        .iter()
+        .map(|container| {
+            container["container"]
+                .as_str()
+                .expect("container result should have a name")
+        })
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+    names
+}
+
 const TWO_WORKERS: &str = r#"
 namespace: orders
 startup_timeout: 2s
@@ -369,6 +384,7 @@ async fn remove_edits_only_the_named_worker_and_restarts_the_project() {
     let daemon = start_daemon(port).await;
 
     let tmp = tempfile::tempdir().unwrap();
+    let foundation_started = tmp.path().join("workers/foundation/started");
     let keep_started = tmp.path().join("workers/keep/started");
     let discard_started = tmp.path().join("workers/discard/started");
     let file = project(
@@ -378,8 +394,13 @@ namespace: removal
 startup_timeout: 3s
 stop_timeout: 100ms
 containers:
+  foundation:
+    worker: path://./workers/foundation
+    scripts:
+      run: "touch started && sleep 30"
   keep:
     worker: path://./workers/keep
+    depends_on: [foundation]
     scripts:
       run: "touch started && sleep 30"
   discard:
@@ -387,7 +408,7 @@ containers:
     scripts:
       run: "touch started && sleep 30"
 "#,
-        &["keep", "discard"],
+        &["foundation", "keep", "discard"],
     );
 
     // Each child creates its marker only after compose has captured the
@@ -399,25 +420,36 @@ containers:
         json!({ "file": file.to_str().unwrap() }),
     );
     let ready = async {
-        wait_for_start_markers(&[keep_started.as_path(), discard_started.as_path()]).await;
-        let keep = register_test_worker(port, "removal", "keep");
+        wait_for_start_markers(&[foundation_started.as_path(), discard_started.as_path()]).await;
+        let foundation = register_test_worker(port, "removal", "foundation");
         let discard = register_test_worker(port, "removal", "discard");
-        wait_for_worker_state(&daemon, "removal", "keep", true).await;
+        wait_for_worker_state(&daemon, "removal", "foundation", true).await;
         wait_for_worker_state(&daemon, "removal", "discard", true).await;
-        (keep, discard)
+        wait_for_start_markers(&[keep_started.as_path()]).await;
+        let keep = register_test_worker(port, "removal", "keep");
+        wait_for_worker_state(&daemon, "removal", "keep", true).await;
+        (foundation, keep, discard)
     };
-    let (up, (keep, discard)) = tokio::join!(up, ready);
+    let (up, (foundation, keep, discard)) = tokio::join!(up, ready);
     let up = up.expect("compose::up should answer");
     assert_eq!(up["status"], "ok", "project did not start: {up}");
+    assert_eq!(
+        operation_containers(&up),
+        vec!["discard", "foundation", "keep"],
+        "initial up used the wrong worker set: {up}"
+    );
 
     // Let the engine release the readiness identities. The child processes
     // remain active and are the processes remove must stop during its down.
+    foundation.shutdown_async().await;
     keep.shutdown_async().await;
     discard.shutdown_async().await;
+    wait_for_worker_state(&daemon, "removal", "foundation", false).await;
     wait_for_worker_state(&daemon, "removal", "keep", false).await;
     wait_for_worker_state(&daemon, "removal", "discard", false).await;
 
-    // The next marker can only come from the process started by remove's up.
+    // The next markers can only come from processes started by remove's up.
+    std::fs::remove_file(&foundation_started).expect("remove first foundation start marker");
     std::fs::remove_file(&keep_started).expect("remove first keep start marker");
 
     let remove = call(
@@ -429,12 +461,15 @@ containers:
         }),
     );
     let ready = async {
+        wait_for_start_markers(&[foundation_started.as_path()]).await;
+        let foundation = register_test_worker(port, "removal", "foundation");
+        wait_for_worker_state(&daemon, "removal", "foundation", true).await;
         wait_for_start_markers(&[keep_started.as_path()]).await;
         let keep = register_test_worker(port, "removal", "keep");
         wait_for_worker_state(&daemon, "removal", "keep", true).await;
-        keep
+        (foundation, keep)
     };
-    let (result, keep) = tokio::join!(remove, ready);
+    let (result, (foundation, keep)) = tokio::join!(remove, ready);
     let result = result.expect("compose::remove should answer");
 
     assert_eq!(result["status"], "ok", "{result}");
@@ -442,6 +477,11 @@ containers:
     assert_eq!(result["changed"], true, "{result}");
     assert_eq!(result["down"]["status"], "ok", "{result}");
     assert_eq!(result["up"]["status"], "ok", "{result}");
+    assert_eq!(
+        operation_containers(&result["up"]),
+        vec!["foundation", "keep"],
+        "restart used the wrong worker set: {result}"
+    );
 
     let edited = std::fs::read_to_string(&file).expect("read edited compose file");
     assert!(
@@ -449,10 +489,15 @@ containers:
         "kept worker was removed: {edited}"
     );
     assert!(
+        edited.contains("    depends_on: [foundation]"),
+        "retained dependency changed: {edited}"
+    );
+    assert!(
         !edited.contains("  discard:"),
         "named worker survived: {edited}"
     );
 
+    foundation.shutdown_async().await;
     keep.shutdown_async().await;
     daemon.shutdown().await;
 }


### PR DESCRIPTION
## Summary

- register the compose::remove remote operation
- remove only the named worker entry without resolving or rewriting the dependency graph
- restart the compose project after the file edit
- document the operation and add unit and WebSocket integration coverage

## Validation

- cargo test -p iii-compose
- cargo clippy -p iii-compose --all-targets -- -D warnings
- cargo test -p iii --test compose_daemon_e2e
- cargo fmt --all -- --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `compose::remove` to remove a specific worker from a Compose project.
  - Removal preserves other workers and dependency declarations, then restarts the project.
  - Clear errors are returned when the worker or file is missing.
  - Concurrent changes to the same project are safely serialized.
  - Temporary project updates are protected from partial or unauthorized access.

- **Documentation**
  - Added usage guidance and examples for the remove operation, including dependency behavior.

- **Tests**
  - Added coverage confirming successful removal, preserved content, dependency handling, and unaffected workers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->