### PR TITLE
feat(compose): add schema introspection

### DIFF
--- a/crates/iii-compose/src/config.rs
+++ b/crates/iii-compose/src/config.rs
@@ -21,6 +21,7 @@ use std::{
 };
 
 use indexmap::IndexMap;
+use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::{
@@ -467,7 +468,7 @@ pub fn parse_duration(value: &str) -> Option<Duration> {
     amount.checked_mul(factor_ms).map(Duration::from_millis)
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct RawComposeFile {
     /// Optional: a project that names itself nowhere lands in `default`, the
@@ -484,6 +485,7 @@ struct RawComposeFile {
     #[serde(default)]
     stop_timeout: Option<String>,
     #[serde(deserialize_with = "deserialize_unique_map")]
+    #[schemars(with = "BTreeMap<String, RawContainer>")]
     containers: IndexMap<String, RawContainer>,
 }
 
@@ -526,7 +528,7 @@ where
     deserializer.deserialize_map(UniqueMap(std::marker::PhantomData))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct RawContainer {
     worker: String,
@@ -537,12 +539,14 @@ struct RawContainer {
     #[serde(default)]
     config_name: Option<String>,
     #[serde(default)]
+    #[schemars(with = "Option<serde_json::Value>")]
     config_override: Option<serde_yaml::Value>,
     #[serde(default)]
     scripts: Option<RawScripts>,
     #[serde(default)]
     working_dir: Option<PathBuf>,
     #[serde(default, deserialize_with = "deserialize_unique_map")]
+    #[schemars(with = "BTreeMap<String, String>")]
     environment: IndexMap<String, String>,
     #[serde(default)]
     env_file: Vec<PathBuf>,
@@ -550,7 +554,7 @@ struct RawContainer {
     startup_timeout: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct RawScripts {
     #[serde(default)]
@@ -561,6 +565,24 @@ struct RawScripts {
     run: Option<String>,
     #[serde(default)]
     post_run: Option<String>,
+}
+
+/// JSON Schema for the operator-authored `worker-compose.yaml` document.
+///
+/// The deserialization types are the source of truth, so a field added to the
+/// parser also appears in `compose::schema` without a second hand-written
+/// contract to update.
+pub(crate) fn worker_compose_schema_json() -> serde_json::Value {
+    serde_json::to_value(schemars::schema_for!(RawComposeFile)).unwrap_or(serde_json::Value::Null)
+}
+
+/// A complete small project returned beside the file schema. The registry
+/// package is deferred by offline validation, so the example does not require
+/// a local worker directory to be useful.
+pub(crate) fn worker_compose_example_json() -> serde_json::Value {
+    serde_json::json!({
+        "worker-compose.yaml": "namespace: app\ncontainers:\n  state:\n    worker: package://api.workers.iii.dev/state\n    version: 0.21.4\n"
+    })
 }
 
 #[cfg(test)]
@@ -586,5 +608,21 @@ mod tests {
             }
             other => panic!("expected a path source, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn worker_compose_schema_and_example_follow_the_parser() {
+        let schema = worker_compose_schema_json();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["required"].as_array().is_some_and(|fields| {
+            fields
+                .iter()
+                .any(|field| field.as_str() == Some("containers"))
+        }));
+
+        let example = worker_compose_example_json();
+        let text = example["worker-compose.yaml"].as_str().unwrap();
+        let parsed = ComposeFile::parse(text, "/tmp/worker-compose.yaml").unwrap();
+        assert!(parsed.containers.contains_key("state"));
     }
 }

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -42,7 +42,7 @@ use crate::{
 
 /// Outcome of one `up` or `down`. The shape is the JSON that `compose::*`
 /// returns, so it is a contract: fields are added, never repurposed.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, schemars::JsonSchema, PartialEq, Eq)]
 pub struct OpResult {
     pub operation_id: String,
     pub status: OpStatus,
@@ -52,14 +52,14 @@ pub struct OpResult {
     pub containers: Vec<ContainerResult>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum OpStatus {
     Ok,
     Failed,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, schemars::JsonSchema, PartialEq, Eq)]
 pub struct ContainerResult {
     pub container: String,
     pub state: ChildStatus,
@@ -68,7 +68,7 @@ pub struct ContainerResult {
     pub error: Option<OpError>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, schemars::JsonSchema, PartialEq, Eq)]
 pub struct OpError {
     pub code: String,
     pub message: String,

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -519,7 +519,7 @@ impl Project {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema, PartialEq, Eq)]
 pub struct ContainerStatus {
     pub container: String,
     pub state: ChildStatus,

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -21,13 +21,19 @@
 //! fall back to `worker-compose.yaml` in the daemon's own directory, and say
 //! so when there is none.
 
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use iii_sdk::{Error, RegisterFunction};
-use serde::Deserialize;
+use schemars::{JsonSchema, schema_for};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use crate::{daemon::Daemon, error::ComposeError};
+use crate::{
+    daemon::Daemon,
+    error::ComposeError,
+    lifecycle::{OpResult, OpStatus},
+    project::ContainerStatus,
+};
 
 /// Payload accepted by every `compose::*` function. All fields optional: the
 /// bare call is the common one.
@@ -55,6 +61,189 @@ pub struct ComposeRequest {
     /// naming a worker should not have to know which of the two words this call
     /// wanted.
     pub worker: Option<String>,
+    /// Function or file contract requested by `compose::schema`.
+    pub function_id: Option<String>,
+}
+
+/// Request fields used by daemon-wide operations.
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+struct DaemonOptions {
+    /// Which daemon the caller believed it reached. This is a guard, not a
+    /// route; use the trigger `--namespace` flag to select the daemon.
+    namespace: Option<String>,
+}
+
+/// Request fields used by project lifecycle operations.
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+struct LifecycleOptions {
+    /// Optional daemon guard. Use the trigger `--namespace` flag to route.
+    namespace: Option<String>,
+    /// Compose file on the daemon host. Defaults to `worker-compose.yaml` in
+    /// the daemon working directory.
+    file: Option<String>,
+    /// Restrict the lifecycle operation to one container.
+    container: Option<String>,
+}
+
+/// Request fields used by project read operations.
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+struct ProjectOptions {
+    /// Optional daemon guard. Use the trigger `--namespace` flag to route.
+    namespace: Option<String>,
+    /// Compose file on the daemon host. Defaults to `worker-compose.yaml` in
+    /// the daemon working directory.
+    file: Option<String>,
+}
+
+/// Request fields used by compose-file worker edits.
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+struct WorkerOptions {
+    /// Optional daemon guard. Use the trigger `--namespace` flag to route.
+    namespace: Option<String>,
+    /// Compose file on the daemon host. Defaults to `worker-compose.yaml` in
+    /// the daemon working directory.
+    file: Option<String>,
+    /// Worker name, `name@version`, registry reference, or local path. The
+    /// accepted form depends on the operation.
+    worker: String,
+}
+
+/// `compose::restart` accepts either spelling for one container.
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+struct RestartOptions {
+    /// Optional daemon guard. Use the trigger `--namespace` flag to route.
+    namespace: Option<String>,
+    /// Compose file on the daemon host. Defaults to `worker-compose.yaml` in
+    /// the daemon working directory.
+    file: Option<String>,
+    /// Container key to restart.
+    container: Option<String>,
+    /// Alias for `container`.
+    worker: Option<String>,
+}
+
+/// `compose::schema` request. Omit `function_id` to return every contract.
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+struct SchemaRequest {
+    /// Optional daemon guard. Use the trigger `--namespace` flag to route.
+    namespace: Option<String>,
+    /// Function id such as `compose::up`, or the `worker-compose.yaml`
+    /// pseudo-id. Omit to return every schema.
+    function_id: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, JsonSchema)]
+struct ProjectSummary {
+    namespace: String,
+    file: PathBuf,
+    containers: Vec<ContainerStatus>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, JsonSchema)]
+struct ListOutcome {
+    daemon: String,
+    daemon_namespace: String,
+    daemon_pid: u32,
+    projects: Vec<ProjectSummary>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, JsonSchema)]
+struct StatusOutcome {
+    namespace: String,
+    file: PathBuf,
+    state_dir: PathBuf,
+    daemon_pid: u32,
+    containers: Vec<ContainerStatus>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, JsonSchema)]
+struct ValidateOutcome {
+    namespace: String,
+    start_order: Vec<String>,
+    deferred_packages: Vec<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, JsonSchema)]
+struct StopOutcome {
+    daemon: String,
+    daemon_pid: u32,
+    stopping: Vec<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, JsonSchema)]
+struct AddOutcome {
+    status: OpStatus,
+    container: String,
+    changed: bool,
+    detail: String,
+    declared: Option<Vec<String>>,
+    down: Option<OpResult>,
+    up: Option<OpResult>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, JsonSchema)]
+struct RemoveOutcome {
+    status: OpStatus,
+    container: String,
+    changed: bool,
+    detail: String,
+    down: OpResult,
+    up: OpResult,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, JsonSchema)]
+struct UpdateOutcome {
+    status: OpStatus,
+    container: String,
+    changed: bool,
+    detail: String,
+    version: Option<String>,
+    from: Option<String>,
+    to: Option<String>,
+    down: Option<OpResult>,
+    up: Option<OpResult>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, JsonSchema)]
+struct RestartOutcome {
+    status: OpStatus,
+    container: Option<String>,
+    changed: bool,
+    restarted: Option<OpResult>,
+    down: Option<OpResult>,
+    up: Option<OpResult>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+struct SchemaEntry {
+    function_id: String,
+    description: String,
+    request: Value,
+    response: Value,
+    /// Recommended client timeout for the operation.
+    default_timeout_ms: u64,
+    /// Whether retrying the same payload is safe.
+    idempotent: bool,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+struct SchemaResponse {
+    schemas: Vec<SchemaEntry>,
 }
 
 /// Registers the control surface. Every id is verbatim — compose never renames
@@ -73,19 +262,18 @@ pub fn register(daemon: &Arc<Daemon>) {
         ("remove", Operation::Remove),
         ("restart", Operation::Restart),
         ("update", Operation::Update),
+        ("schema", Operation::Schema),
     ] {
         let daemon = Arc::clone(daemon);
         let function = format!("compose::{name}");
         let guard_name = name.to_string();
 
-        client.register_function(
-            function,
-            RegisterFunction::new_async(move |request: ComposeRequest| {
-                let daemon = Arc::clone(&daemon);
-                let guard_name = guard_name.clone();
-                async move { dispatch(daemon, kind, guard_name, request).await }
-            }),
-        );
+        let registration = RegisterFunction::new_async(move |request: ComposeRequest| {
+            let daemon = Arc::clone(&daemon);
+            let guard_name = guard_name.clone();
+            async move { dispatch(daemon, kind, guard_name, request).await }
+        });
+        client.register_function(function.clone(), describe_op(registration, &function));
     }
 }
 
@@ -101,6 +289,7 @@ enum Operation {
     Remove,
     Restart,
     Update,
+    Schema,
 }
 
 async fn dispatch(
@@ -223,7 +412,198 @@ async fn dispatch(
             })),
             Err(err) => Err(compose_error(&err)),
         },
+        Operation::Schema => Ok(to_value(&build_schema_response(
+            request.function_id.as_deref(),
+        ))),
     }
+}
+
+fn schema_for_value<T: JsonSchema>() -> Option<Value> {
+    serde_json::to_value(schema_for!(T)).ok()
+}
+
+/// One source of truth for function registration and `compose::schema`.
+fn op_description(function_id: &str) -> &'static str {
+    match function_id {
+        "compose::up" => {
+            "Start a compose project, or one container and its dependencies. \
+             Repeated calls leave ready containers running."
+        }
+        "compose::down" => {
+            "Stop a compose project, or one container and its dependents, in \
+             reverse dependency order."
+        }
+        "compose::list" => "List every project loaded by this compose daemon.",
+        "compose::status" => {
+            "Report the project namespace, state directory, daemon pid, and \
+             current state of every declared container."
+        }
+        "compose::stop" => {
+            "Ask this compose daemon to stop every project and exit after it \
+             answers the caller."
+        }
+        "compose::validate" => {
+            "Validate a worker-compose.yaml file offline without loading or \
+             starting its project."
+        }
+        "compose::add" => {
+            "Declare a worker and its registry dependencies in the compose \
+             file, pin resolved versions, then restart the project."
+        }
+        "compose::remove" => {
+            "Remove one declared worker from the compose file, then restart \
+             the project."
+        }
+        "compose::restart" => {
+            "Restart the whole project, or restart one named container without \
+             changing its dependency graph."
+        }
+        "compose::update" => {
+            "Move one declared package worker to a requested or latest version, \
+             then restart the project."
+        }
+        "compose::schema" => {
+            "Return request and response JSON Schemas for compose::* functions. \
+             Optional function_id filters one entry. The worker-compose.yaml \
+             pseudo-id returns the compose-file schema and an example."
+        }
+        "worker-compose.yaml" => {
+            "JSON Schema for a worker-compose.yaml file. The response is a \
+             complete small example keyed by its file name."
+        }
+        _ => "",
+    }
+}
+
+/// Recommended timeout and retry safety for each operation.
+fn op_metadata(function_id: &str) -> (u64, bool) {
+    match function_id {
+        "compose::up" => (600_000, true),
+        "compose::down" => (60_000, true),
+        "compose::list" => (10_000, true),
+        "compose::status" => (10_000, true),
+        "compose::stop" => (30_000, false),
+        "compose::validate" => (10_000, true),
+        "compose::add" => (600_000, true),
+        "compose::remove" => (600_000, true),
+        "compose::restart" => (600_000, false),
+        "compose::update" => (600_000, true),
+        "compose::schema" | "worker-compose.yaml" => (10_000, true),
+        _ => (30_000, false),
+    }
+}
+
+/// Every callable compose function plus the compose-file authoring contract.
+type SchemaTriple = (&'static str, Option<Value>, Option<Value>);
+
+fn schema_table() -> &'static [SchemaTriple] {
+    static TABLE: std::sync::LazyLock<Vec<SchemaTriple>> = std::sync::LazyLock::new(|| {
+        vec![
+            (
+                "compose::up",
+                schema_for_value::<LifecycleOptions>(),
+                schema_for_value::<OpResult>(),
+            ),
+            (
+                "compose::down",
+                schema_for_value::<LifecycleOptions>(),
+                schema_for_value::<OpResult>(),
+            ),
+            (
+                "compose::list",
+                schema_for_value::<DaemonOptions>(),
+                schema_for_value::<ListOutcome>(),
+            ),
+            (
+                "compose::status",
+                schema_for_value::<ProjectOptions>(),
+                schema_for_value::<StatusOutcome>(),
+            ),
+            (
+                "compose::stop",
+                schema_for_value::<DaemonOptions>(),
+                schema_for_value::<StopOutcome>(),
+            ),
+            (
+                "compose::validate",
+                schema_for_value::<ProjectOptions>(),
+                schema_for_value::<ValidateOutcome>(),
+            ),
+            (
+                "compose::add",
+                schema_for_value::<WorkerOptions>(),
+                schema_for_value::<AddOutcome>(),
+            ),
+            (
+                "compose::remove",
+                schema_for_value::<WorkerOptions>(),
+                schema_for_value::<RemoveOutcome>(),
+            ),
+            (
+                "compose::restart",
+                schema_for_value::<RestartOptions>(),
+                schema_for_value::<RestartOutcome>(),
+            ),
+            (
+                "compose::update",
+                schema_for_value::<WorkerOptions>(),
+                schema_for_value::<UpdateOutcome>(),
+            ),
+            (
+                "compose::schema",
+                schema_for_value::<SchemaRequest>(),
+                schema_for_value::<SchemaResponse>(),
+            ),
+            (
+                "worker-compose.yaml",
+                Some(crate::config::worker_compose_schema_json()),
+                Some(crate::config::worker_compose_example_json()),
+            ),
+        ]
+    });
+    &TABLE
+}
+
+fn build_schema_response(filter: Option<&str>) -> SchemaResponse {
+    let schemas = schema_table()
+        .iter()
+        .filter(|(id, _, _)| filter.is_none_or(|filter| filter == *id))
+        .map(|(function_id, request, response)| {
+            let (default_timeout_ms, idempotent) = op_metadata(function_id);
+            SchemaEntry {
+                function_id: (*function_id).to_string(),
+                description: op_description(function_id).to_string(),
+                request: request.clone().unwrap_or(Value::Null),
+                response: response.clone().unwrap_or(Value::Null),
+                default_timeout_ms,
+                idempotent,
+            }
+        })
+        .collect();
+    SchemaResponse { schemas }
+}
+
+/// Add descriptions, operation metadata, and the same schemas returned by
+/// `compose::schema` to the engine function registry.
+fn describe_op(registration: RegisterFunction, function_id: &str) -> RegisterFunction {
+    let (default_timeout_ms, idempotent) = op_metadata(function_id);
+    let mut registration = registration
+        .description(op_description(function_id))
+        .metadata(json!({
+            "default_timeout_ms": default_timeout_ms,
+            "idempotent": idempotent,
+        }));
+    if let Some((_, request, response)) =
+        schema_table().iter().find(|(id, _, _)| *id == function_id)
+    {
+        if let Some(request) = request {
+            registration = registration.request_format(request.clone());
+        }
+        if let Some(response) = response {
+            registration = registration.response_format(response.clone());
+        }
+    }
+    registration
 }
 
 /// Compose errors cross the wire as their stable code plus the message, so a
@@ -243,4 +623,94 @@ fn to_value<T: serde::Serialize>(value: &T) -> Value {
 
 fn operation_id() -> String {
     uuid::Uuid::new_v4().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema_entry(id: &str) -> &'static SchemaTriple {
+        schema_table()
+            .iter()
+            .find(|(entry_id, _, _)| *entry_id == id)
+            .unwrap_or_else(|| panic!("schema_table is missing {id}"))
+    }
+
+    #[test]
+    fn schema_table_covers_every_registered_operation() {
+        for operation in [
+            "compose::up",
+            "compose::down",
+            "compose::list",
+            "compose::status",
+            "compose::stop",
+            "compose::validate",
+            "compose::add",
+            "compose::remove",
+            "compose::restart",
+            "compose::update",
+            "compose::schema",
+        ] {
+            let (_, request, response) = schema_entry(operation);
+            assert!(request.is_some(), "{operation} request schema missing");
+            assert!(response.is_some(), "{operation} response schema missing");
+            assert!(!op_description(operation).is_empty());
+        }
+    }
+
+    #[test]
+    fn operation_requests_expose_only_supported_fields() {
+        let (_, up, _) = schema_entry("compose::up");
+        let up = up.as_ref().unwrap()["properties"].as_object().unwrap();
+        assert!(up.contains_key("namespace"));
+        assert!(up.contains_key("file"));
+        assert!(up.contains_key("container"));
+        assert!(!up.contains_key("worker"));
+
+        let (_, add, _) = schema_entry("compose::add");
+        let add = add.as_ref().unwrap()["properties"].as_object().unwrap();
+        assert!(add.contains_key("namespace"));
+        assert!(add.contains_key("file"));
+        assert!(add.contains_key("worker"));
+        assert!(!add.contains_key("container"));
+        assert!(
+            schema_entry("compose::add").1.as_ref().unwrap()["required"]
+                .as_array()
+                .is_some_and(|fields| fields.iter().any(|field| field.as_str() == Some("worker")))
+        );
+
+        let (_, list, _) = schema_entry("compose::list");
+        let list = list.as_ref().unwrap()["properties"].as_object().unwrap();
+        assert_eq!(list.keys().collect::<Vec<_>>(), vec!["namespace"]);
+    }
+
+    #[test]
+    fn schema_response_filters_one_function_or_returns_all() {
+        let filtered = build_schema_response(Some("compose::up"));
+        assert_eq!(filtered.schemas.len(), 1);
+        assert_eq!(filtered.schemas[0].function_id, "compose::up");
+
+        let all = build_schema_response(None);
+        assert_eq!(all.schemas.len(), schema_table().len());
+        assert!(
+            all.schemas
+                .iter()
+                .any(|entry| entry.function_id == "worker-compose.yaml")
+        );
+    }
+
+    #[test]
+    fn compose_file_pseudo_entry_carries_schema_and_example() {
+        let (_, request, response) = schema_entry("worker-compose.yaml");
+        let request = request.as_ref().unwrap();
+        assert_eq!(request["type"], "object");
+        assert!(request["properties"]["containers"].is_object());
+
+        let response = response.as_ref().unwrap();
+        assert!(
+            response["worker-compose.yaml"]
+                .as_str()
+                .is_some_and(|text| text.contains("containers:"))
+        );
+    }
 }

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -251,19 +251,7 @@ struct SchemaResponse {
 pub fn register(daemon: &Arc<Daemon>) {
     let client = daemon.engine().client();
 
-    for (name, kind) in [
-        ("up", Operation::Up),
-        ("down", Operation::Down),
-        ("list", Operation::List),
-        ("status", Operation::Status),
-        ("stop", Operation::Stop),
-        ("validate", Operation::Validate),
-        ("add", Operation::Add),
-        ("remove", Operation::Remove),
-        ("restart", Operation::Restart),
-        ("update", Operation::Update),
-        ("schema", Operation::Schema),
-    ] {
+    for &(name, kind) in REGISTERED_OPERATIONS {
         let daemon = Arc::clone(daemon);
         let function = format!("compose::{name}");
         let guard_name = name.to_string();
@@ -291,6 +279,21 @@ enum Operation {
     Update,
     Schema,
 }
+
+/// Canonical list of functions exposed by the compose daemon.
+const REGISTERED_OPERATIONS: &[(&str, Operation)] = &[
+    ("up", Operation::Up),
+    ("down", Operation::Down),
+    ("list", Operation::List),
+    ("status", Operation::Status),
+    ("stop", Operation::Stop),
+    ("validate", Operation::Validate),
+    ("add", Operation::Add),
+    ("remove", Operation::Remove),
+    ("restart", Operation::Restart),
+    ("update", Operation::Update),
+    ("schema", Operation::Schema),
+];
 
 async fn dispatch(
     daemon: Arc<Daemon>,
@@ -641,23 +644,12 @@ mod tests {
 
     #[test]
     fn schema_table_covers_every_registered_operation() {
-        for operation in [
-            "compose::up",
-            "compose::down",
-            "compose::list",
-            "compose::status",
-            "compose::stop",
-            "compose::validate",
-            "compose::add",
-            "compose::remove",
-            "compose::restart",
-            "compose::update",
-            "compose::schema",
-        ] {
-            let (_, request, response) = schema_entry(operation);
+        for (name, _) in REGISTERED_OPERATIONS {
+            let operation = format!("compose::{name}");
+            let (_, request, response) = schema_entry(&operation);
             assert!(request.is_some(), "{operation} request schema missing");
             assert!(response.is_some(), "{operation} response schema missing");
-            assert!(!op_description(operation).is_empty());
+            assert!(!op_description(&operation).is_empty());
         }
     }
 

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -418,6 +418,7 @@ async fn dispatch(
     }
 }
 
+/// Serialize the generated root schema into the value carried over the wire.
 fn schema_for_value<T: JsonSchema>() -> Option<Value> {
     serde_json::to_value(schema_for!(T)).ok()
 }
@@ -484,10 +485,10 @@ fn op_metadata(function_id: &str) -> (u64, bool) {
         "compose::status" => (10_000, true),
         "compose::stop" => (30_000, false),
         "compose::validate" => (10_000, true),
-        "compose::add" => (600_000, true),
+        "compose::add" => (600_000, false),
         "compose::remove" => (600_000, true),
         "compose::restart" => (600_000, false),
-        "compose::update" => (600_000, true),
+        "compose::update" => (600_000, false),
         "compose::schema" | "worker-compose.yaml" => (10_000, true),
         _ => (30_000, false),
     }
@@ -496,6 +497,7 @@ fn op_metadata(function_id: &str) -> (u64, bool) {
 /// Every callable compose function plus the compose-file authoring contract.
 type SchemaTriple = (&'static str, Option<Value>, Option<Value>);
 
+/// Build every schema once and share it between registration and requests.
 fn schema_table() -> &'static [SchemaTriple] {
     static TABLE: std::sync::LazyLock<Vec<SchemaTriple>> = std::sync::LazyLock::new(|| {
         vec![
@@ -564,6 +566,7 @@ fn schema_table() -> &'static [SchemaTriple] {
     &TABLE
 }
 
+/// Select one schema when requested, or return the complete table.
 fn build_schema_response(filter: Option<&str>) -> SchemaResponse {
     let schemas = schema_table()
         .iter()
@@ -697,6 +700,12 @@ mod tests {
                 .iter()
                 .any(|entry| entry.function_id == "worker-compose.yaml")
         );
+    }
+
+    #[test]
+    fn unpinned_registry_edits_are_not_advertised_as_idempotent() {
+        assert_eq!(op_metadata("compose::add"), (600_000, false));
+        assert_eq!(op_metadata("compose::update"), (600_000, false));
     }
 
     #[test]

--- a/crates/iii-compose/src/state.rs
+++ b/crates/iii-compose/src/state.rs
@@ -57,7 +57,7 @@ pub fn project_slug(compose_path: &Path) -> String {
     format!("{readable}-{}", &digest[..8])
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ChildStatus {
     /// Spawned, not yet visible in the engine.

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -152,6 +152,7 @@ All functions accept the same payload.
 | `container` | string | Restricts the operation to one container and the containers it depends on.        |
 | `namespace` | string | Which daemon the caller believed they were reaching. A guard, see below.          |
 | `worker`    | string | The worker used by `add`, `remove`, `restart`, and `update`.                      |
+| `function_id` | string | The function or file contract requested by `compose::schema`.                  |
 
 A project is its compose file, and nothing else names one. The same file reached twice is the same
 project however it was spelled, so there is no second identity to keep in sync and no way to point
@@ -176,9 +177,21 @@ one at the wrong file.
 | `compose::restart`  | `file`, `worker` | The `down` and the `up`, or one container's restart.                    |
 | `compose::update`   | `file`, `worker` | Both versions, and the restart that followed.                           |
 | `compose::stop`     | nothing   | The daemon name, its pid, and the projects it is about to stop.                |
+| `compose::schema`   | `function_id` | Request/response JSON Schemas, descriptions, timeouts, and retry safety.    |
 
 `file` is not required. Left out, it falls back to a `worker-compose.yaml` in the daemon's own
 working directory. `worker` has no fallback.
+
+`compose::schema` is read-only. With no `function_id`, it returns every `compose::*` contract.
+Pass a function id to return one contract. The pseudo-id `worker-compose.yaml` returns the file's
+JSON Schema as `request` and a complete small example as `response`. The same function schemas,
+descriptions, and metadata are also published through `engine::functions::info`.
+
+```bash
+iii trigger compose::schema --namespace dev
+iii trigger compose::schema --namespace dev function_id=compose::up
+iii trigger compose::schema --namespace dev function_id=worker-compose.yaml
+```
 
 ### Adding a worker
 
@@ -221,6 +234,7 @@ iii trigger compose::list   --namespace dev
 iii trigger compose::add    --namespace dev file=./worker-compose.yaml worker=state
 iii trigger compose::remove --namespace dev file=./worker-compose.yaml worker=state
 iii trigger compose::restart --namespace dev file=./worker-compose.yaml
+iii trigger compose::schema --namespace dev function_id=compose::up
 iii trigger compose::stop   --namespace dev
 ```
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -146,6 +146,7 @@ All functions accept the same payload.
 | `container` | string | Restricts the operation to one container and the containers it depends on.        |
 | `namespace` | string | Which daemon the caller believed they were reaching. A guard, see below.          |
 | `worker`    | string | The worker used by `add`, `remove`, `restart`, and `update`.                      |
+| `function_id` | string | The function or file contract requested by `compose::schema`.                  |
 
 A project is its compose file, and nothing else names one. The same file reached twice is the same
 project however it was spelled, so there is no second identity to keep in sync and no way to point
@@ -170,9 +171,21 @@ one at the wrong file.
 | `compose::restart`  | `file`, `worker` | The `down` and the `up`, or one container's restart.                    |
 | `compose::update`   | `file`, `worker` | Both versions, and the restart that followed.                           |
 | `compose::stop`     | nothing   | The daemon name, its pid, and the projects it is about to stop.                |
+| `compose::schema`   | `function_id` | Request/response JSON Schemas, descriptions, timeouts, and retry safety.    |
 
 `file` is not required. Left out, it falls back to a `worker-compose.yaml` in the daemon's own
 working directory. `worker` has no fallback.
+
+`compose::schema` is read-only. With no `function_id`, it returns every `compose::*` contract.
+Pass a function id to return one contract. The pseudo-id `worker-compose.yaml` returns the file's
+JSON Schema as `request` and a complete small example as `response`. The same function schemas,
+descriptions, and metadata are also published through `engine::functions::info`.
+
+```bash
+iii trigger compose::schema --namespace dev
+iii trigger compose::schema --namespace dev function_id=compose::up
+iii trigger compose::schema --namespace dev function_id=worker-compose.yaml
+```
 
 ### Adding a worker
 
@@ -215,6 +228,7 @@ iii trigger compose::list   --namespace dev
 iii trigger compose::add    --namespace dev file=./worker-compose.yaml worker=state
 iii trigger compose::remove --namespace dev file=./worker-compose.yaml worker=state
 iii trigger compose::restart --namespace dev file=./worker-compose.yaml
+iii trigger compose::schema --namespace dev function_id=compose::up
 iii trigger compose::stop   --namespace dev
 ```
 

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -263,6 +263,41 @@ async fn the_daemon_serves_compose_functions_in_the_default_namespace() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn schema_introspection_is_callable_and_matches_engine_metadata() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let schema = call(
+        port,
+        "compose::schema",
+        json!({ "function_id": "compose::up" }),
+    )
+    .await
+    .expect("compose::schema should answer");
+    let schemas = schema["schemas"].as_array().expect("schemas array");
+    assert_eq!(schemas.len(), 1, "the filter returns one entry: {schema}");
+    assert_eq!(schemas[0]["function_id"], "compose::up");
+    assert!(schemas[0]["request"]["properties"]["file"].is_object());
+    assert!(schemas[0]["response"]["properties"]["containers"].is_object());
+    assert_eq!(schemas[0]["default_timeout_ms"], 600_000);
+    assert_eq!(schemas[0]["idempotent"], true);
+
+    let info = call(
+        port,
+        "engine::functions::info",
+        json!({ "function_id": "compose::up" }),
+    )
+    .await
+    .expect("engine::functions::info should find compose::up");
+    assert_eq!(info["request_schema"], schemas[0]["request"]);
+    assert_eq!(info["response_schema"], schemas[0]["response"]);
+    assert_eq!(info["metadata"]["default_timeout_ms"], 600_000);
+
+    daemon.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn a_project_scoped_call_names_the_argument_it_wanted() {
     isolate_state();
     let port = spawn_engine().await;


### PR DESCRIPTION
## Summary

- add compose::schema with optional function filtering
- publish operation-specific request and response schemas through engine introspection
- expose the worker-compose.yaml schema and a complete example
- document the command and cover it with unit and engine E2E tests

## Test plan

- [x] cargo test -p iii-compose
- [x] cargo test -p iii --test compose_daemon_e2e
- [x] cargo clippy -p iii-compose --all-targets -- -D warnings
- [x] cargo fmt --all -- --check
- [ ] pnpm fmt:check (blocked before file checks by existing nested Biome root configurations in console/packages/console-frontend and sdk)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the read-only `compose::schema` operation for discovering Compose request and response contracts.
  - Retrieve schemas for all Compose operations, a selected operation, or the `worker-compose.yaml` format and example.
  - Published operation descriptions, timeout limits, and retry-safety metadata through Compose schema responses and function information.
  - Added schema coverage for Compose statuses, results, errors, and container states.

- **Documentation**
  - Updated Compose documentation with the new `function_id` field, supported identifiers, outputs, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->