### PR TITLE
feat(compose): add multiple workers in one call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2814,6 +2814,7 @@ dependencies = [
  "hex",
  "iii-sdk",
  "indexmap 2.14.0",
+ "jsonschema",
  "nix 0.31.2",
  "reqwest 0.12.28",
  "schemars 0.8.22",

--- a/crates/iii-compose/Cargo.toml
+++ b/crates/iii-compose/Cargo.toml
@@ -66,3 +66,4 @@ windows-sys = { version = "0.60", features = [
 
 [dev-dependencies]
 tempfile = { workspace = true }
+jsonschema = { version = "0.30", default-features = false }

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -192,7 +192,7 @@ impl Daemon {
         Ok(project.up(container, operation_id).await)
     }
 
-    /// Adds a container to a project's file, then restarts the project.
+    /// Adds containers to a project's file, then restarts the project once.
     ///
     /// The file is the operator's, so it is edited rather than rewritten: see
     /// [`crate::edit`]. A version the caller did not pin is resolved once and
@@ -207,18 +207,22 @@ impl Daemon {
     pub async fn add(
         &self,
         file: Option<&Path>,
-        worker: Option<&str>,
+        workers: &[String],
         operation_id: String,
     ) -> Result<Value> {
-        let Some(worker) = worker else {
+        if workers.is_empty() {
             return Err(ComposeError::InvalidWorkerSpec {
                 spec: String::new(),
-                reason: "no worker was named. Pass worker=<name|name@version|./path>".to_string(),
+                reason: "no worker was named. Pass one or more worker=<name|name@version|./path> arguments"
+                    .to_string(),
             });
-        };
+        }
 
         let path = self.resolve_file(file)?;
-        let asked = crate::edit::parse_worker(worker)?;
+        let asked = workers
+            .iter()
+            .map(|worker| crate::edit::parse_worker(worker))
+            .collect::<Result<Vec<_>>>()?;
         // A worker is not useful alone: its manifest names what it calls, and
         // the registry answers with that whole graph already pinned to versions
         // that satisfy each other. They are declared rather than started
@@ -227,7 +231,10 @@ impl Daemon {
         // Dependencies first and the worker last: with no `depends_on`, start
         // order is declaration order, so this is what makes a worker start
         // after the things it calls.
-        let wanted = self.expand(&asked).await?;
+        let mut wanted = Vec::new();
+        for worker in &asked {
+            wanted.extend(self.expand(worker).await?);
+        }
 
         let _mutation = self.lock_mutation(path).await;
         let text = std::fs::read_to_string(path).map_err(|source| ComposeError::Io {
@@ -251,12 +258,24 @@ impl Daemon {
             }
         }
 
+        let requested = asked
+            .iter()
+            .map(|worker| worker.key.clone())
+            .collect::<Vec<_>>();
+        let container = requested[0].clone();
+
         if added.is_empty() && replaced.is_empty() {
+            let detail = if requested.len() == 1 {
+                "already declared at this version"
+            } else {
+                "all workers are already declared at these versions"
+            };
             return Ok(serde_json::json!({
                 "status": "ok",
-                "container": asked.key,
+                "container": container,
+                "workers": requested,
                 "changed": false,
-                "detail": "already declared at this version",
+                "detail": detail,
             }));
         }
         let action = match (added.is_empty(), replaced.is_empty()) {
@@ -278,7 +297,8 @@ impl Daemon {
         let (down, up) = self.restart_project(file, None, &operation_id).await?;
         Ok(serde_json::json!({
             "status": up.status,
-            "container": asked.key,
+            "container": container,
+            "workers": requested,
             "changed": true,
             "declared": added,
             "detail": action,

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -39,6 +39,41 @@ use crate::{
 /// slow enough that an idle daemon costs nothing.
 const SUPERVISION_INTERVAL: Duration = Duration::from_millis(250);
 
+/// Keeps one declaration for a dependency shared by several requested workers.
+///
+/// Registry graphs are resolved per requested root. Two roots may therefore
+/// return the same container. Identical declarations are one shared
+/// dependency; different declarations mean the roots resolved incompatible
+/// versions, sources, or dependency edges. Reject that batch before the file
+/// is read or edited, so argument order cannot select the winning declaration.
+fn coalesce_expanded(
+    expanded: Vec<crate::edit::NewContainer>,
+) -> Result<Vec<crate::edit::NewContainer>> {
+    let mut positions = BTreeMap::new();
+    let mut unique: Vec<crate::edit::NewContainer> = Vec::with_capacity(expanded.len());
+
+    for container in expanded {
+        if let Some(&position) = positions.get(&container.key) {
+            if unique[position] != container {
+                return Err(ComposeError::InvalidWorkerSpec {
+                    spec: container.key.clone(),
+                    reason: format!(
+                        "the requested workers resolve container '{}' to conflicting sources, \
+                         versions, or dependencies",
+                        container.key
+                    ),
+                });
+            }
+            continue;
+        }
+
+        positions.insert(container.key.clone(), unique.len());
+        unique.push(container);
+    }
+
+    Ok(unique)
+}
+
 pub struct Daemon {
     /// What this daemon registered as. Fixed, and the same on every machine:
     /// what tells two daemons apart is the namespace, not the name.
@@ -235,6 +270,7 @@ impl Daemon {
         for worker in &asked {
             wanted.extend(self.expand(worker).await?);
         }
+        let wanted = coalesce_expanded(wanted)?;
 
         let _mutation = self.lock_mutation(path).await;
         let text = std::fs::read_to_string(path).map_err(|source| ComposeError::Io {
@@ -810,6 +846,31 @@ fn open_private_temp(path: &Path) -> std::io::Result<std::fs::File> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn identical_shared_dependencies_are_declared_once() {
+        let state = crate::edit::parse_worker("state@1.0.0").unwrap();
+        let queue = crate::edit::parse_worker("queue@1.0.0").unwrap();
+
+        let merged = coalesce_expanded(vec![state.clone(), queue.clone(), state.clone()]).unwrap();
+
+        assert_eq!(merged, vec![state, queue]);
+    }
+
+    #[test]
+    fn conflicting_shared_dependencies_are_rejected_before_editing() {
+        let first = crate::edit::parse_worker("state@1.0.0").unwrap();
+        let second = crate::edit::parse_worker("state@2.0.0").unwrap();
+
+        for expanded in [vec![first.clone(), second.clone()], vec![second, first]] {
+            let error = coalesce_expanded(expanded)
+                .expect_err("two versions of one shared dependency must not be order-dependent");
+
+            assert_eq!(error.code(), "INVALID_WORKER_SPEC");
+            assert!(error.to_string().contains("state"), "{error}");
+            assert!(error.to_string().contains("conflicting"), "{error}");
+        }
+    }
 
     #[cfg(unix)]
     #[test]

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -112,9 +112,11 @@ struct AddOptions {
     /// Compose file on the daemon host. Defaults to `worker-compose.yaml` in
     /// the daemon working directory.
     file: Option<String>,
-    /// Worker names, `name@version` references, registry references, or local
-    /// paths to add in one edit and one restart.
-    workers: Vec<String>,
+    /// Canonical list of worker names, `name@version` references, registry
+    /// references, or local paths to add in one edit and one restart.
+    workers: Option<Vec<String>>,
+    /// Backward-compatible form for adding one worker.
+    worker: Option<String>,
 }
 
 /// Request fields used by single-worker compose-file edits.
@@ -460,6 +462,24 @@ fn schema_for_value<T: JsonSchema>() -> Option<Value> {
     serde_json::to_value(schema_for!(T)).ok()
 }
 
+/// `compose::add` accepts its canonical list or the old singular field.
+///
+/// Both fields are optional in the Rust shape so they can share the common
+/// namespace and file properties. `anyOf` states the runtime rule that at
+/// least one input form must be present. Supplying both is valid; dispatch
+/// gives the canonical `workers` list precedence.
+fn add_options_schema() -> Option<Value> {
+    let mut schema = schema_for_value::<AddOptions>()?;
+    schema.as_object_mut()?.insert(
+        "anyOf".to_string(),
+        json!([
+            { "required": ["workers"] },
+            { "required": ["worker"] },
+        ]),
+    );
+    Some(schema)
+}
+
 /// One source of truth for function registration and `compose::schema`.
 fn op_description(function_id: &str) -> &'static str {
     match function_id {
@@ -570,7 +590,7 @@ fn schema_table() -> &'static [SchemaTriple] {
             ),
             (
                 "compose::add",
-                schema_for_value::<AddOptions>(),
+                add_options_schema(),
                 schema_for_value::<AddOutcome>(),
             ),
             (
@@ -721,13 +741,18 @@ mod tests {
         assert!(add.contains_key("namespace"));
         assert!(add.contains_key("file"));
         assert!(add.contains_key("workers"));
-        assert!(!add.contains_key("worker"));
+        assert!(add.contains_key("worker"));
         assert!(!add.contains_key("container"));
-        assert!(
-            schema_entry("compose::add").1.as_ref().unwrap()["required"]
-                .as_array()
-                .is_some_and(|fields| fields.iter().any(|field| field.as_str() == Some("workers")))
-        );
+        let alternatives = schema_entry("compose::add").1.as_ref().unwrap()["anyOf"]
+            .as_array()
+            .expect("add should require either request form");
+        for field in ["workers", "worker"] {
+            assert!(alternatives.iter().any(|alternative| {
+                alternative["required"]
+                    .as_array()
+                    .is_some_and(|required| required.iter().any(|item| item == field))
+            }));
+        }
 
         let (_, list, _) = schema_entry("compose::list");
         let list = list.as_ref().unwrap()["properties"].as_object().unwrap();

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -55,12 +55,17 @@ pub struct ComposeRequest {
     pub container: Option<String>,
     /// The worker a call is about.
     ///
-    /// `compose::add` and `compose::update` read a spec: `name`,
-    /// `name@version`, or a path. `compose::remove` and `compose::restart` read
-    /// a container key, where it is the spelling for `container` — an operator
-    /// naming a worker should not have to know which of the two words this call
-    /// wanted.
+    /// `compose::update` reads a spec: `name`, `name@version`, or a path.
+    /// `compose::remove` and `compose::restart` read a container key, where it
+    /// is the spelling for `container` — an operator naming a worker should not
+    /// have to know which of the two words this call wanted. `compose::add`
+    /// keeps this field as a compatibility alias for a single list item.
     pub worker: Option<String>,
+    /// Workers to add in one file edit and one project restart.
+    ///
+    /// This is the canonical `compose::add` JSON field. The singular `worker`
+    /// field remains accepted for clients that used the old contract.
+    pub workers: Option<Vec<String>>,
     /// Function or file contract requested by `compose::schema`.
     pub function_id: Option<String>,
 }
@@ -98,7 +103,21 @@ struct ProjectOptions {
     file: Option<String>,
 }
 
-/// Request fields used by compose-file worker edits.
+/// Request fields used by `compose::add`.
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+struct AddOptions {
+    /// Optional daemon guard. Use the trigger `--namespace` flag to route.
+    namespace: Option<String>,
+    /// Compose file on the daemon host. Defaults to `worker-compose.yaml` in
+    /// the daemon working directory.
+    file: Option<String>,
+    /// Worker names, `name@version` references, registry references, or local
+    /// paths to add in one edit and one restart.
+    workers: Vec<String>,
+}
+
+/// Request fields used by single-worker compose-file edits.
 #[allow(dead_code)]
 #[derive(JsonSchema)]
 struct WorkerOptions {
@@ -185,7 +204,11 @@ struct StopOutcome {
 #[derive(Debug, Clone, JsonSchema)]
 struct AddOutcome {
     status: OpStatus,
+    /// The first requested worker. This keeps the single-worker response
+    /// contract stable.
     container: String,
+    /// Every requested worker. Present in responses from list-aware daemons.
+    workers: Option<Vec<String>>,
     changed: bool,
     detail: String,
     declared: Option<Vec<String>>,
@@ -332,13 +355,24 @@ async fn dispatch(
             Ok(result) => Ok(to_value(&result)),
             Err(err) => Err(compose_error(&err)),
         },
-        Operation::Add => match daemon
-            .add(file.as_deref(), request.worker.as_deref(), operation_id())
-            .await
-        {
-            Ok(result) => Ok(result),
-            Err(err) => Err(compose_error(&err)),
-        },
+        Operation::Add => {
+            let result = match request.workers.as_deref() {
+                Some(workers) => daemon.add(file.as_deref(), workers, operation_id()).await,
+                None => match request.worker.as_ref() {
+                    Some(worker) => {
+                        daemon
+                            .add(
+                                file.as_deref(),
+                                std::slice::from_ref(worker),
+                                operation_id(),
+                            )
+                            .await
+                    }
+                    None => daemon.add(file.as_deref(), &[], operation_id()).await,
+                },
+            };
+            result.map_err(|err| compose_error(&err))
+        }
         Operation::Remove => match daemon
             .remove(file.as_deref(), request.worker.as_deref(), operation_id())
             .await
@@ -451,8 +485,8 @@ fn op_description(function_id: &str) -> &'static str {
              starting its project."
         }
         "compose::add" => {
-            "Declare a worker and its registry dependencies in the compose \
-             file, pin resolved versions, then restart the project."
+            "Declare workers and their registry dependencies in the compose \
+             file, pin resolved versions, then restart the project once."
         }
         "compose::remove" => {
             "Remove one declared worker from the compose file, then restart \
@@ -536,7 +570,7 @@ fn schema_table() -> &'static [SchemaTriple] {
             ),
             (
                 "compose::add",
-                schema_for_value::<WorkerOptions>(),
+                schema_for_value::<AddOptions>(),
                 schema_for_value::<AddOutcome>(),
             ),
             (
@@ -654,6 +688,26 @@ mod tests {
     }
 
     #[test]
+    fn add_request_accepts_a_worker_list_and_the_singular_compatibility_field() {
+        let listed: ComposeRequest = serde_json::from_value(json!({
+            "workers": ["database", "web"],
+        }))
+        .expect("workers should deserialize");
+        assert_eq!(
+            listed.workers,
+            Some(vec!["database".to_string(), "web".to_string()])
+        );
+        assert_eq!(listed.worker, None);
+
+        let singular: ComposeRequest = serde_json::from_value(json!({
+            "worker": "database",
+        }))
+        .expect("the old singular field should deserialize");
+        assert_eq!(singular.worker.as_deref(), Some("database"));
+        assert_eq!(singular.workers, None);
+    }
+
+    #[test]
     fn operation_requests_expose_only_supported_fields() {
         let (_, up, _) = schema_entry("compose::up");
         let up = up.as_ref().unwrap()["properties"].as_object().unwrap();
@@ -666,12 +720,13 @@ mod tests {
         let add = add.as_ref().unwrap()["properties"].as_object().unwrap();
         assert!(add.contains_key("namespace"));
         assert!(add.contains_key("file"));
-        assert!(add.contains_key("worker"));
+        assert!(add.contains_key("workers"));
+        assert!(!add.contains_key("worker"));
         assert!(!add.contains_key("container"));
         assert!(
             schema_entry("compose::add").1.as_ref().unwrap()["required"]
                 .as_array()
-                .is_some_and(|fields| fields.iter().any(|field| field.as_str() == Some("worker")))
+                .is_some_and(|fields| fields.iter().any(|field| field.as_str() == Some("workers")))
         );
 
         let (_, list, _) = schema_entry("compose::list");

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -480,6 +480,12 @@ fn add_options_schema() -> Option<Value> {
         .pointer_mut("/properties/workers")?
         .as_object_mut()?
         .insert("minItems".to_string(), json!(1));
+    for pointer in ["/properties/worker", "/properties/workers/items"] {
+        schema
+            .pointer_mut(pointer)?
+            .as_object_mut()?
+            .insert("pattern".to_string(), json!(r"\S"));
+    }
     schema.as_object_mut()?.insert(
         "anyOf".to_string(),
         json!([
@@ -759,6 +765,10 @@ mod tests {
             json!({ "workers": null }),
             json!({ "worker": null }),
             json!({ "workers": [], "worker": "database" }),
+            json!({ "worker": "" }),
+            json!({ "worker": "  " }),
+            json!({ "workers": [""] }),
+            json!({ "workers": ["  "] }),
         ] {
             assert!(!validator.is_valid(&invalid), "should reject {invalid}");
         }

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -470,6 +470,10 @@ fn schema_for_value<T: JsonSchema>() -> Option<Value> {
 /// gives the canonical `workers` list precedence.
 fn add_options_schema() -> Option<Value> {
     let mut schema = schema_for_value::<AddOptions>()?;
+    schema
+        .pointer_mut("/properties/workers")?
+        .as_object_mut()?
+        .insert("minItems".to_string(), json!(1));
     schema.as_object_mut()?.insert(
         "anyOf".to_string(),
         json!([
@@ -743,6 +747,7 @@ mod tests {
         assert!(add.contains_key("workers"));
         assert!(add.contains_key("worker"));
         assert!(!add.contains_key("container"));
+        assert_eq!(add["workers"]["minItems"], 1);
         let alternatives = schema_entry("compose::add").1.as_ref().unwrap()["anyOf"]
             .as_array()
             .expect("add should require either request form");

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -470,6 +470,12 @@ fn schema_for_value<T: JsonSchema>() -> Option<Value> {
 /// gives the canonical `workers` list precedence.
 fn add_options_schema() -> Option<Value> {
     let mut schema = schema_for_value::<AddOptions>()?;
+    for field in ["workers", "worker"] {
+        let types = schema
+            .pointer_mut(&format!("/properties/{field}/type"))?
+            .as_array_mut()?;
+        types.retain(|kind| kind != "null");
+    }
     schema
         .pointer_mut("/properties/workers")?
         .as_object_mut()?
@@ -729,6 +735,33 @@ mod tests {
         .expect("the old singular field should deserialize");
         assert_eq!(singular.worker.as_deref(), Some("database"));
         assert_eq!(singular.workers, None);
+    }
+
+    #[test]
+    fn add_schema_requires_one_non_null_non_empty_worker_form() {
+        let schema = schema_entry("compose::add").1.as_ref().unwrap();
+        let validator = jsonschema::Validator::new(schema).expect("add schema should compile");
+
+        for valid in [
+            json!({ "workers": ["database", "web"] }),
+            json!({ "worker": "database" }),
+        ] {
+            let errors = validator
+                .iter_errors(&valid)
+                .map(|error| error.to_string())
+                .collect::<Vec<_>>();
+            assert!(errors.is_empty(), "should accept {valid}: {errors:?}");
+        }
+
+        for invalid in [
+            json!({}),
+            json!({ "workers": [] }),
+            json!({ "workers": null }),
+            json!({ "worker": null }),
+            json!({ "workers": [], "worker": "database" }),
+        ] {
+            assert!(!validator.is_valid(&invalid), "should reject {invalid}");
+        }
     }
 
     #[test]

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -151,7 +151,8 @@ All functions accept the same payload.
 | `file`      | string | Which project: the path to its compose file.                                      |
 | `container` | string | Restricts the operation to one container and the containers it depends on.        |
 | `namespace` | string | Which daemon the caller believed they were reaching. A guard, see below.          |
-| `worker`    | string | The worker used by `add`, `remove`, `restart`, and `update`.                      |
+| `worker`    | string | A repeatable CLI argument for `add`; one worker for `remove`, `restart`, and `update`. |
+| `workers`   | string[] | The canonical JSON list used by `add`.                                          |
 | `function_id` | string | The function or file contract requested by `compose::schema`.                  |
 
 A project is its compose file, and nothing else names one. The same file reached twice is the same
@@ -172,7 +173,7 @@ one at the wrong file.
 | `compose::status`   | `file`    | The project's namespace, file, state directory, daemon pid, container states.  |
 | `compose::list`     | nothing   | The daemon name, its namespace, its pid, and every project it holds.           |
 | `compose::validate` | `file`    | A validation report.                                                           |
-| `compose::add`      | `file`, `worker` | What the edit did, and the `down` and `up` that followed.               |
+| `compose::add`      | `file`, `workers` | What the edit did, and the one `down` and `up` that followed.           |
 | `compose::remove`   | `file`, `worker` | The worker removed, and the `down` and `up` that followed.              |
 | `compose::restart`  | `file`, `worker` | The `down` and the `up`, or one container's restart.                    |
 | `compose::update`   | `file`, `worker` | Both versions, and the restart that followed.                           |
@@ -180,7 +181,7 @@ one at the wrong file.
 | `compose::schema`   | `function_id` | Request/response JSON Schemas, descriptions, timeouts, and retry safety.    |
 
 `file` is not required. Left out, it falls back to a `worker-compose.yaml` in the daemon's own
-working directory. `worker` has no fallback.
+working directory. `worker` and `workers` have no fallback.
 
 `compose::schema` is read-only. With no `function_id`, it returns every `compose::*` contract.
 Pass a function id to return one contract. The pseudo-id `worker-compose.yaml` returns the file's
@@ -193,12 +194,14 @@ iii trigger compose::schema --namespace dev function_id=compose::up
 iii trigger compose::schema --namespace dev function_id=worker-compose.yaml
 ```
 
-### Adding a worker
+### Adding workers
 
-`compose::add` declares a worker in the compose file and restarts the project.
-`worker=` takes a registry name (`state`), a name with a version (`state@0.21.4`)
-or a directory (`./workers/api`); a leading `.` or `/` is what makes it a path,
-since a registry reference may carry a host of its own.
+`compose::add` declares one or more workers in the compose file and restarts the project once.
+On the CLI, repeat `worker=` for each worker. Each value takes a registry name (`state`), a name
+with a version (`state@0.21.4`), or a directory (`./workers/api`); a leading `.` or `/` is what
+makes it a path, since a registry reference may carry a host of its own. The JSON function contract
+uses one list: `{ "workers": ["database", "web"] }`. The old singular JSON field remains accepted
+for one worker.
 
 An unpinned name is resolved once and written out as an exact version, so a
 later `up` cannot quietly get a different build. The same worker at the same
@@ -231,7 +234,7 @@ iii trigger compose::up     --namespace dev file=./worker-compose.yaml container
 iii trigger compose::status --namespace dev file=./worker-compose.yaml
 iii trigger compose::down   --namespace dev file=./worker-compose.yaml
 iii trigger compose::list   --namespace dev
-iii trigger compose::add    --namespace dev file=./worker-compose.yaml worker=state
+iii trigger compose::add    --namespace dev file=./worker-compose.yaml worker=database worker=web
 iii trigger compose::remove --namespace dev file=./worker-compose.yaml worker=state
 iii trigger compose::restart --namespace dev file=./worker-compose.yaml
 iii trigger compose::schema --namespace dev function_id=compose::up
@@ -292,7 +295,7 @@ Already on the version asked for, nothing is written and `changed` is `false`.
 
 The container has to be declared already, and has to be a `package://` one: this edits a version
 line, it does not add a container, and a `path://` worker has no version to move. Use
-[`compose::add`](#adding-a-worker) to declare something new.
+[`compose::add`](#adding-workers) to declare something new.
 
 Only the version line changes. A `depends_on` written by hand comes through as it was, since
 rewriting the graph is what `compose::add` is for.

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -145,7 +145,8 @@ All functions accept the same payload.
 | `file`      | string | Which project: the path to its compose file.                                      |
 | `container` | string | Restricts the operation to one container and the containers it depends on.        |
 | `namespace` | string | Which daemon the caller believed they were reaching. A guard, see below.          |
-| `worker`    | string | The worker used by `add`, `remove`, `restart`, and `update`.                      |
+| `worker`    | string | A repeatable CLI argument for `add`; one worker for `remove`, `restart`, and `update`. |
+| `workers`   | string[] | The canonical JSON list used by `add`.                                          |
 | `function_id` | string | The function or file contract requested by `compose::schema`.                  |
 
 A project is its compose file, and nothing else names one. The same file reached twice is the same
@@ -166,7 +167,7 @@ one at the wrong file.
 | `compose::status`   | `file`    | The project's namespace, file, state directory, daemon pid, container states.  |
 | `compose::list`     | nothing   | The daemon name, its namespace, its pid, and every project it holds.           |
 | `compose::validate` | `file`    | A validation report.                                                           |
-| `compose::add`      | `file`, `worker` | What the edit did, and the `down` and `up` that followed.               |
+| `compose::add`      | `file`, `workers` | What the edit did, and the one `down` and `up` that followed.           |
 | `compose::remove`   | `file`, `worker` | The worker removed, and the `down` and `up` that followed.              |
 | `compose::restart`  | `file`, `worker` | The `down` and the `up`, or one container's restart.                    |
 | `compose::update`   | `file`, `worker` | Both versions, and the restart that followed.                           |
@@ -174,7 +175,7 @@ one at the wrong file.
 | `compose::schema`   | `function_id` | Request/response JSON Schemas, descriptions, timeouts, and retry safety.    |
 
 `file` is not required. Left out, it falls back to a `worker-compose.yaml` in the daemon's own
-working directory. `worker` has no fallback.
+working directory. `worker` and `workers` have no fallback.
 
 `compose::schema` is read-only. With no `function_id`, it returns every `compose::*` contract.
 Pass a function id to return one contract. The pseudo-id `worker-compose.yaml` returns the file's
@@ -187,12 +188,14 @@ iii trigger compose::schema --namespace dev function_id=compose::up
 iii trigger compose::schema --namespace dev function_id=worker-compose.yaml
 ```
 
-### Adding a worker
+### Adding workers
 
-`compose::add` declares a worker in the compose file and restarts the project.
-`worker=` takes a registry name (`state`), a name with a version (`state@0.21.4`)
-or a directory (`./workers/api`); a leading `.` or `/` is what makes it a path,
-since a registry reference may carry a host of its own.
+`compose::add` declares one or more workers in the compose file and restarts the project once.
+On the CLI, repeat `worker=` for each worker. Each value takes a registry name (`state`), a name
+with a version (`state@0.21.4`), or a directory (`./workers/api`); a leading `.` or `/` is what
+makes it a path, since a registry reference may carry a host of its own. The JSON function contract
+uses one list: `{ "workers": ["database", "web"] }`. The old singular JSON field remains accepted
+for one worker.
 
 An unpinned name is resolved once and written out as an exact version, so a
 later `up` cannot quietly get a different build. The same worker at the same
@@ -225,7 +228,7 @@ iii trigger compose::up     --namespace dev file=./worker-compose.yaml container
 iii trigger compose::status --namespace dev file=./worker-compose.yaml
 iii trigger compose::down   --namespace dev file=./worker-compose.yaml
 iii trigger compose::list   --namespace dev
-iii trigger compose::add    --namespace dev file=./worker-compose.yaml worker=state
+iii trigger compose::add    --namespace dev file=./worker-compose.yaml worker=database worker=web
 iii trigger compose::remove --namespace dev file=./worker-compose.yaml worker=state
 iii trigger compose::restart --namespace dev file=./worker-compose.yaml
 iii trigger compose::schema --namespace dev function_id=compose::up
@@ -286,7 +289,7 @@ Already on the version asked for, nothing is written and `changed` is `false`.
 
 The container has to be declared already, and has to be a `package://` one: this edits a version
 line, it does not add a container, and a `path://` worker has no version to move. Use
-[`compose::add`](#adding-a-worker) to declare something new.
+[`compose::add`](#adding-workers) to declare something new.
 
 Only the version line changes. A `depends_on` written by hand comes through as it was, since
 rewriting the graph is what `compose::add` is for.

--- a/engine/src/cli_trigger/mod.rs
+++ b/engine/src/cli_trigger/mod.rs
@@ -80,7 +80,15 @@ pub async fn run_trigger(args: &TriggerArgs) -> Result<(), TriggerCliError> {
     let function_path = args.function_path.as_deref().ok_or_else(|| {
         anyhow::anyhow!("iii trigger: missing FUNCTION_PATH. Try: `iii trigger <fn-path> [args]`")
     })?;
-    let payload = payload::parse(&args.kv, args.json.as_deref())?;
+    // `compose::add` has a list in its JSON contract, while the shell form
+    // repeats the readable singular key: `worker=database worker=web`.
+    // Keep this adaptation scoped to that function so repeated keys for every
+    // other trigger retain their established last-value-wins behaviour.
+    let payload = if function_path == "compose::add" {
+        payload::parse_collecting(&args.kv, args.json.as_deref(), "worker", "workers")?
+    } else {
+        payload::parse(&args.kv, args.json.as_deref())?
+    };
     exec::invoke(
         function_path,
         payload,

--- a/engine/src/cli_trigger/payload.rs
+++ b/engine/src/cli_trigger/payload.rs
@@ -7,6 +7,10 @@
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
+fn decode_value(value: &str) -> Value {
+    serde_json::from_str(value).unwrap_or_else(|_| Value::String(value.to_string()))
+}
+
 /// Resolve a payload from CLI tokens and an optional `--json` value.
 ///
 /// Resolution order:
@@ -33,7 +37,7 @@ pub fn parse(kv_tokens: &[String], json_override: Option<&str>) -> Result<Value>
             if k.is_empty() {
                 bail!("payload key must not be empty (got `{}`)", token);
             }
-            let value = serde_json::from_str(v).unwrap_or_else(|_| Value::String(v.to_string()));
+            let value = decode_value(v);
             obj.insert(k.to_string(), value);
         }
         Some(obj)
@@ -61,6 +65,42 @@ pub fn parse(kv_tokens: &[String], json_override: Option<&str>) -> Result<Value>
             bail!("--json must be an object when combined with kv pairs")
         }
     }
+}
+
+/// Resolve a payload while collecting repeated singular arguments into one
+/// plural array field.
+///
+/// This is the CLI adapter for functions whose JSON contract takes a list but
+/// whose shell syntax repeats a readable singular key. Other keys keep the
+/// normal [`parse`] rules. Collected key-value arguments override either the
+/// singular compatibility field or the plural field from `--json`.
+pub fn parse_collecting(
+    kv_tokens: &[String],
+    json_override: Option<&str>,
+    singular: &str,
+    plural: &str,
+) -> Result<Value> {
+    let mut remaining = Vec::with_capacity(kv_tokens.len());
+    let mut collected = Vec::new();
+
+    for token in kv_tokens {
+        match token.split_once('=') {
+            Some((key, value)) if key == singular => collected.push(decode_value(value)),
+            _ => remaining.push(token.clone()),
+        }
+    }
+
+    let mut payload = parse(&remaining, json_override)?;
+    if collected.is_empty() {
+        return Ok(payload);
+    }
+
+    let object = payload
+        .as_object_mut()
+        .context("--json must be an object when combined with kv pairs")?;
+    object.remove(singular);
+    object.insert(plural.to_string(), Value::Array(collected));
+    Ok(payload)
 }
 
 #[cfg(test)]
@@ -135,5 +175,47 @@ mod tests {
     fn kv_empty_key_errors() {
         let err = parse(&[s("=value")], None).unwrap_err().to_string();
         assert!(err.contains("must not be empty"), "got: {}", err);
+    }
+
+    #[test]
+    fn collecting_repeated_singular_values_builds_a_plural_array() {
+        let got = parse_collecting(
+            &[
+                s("file=worker-compose.yaml"),
+                s("worker=database"),
+                s("worker=web"),
+            ],
+            None,
+            "worker",
+            "workers",
+        )
+        .unwrap();
+
+        assert_eq!(
+            got,
+            json!({
+                "file": "worker-compose.yaml",
+                "workers": ["database", "web"],
+            })
+        );
+    }
+
+    #[test]
+    fn collecting_one_singular_value_still_builds_an_array() {
+        let got = parse_collecting(&[s("worker=database")], None, "worker", "workers").unwrap();
+        assert_eq!(got, json!({"workers": ["database"]}));
+    }
+
+    #[test]
+    fn collected_values_override_json_worker_fields() {
+        let got = parse_collecting(
+            &[s("worker=web")],
+            Some(r#"{"worker":"old","workers":["old"]}"#),
+            "worker",
+            "workers",
+        )
+        .unwrap();
+
+        assert_eq!(got, json!({"workers": ["web"]}));
     }
 }

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1116,6 +1116,29 @@ mod tests {
     }
 
     #[test]
+    fn compose_add_parses_repeated_worker_arguments() {
+        let cli = Cli::try_parse_from([
+            "iii",
+            "trigger",
+            "-n",
+            "dev",
+            "compose::add",
+            "worker=database",
+            "worker=web",
+        ])
+        .expect("compose::add should parse repeated workers");
+
+        match cli.command {
+            Some(Commands::Trigger(args)) => {
+                assert_eq!(args.namespace.as_deref(), Some("dev"));
+                assert_eq!(args.function_path.as_deref(), Some("compose::add"));
+                assert_eq!(args.kv, vec!["worker=database", "worker=web"]);
+            }
+            _ => panic!("expected Trigger subcommand"),
+        }
+    }
+
+    #[test]
     fn trigger_without_the_flag_carries_no_namespace() {
         let cli = Cli::try_parse_from(["iii", "trigger", "state::get", "key=a"])
             .expect("should parse a plain trigger");

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -413,6 +413,102 @@ async fn validating_a_file_does_not_take_the_project_on() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn add_edits_several_workers_and_restarts_the_project_once() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let existing_started = tmp.path().join("workers/existing/started");
+    let database_started = tmp.path().join("workers/database/started");
+    let web_started = tmp.path().join("workers/web/started");
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: addition
+startup_timeout: 3s
+stop_timeout: 100ms
+containers:
+  existing:
+    worker: path://./workers/existing
+    scripts:
+      run: "echo started >> started && sleep 30"
+"#,
+        &["existing", "database", "web"],
+    );
+    for worker in ["database", "web"] {
+        std::fs::write(
+            tmp.path()
+                .join("workers")
+                .join(worker)
+                .join("iii.worker.yaml"),
+            "scripts:\n  start: \"echo started >> started && sleep 30\"\n",
+        )
+        .expect("write worker manifest");
+    }
+
+    let add = call(
+        port,
+        "compose::add",
+        json!({
+            "file": file.to_str().unwrap(),
+            "workers": ["./workers/database", "./workers/web"],
+        }),
+    );
+    let ready = async {
+        wait_for_start_markers(&[
+            existing_started.as_path(),
+            database_started.as_path(),
+            web_started.as_path(),
+        ])
+        .await;
+        let existing = register_test_worker(port, "addition", "existing");
+        let database = register_test_worker(port, "addition", "database");
+        let web = register_test_worker(port, "addition", "web");
+        for worker in ["existing", "database", "web"] {
+            wait_for_worker_state(&daemon, "addition", worker, true).await;
+        }
+        (existing, database, web)
+    };
+    let (result, (existing, database, web)) = tokio::join!(add, ready);
+    let result = result.expect("compose::add should answer");
+
+    assert_eq!(result["status"], "ok", "{result}");
+    assert_eq!(result["workers"], json!(["database", "web"]), "{result}");
+    assert_eq!(result["container"], "database", "{result}");
+    assert_eq!(result["changed"], true, "{result}");
+    assert_eq!(result["down"]["status"], "ok", "{result}");
+    assert_eq!(result["up"]["status"], "ok", "{result}");
+    assert_eq!(
+        operation_containers(&result["up"]),
+        vec!["database", "existing", "web"],
+        "the one restart used the complete edited worker set: {result}"
+    );
+
+    let edited = std::fs::read_to_string(&file).expect("read edited compose file");
+    for worker in ["database", "web"] {
+        assert_eq!(
+            edited.matches(&format!("  {worker}:\n")).count(),
+            1,
+            "worker should be declared once: {edited}"
+        );
+    }
+    for marker in [&existing_started, &database_started, &web_started] {
+        let starts = std::fs::read_to_string(marker).expect("read start count");
+        assert_eq!(
+            starts.lines().count(),
+            1,
+            "the batch should restart the project once: {starts}"
+        );
+    }
+
+    existing.shutdown_async().await;
+    database.shutdown_async().await;
+    web.shutdown_async().await;
+    daemon.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn remove_edits_only_the_named_worker_and_restarts_the_project() {
     isolate_state();
     let port = spawn_engine().await;


### PR DESCRIPTION
## Summary

- allow `compose::add` CLI calls to repeat `worker=<name>`
- send the repeated values through the canonical `workers` request field while keeping the singular JSON field compatible
- add every requested worker in one compose-file edit and restart the project once
- update the compose schemas, documentation, and integration coverage

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p iii-compose`
- `cargo test -p iii compose_add_parses_repeated_worker_arguments`
- `cargo test -p iii cli_trigger::payload::tests`
- `cargo test -p iii --test compose_daemon_e2e`
- `cargo clippy -p iii-compose --all-targets -- -D warnings`
- `cargo clippy -p iii --bin iii --test compose_daemon_e2e --no-deps`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for adding multiple workers in a single `compose::add` operation.
  * Added repeatable CLI `worker=` arguments and a canonical JSON `workers` list.
  * Projects now restart once after multiple workers are added.
  * Existing singular JSON `worker` requests remain supported.

* **Bug Fixes**
  * Shared worker declarations are deduplicated, while conflicting or invalid specifications are rejected.

* **Documentation**
  * Updated compose payload documentation and examples.

* **Tests**
  * Added coverage for repeated worker arguments, compatibility behavior, conflict handling, and multi-worker additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->