### PR TITLE
fix(compose): enforce --up flag contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Before iii:
 After iii:
 
 - Declare workers in `worker-compose.yaml`
-- Run them with `iii compose up`
+- Run them with `iii compose --up`
 - Done. It is in the system, traceable, and callable.
 
 Platform teams publish workers. Application teams register functions and declare triggers. Agents
@@ -119,7 +119,7 @@ Then scaffold and start a project:
 iii project init myapp    # scaffold a project
 cd myapp
 # declare project workers in worker-compose.yaml
-iii compose up            # start the engine and project workers
+iii compose --up          # start the engine and project workers
 ```
 
 Full walkthrough at the [Quickstart guide](https://iii.dev/docs/quickstart).

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ state, observability, agents, and sandboxes each usually bring their own integra
 collapses that into one live system surface.
 
 ```bash
-iii compose --namespace dev up
+iii compose --namespace dev --up
 iii trigger -n dev compose::add worker=queue
 iii trigger -n dev compose::add worker=agent
 iii trigger -n dev compose::add worker=<anything>

--- a/crates/iii-compose/src/cli.rs
+++ b/crates/iii-compose/src/cli.rs
@@ -82,6 +82,10 @@ pub enum ComposeCommand {
 impl ComposeCli {
     /// Resolves the invocation, rejecting incomplete flag combinations.
     pub fn plan(&self) -> Result<ComposeCommand> {
+        if !self.up && self.file.is_some() {
+            return Err(ComposeError::FileRequiresUp);
+        }
+
         let explicit_daemon_namespace = self.validated_namespace()?;
 
         // A missing `--file` is not "no file": it is the same fallback a call

--- a/crates/iii-compose/src/error.rs
+++ b/crates/iii-compose/src/error.rs
@@ -58,6 +58,9 @@ pub enum ComposeError {
     )]
     EngineUrlConflictsWithManaged,
 
+    #[error("--file requires --up")]
+    FileRequiresUp,
+
     #[error(
         "{path} declares engine:, but this Compose daemon is connected to an external engine. \
          Start the file in a separate `iii compose --up` invocation without --engine"
@@ -495,6 +498,7 @@ impl ComposeError {
             Self::InvalidManagedEngineUrl => "INVALID_MANAGED_ENGINE_URL",
             Self::EngineUrlRequired => "ENGINE_URL_REQUIRED",
             Self::EngineUrlConflictsWithManaged => "ENGINE_URL_CONFLICTS_WITH_MANAGED",
+            Self::FileRequiresUp => "FILE_REQUIRES_UP",
             Self::EngineSectionRequiresManagedStart { .. } => {
                 "ENGINE_SECTION_REQUIRES_MANAGED_START"
             }

--- a/crates/iii-compose/tests/cli.rs
+++ b/crates/iii-compose/tests/cli.rs
@@ -120,6 +120,20 @@ fn the_project_flags_are_gone_rather_than_ignored() {
 }
 
 #[test]
+fn a_programmatic_file_without_up_is_refused() {
+    let err = ComposeCli {
+        engine: None,
+        ns: None,
+        up: false,
+        file: Some("other.yaml".into()),
+    }
+    .plan()
+    .expect_err("a public ComposeCli must enforce the same rule as clap");
+
+    assert_eq!(err.code(), "FILE_REQUIRES_UP");
+}
+
+#[test]
 fn an_explicit_engine_beats_the_environment_and_there_is_no_default_external_url() {
     // The only test that touches III_URL, so no other test can race it.
     unsafe { std::env::set_var("III_URL", "ws://from-env:1") };

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -5,6 +5,12 @@ owner: "devrel"
 type: "reference"
 ---
 
+<Update label="0.23.0" description="Upcoming">
+  ## Breaking: Compose startup uses `--up`
+
+  `iii compose up` is replaced by `iii compose --up`. The positional `up` form is rejected, and `--file` is valid only with `--up`; bare `iii compose` starts the daemon without starting a project. Migrate explicit files to `iii compose --up --file worker-compose.yaml`.
+</Update>
+
 <Update label="0.22.1" description="August 2026">
   ## Queue workers restore their persisted transport on restart
 

--- a/scripts/start-iii.sh
+++ b/scripts/start-iii.sh
@@ -61,7 +61,7 @@ if [[ -n "$COMPOSE_FILE" ]]; then
     fi
     "$BINARY" compose \
       --namespace "$COMPOSE_NAMESPACE" \
-      up --file "$COMPOSE_FILE" > "$LOG_FILE" 2>&1 &
+      --up --file "$COMPOSE_FILE" > "$LOG_FILE" 2>&1 &
   else
     if [[ -z "$ENGINE_URL" ]]; then
       echo "Compose file $COMPOSE_FILE has no engine section; pass --engine or --iii-url" >&2
@@ -70,7 +70,7 @@ if [[ -n "$COMPOSE_FILE" ]]; then
     "$BINARY" compose \
       --engine "$ENGINE_URL" \
       --namespace "$COMPOSE_NAMESPACE" \
-      up --file "$COMPOSE_FILE" > "$LOG_FILE" 2>&1 &
+      --up --file "$COMPOSE_FILE" > "$LOG_FILE" 2>&1 &
   fi
 else
   "$BINARY" --config "$CONFIG" > "$LOG_FILE" 2>&1 &

--- a/skills/iii-engine-config/SKILL.md
+++ b/skills/iii-engine-config/SKILL.md
@@ -45,7 +45,7 @@ containers: {}
 Start it with:
 
 ```bash
-iii compose --namespace orders-daemon up --file worker-compose.yaml
+iii compose --namespace orders-daemon --up --file worker-compose.yaml
 ```
 
 `engine.url` defaults to `ws://127.0.0.1:49134` and uses Compose's `${VAR:-default}` expansion.
@@ -95,7 +95,7 @@ Start the engine and external Compose daemon separately:
 
 ```bash
 iii --config config.yaml
-iii compose --namespace orders-daemon --engine ws://127.0.0.1:49134 up --file worker-compose.yaml
+iii compose --namespace orders-daemon --engine ws://127.0.0.1:49134 --up --file worker-compose.yaml
 ```
 
 The external Compose file must omit `engine:`. `III_URL` may replace `--engine`. Direct config

--- a/skills/iii-getting-started/SKILL.md
+++ b/skills/iii-getting-started/SKILL.md
@@ -41,7 +41,7 @@ cd <your-project>
 ## Step 3: Start the Project
 
 ```bash
-iii compose --namespace dev up --file worker-compose.yaml
+iii compose --namespace dev --up --file worker-compose.yaml
 ```
 
 The file's `engine:` section starts the engine; `containers:` starts project workers. The engine


### PR DESCRIPTION
## What

- Reject programmatic `ComposeCli` values that set `file` without `up`.
- Update the README and startup script to use `iii compose --up`.
- Add the Compose startup breaking change and migration command to the 0.23.0 changelog.

## Why

This follow-up to #2081 makes the public planning API enforce the same contract as Clap and completes the command migration in repository guidance.

## Notes

`iii compose up` is rejected. Use `iii compose --up`; `--file` is valid only with `--up`.

## Testing

- `cargo test -p iii-compose` (250 passed)
- `cargo test -p iii --bin iii` (146 passed)
- `cargo clippy -p iii-compose --all-targets -- -D warnings`
- `bash -n scripts/start-iii.sh`
- docs skill artifacts verified against sources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Updated Compose CLI syntax: use `iii compose --up` instead of `iii compose up`.
  * The `--file` option now requires `--up`.
  * Running `iii compose` without `--up` only starts the daemon.

* **Documentation**
  * Updated quick-start instructions, scripts, and the upcoming 0.23.0 changelog to reflect the new command syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->