### PR TITLE
fix(compose): clean up interrupted startup

### DIFF
--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -287,6 +287,28 @@ impl Daemon {
         Ok(project.up(container, operation_id).await)
     }
 
+    /// Brings the initial foreground project up until the process is asked to
+    /// stop. Remote `compose::up` calls use [`Self::up`] and are not tied to a
+    /// signal received by the foreground CLI.
+    pub(crate) async fn up_until_shutdown(
+        &self,
+        file: Option<&Path>,
+        container: Option<&str>,
+        operation_id: String,
+        shutdown: crate::shutdown::ShutdownSignal,
+    ) -> Result<Option<OpResult>> {
+        let file = self.resolve_file(file)?;
+        let current = ComposeFile::load(file)?;
+        self.engine_policy.validate_project(&current)?;
+        let project = self.project(file).await?;
+        if shutdown.requested() {
+            return Ok(None);
+        }
+        Ok(project
+            .up_until_shutdown(container, operation_id, shutdown)
+            .await)
+    }
+
     /// Adds containers to a project's file, then reconciles the project once.
     ///
     /// The file is the operator's, so it is edited rather than rewritten: see

--- a/crates/iii-compose/src/hooks.rs
+++ b/crates/iii-compose/src/hooks.rs
@@ -62,10 +62,25 @@ pub async fn await_pre_run(
     script: &str,
     timeout: Duration,
 ) -> Result<(), HookError> {
+    await_pre_run_until_shutdown(ctx, script, timeout, None)
+        .await
+        .expect("a hook without a shutdown signal cannot be interrupted")
+}
+
+/// Runs `pre_run`, killing and reaping its process group if foreground compose
+/// is interrupted while the hook is active.
+pub(crate) async fn await_pre_run_until_shutdown(
+    ctx: &SpawnCtx<'_>,
+    script: &str,
+    timeout: Duration,
+    shutdown: Option<&mut crate::shutdown::ShutdownSignal>,
+) -> Option<Result<(), HookError>> {
     const HOOK: &str = "pre_run";
 
-    let mut hook =
-        spawn_hook(ctx, script).map_err(|source| HookError::Spawn { hook: HOOK, source })?;
+    let mut hook = match spawn_hook(ctx, script) {
+        Ok(hook) => hook,
+        Err(source) => return Some(Err(HookError::Spawn { hook: HOOK, source })),
+    };
     let child = &mut hook.child;
 
     let mut stdout = child.stdout.take();
@@ -79,28 +94,60 @@ pub async fn await_pre_run(
         (status, out, err)
     };
 
-    match tokio::time::timeout(timeout, run).await {
-        Ok((status, out, err)) => {
+    enum HookOutcome {
+        Finished((std::io::Result<std::process::ExitStatus>, String, String)),
+        TimedOut,
+        Interrupted,
+    }
+
+    let outcome = {
+        tokio::pin!(run);
+        let timer = tokio::time::sleep(timeout);
+        tokio::pin!(timer);
+        match shutdown {
+            Some(shutdown) => tokio::select! {
+                biased;
+                _ = shutdown.wait() => HookOutcome::Interrupted,
+                result = &mut run => HookOutcome::Finished(result),
+                _ = &mut timer => HookOutcome::TimedOut,
+            },
+            None => tokio::select! {
+                result = &mut run => HookOutcome::Finished(result),
+                _ = &mut timer => HookOutcome::TimedOut,
+            },
+        }
+    };
+
+    match outcome {
+        HookOutcome::Finished((status, out, err)) => {
             log_output(HOOK, ctx.container_key, &out, &err);
-            let status = status.map_err(|source| HookError::Spawn { hook: HOOK, source })?;
+            let status = match status {
+                Ok(status) => status,
+                Err(source) => return Some(Err(HookError::Spawn { hook: HOOK, source })),
+            };
             if status.success() {
-                Ok(())
+                Some(Ok(()))
             } else {
-                Err(HookError::Failed {
+                Some(Err(HookError::Failed {
                     hook: HOOK,
                     code: status.code().unwrap_or(-1),
-                })
+                }))
             }
         }
-        Err(_) => {
+        HookOutcome::TimedOut => {
             // Kill before waiting: the hook is hung by definition, so waiting
             // first would never return.
             hook.kill_tree();
             let _ = hook.child.wait().await;
-            Err(HookError::Timeout {
+            Some(Err(HookError::Timeout {
                 hook: HOOK,
                 timeout,
-            })
+            }))
+        }
+        HookOutcome::Interrupted => {
+            hook.kill_tree();
+            let _ = hook.child.wait().await;
+            None
         }
     }
 }

--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -37,6 +37,7 @@ pub mod project;
 pub mod registry;
 pub mod remote;
 pub mod report;
+mod shutdown;
 pub mod spawn;
 pub mod state;
 
@@ -137,6 +138,11 @@ async fn serve(
         EngineMode::Managed { url } | EngineMode::External { url } => url.clone(),
     };
 
+    // Install this before the first owned process starts. Signal delivery uses
+    // separate process groups, so compose must stay alive long enough to stop
+    // each child itself.
+    let shutdown = shutdown::ShutdownSignal::install()?;
+
     let managed_engine = match engine_mode {
         EngineMode::Managed { .. } => {
             let spec = initial_file
@@ -173,14 +179,19 @@ async fn serve(
         .and_then(daemon::EnginePolicy::managed)
         .unwrap_or(daemon::EnginePolicy::External);
 
-    let result = serve_daemon(
-        engine_url,
-        daemon_namespace,
-        start,
-        managed_engine.as_ref(),
-        engine_policy,
-    )
-    .await;
+    let result = if shutdown.requested() {
+        Ok(())
+    } else {
+        serve_daemon(
+            engine_url,
+            daemon_namespace,
+            start,
+            managed_engine.as_ref(),
+            engine_policy,
+            shutdown,
+        )
+        .await
+    };
 
     if let Some(engine) = &managed_engine {
         println!("{}", "stopping engine...".dimmed());
@@ -206,6 +217,7 @@ async fn serve_daemon(
     start: Option<std::path::PathBuf>,
     managed_engine: Option<&managed_engine::ManagedEngine>,
     engine_policy: daemon::EnginePolicy,
+    shutdown: shutdown::ShutdownSignal,
 ) -> Result<()> {
     use colored::Colorize;
 
@@ -241,7 +253,14 @@ async fn serve_daemon(
             daemon.shutdown().await;
             return Err(engine_exited(engine, status).await);
         }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let mut interrupted = shutdown.clone();
+        tokio::select! {
+            _ = interrupted.wait() => {
+                daemon.shutdown().await;
+                return Ok(());
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {}
+        }
     }
 
     if let Some(engine) = managed_engine
@@ -279,13 +298,23 @@ async fn serve_daemon(
     if let Some(file) = &start {
         println!();
         let operation_id = uuid::Uuid::new_v4().to_string();
-        let result = daemon.up(Some(file), None, operation_id).await;
+        let result = daemon
+            .up_until_shutdown(Some(file), None, operation_id, shutdown.clone())
+            .await;
         match result {
-            Ok(result) if result.status == lifecycle::OpStatus::Failed => {
+            Ok(None) => {
+                println!(
+                    "{}",
+                    "startup interrupted; stopping every project...".dimmed()
+                );
+                daemon.shutdown().await;
+                return Ok(());
+            }
+            Ok(Some(result)) if result.status == lifecycle::OpStatus::Failed => {
                 daemon.shutdown().await;
                 return Err(ComposeError::ProjectDidNotStart { path: file.clone() });
             }
-            Ok(_) => {}
+            Ok(Some(_)) => {}
             Err(err) => {
                 daemon.shutdown().await;
                 return Err(err);
@@ -295,35 +324,10 @@ async fn serve_daemon(
 
     // Serve until asked to stop, or until the engine refuses this identity.
     //
-    // Both signals matter and for different reasons: an operator presses Ctrl-C
-    // (SIGINT), while every supervisor — systemd, docker, a `kill` in a script
-    // — sends SIGTERM. Handling only the first leaves the children orphaned on
-    // the path that production actually takes.
-    let interrupted = tokio::signal::ctrl_c();
-    tokio::pin!(interrupted);
-    #[cfg(unix)]
-    let mut terminated =
-        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
-            Ok(terminated) => terminated,
-            Err(err) => {
-                daemon.shutdown().await;
-                return Err(ComposeError::SpawnFailed {
-                    container: "<daemon>".to_string(),
-                    message: format!("could not listen for SIGTERM: {err}"),
-                });
-            }
-        };
-
     loop {
-        #[cfg(unix)]
+        let mut interrupted = shutdown.clone();
         let stop = tokio::select! {
-            _ = &mut interrupted => true,
-            _ = terminated.recv() => true,
-            _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => false,
-        };
-        #[cfg(not(unix))]
-        let stop = tokio::select! {
-            _ = &mut interrupted => true,
+            _ = interrupted.wait() => true,
             _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => false,
         };
 

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -108,7 +108,24 @@ pub struct LifecycleCtx<'a> {
 
 /// What one container's start produced: which one, how long it took, and
 /// whether it came up.
-type StartOutcome = (String, Duration, Result<(ChildRecord, Supervised)>);
+type StartOutcome = (String, Duration, StartAttempt);
+
+enum StartAttempt {
+    Ready(ChildRecord, Supervised),
+    Failed(ComposeError),
+    Interrupted,
+}
+
+enum StartFailure {
+    Failed(ComposeError),
+    Interrupted,
+}
+
+impl From<ComposeError> for StartFailure {
+    fn from(error: ComposeError) -> Self {
+        Self::Failed(error)
+    }
+}
 
 /// Environment variable that overrides how many containers may start at once.
 const MAX_PARALLEL_WORKERS_ENV: &str = "III_COMPOSE_MAX_PARALLEL_WORKERS";
@@ -145,12 +162,38 @@ pub async fn up(
     target: Option<&str>,
     operation_id: String,
 ) -> OpResult {
+    up_inner(ctx, children, records, target, operation_id, None)
+        .await
+        .expect("up without a shutdown signal cannot be interrupted")
+}
+
+/// Starts the foreground project's graph, rolling back this operation when an
+/// OS shutdown signal arrives.
+pub(crate) async fn up_until_shutdown(
+    ctx: &LifecycleCtx<'_>,
+    children: &mut Children,
+    records: &mut BTreeMap<String, ChildRecord>,
+    target: Option<&str>,
+    operation_id: String,
+    shutdown: crate::shutdown::ShutdownSignal,
+) -> Option<OpResult> {
+    up_inner(ctx, children, records, target, operation_id, Some(shutdown)).await
+}
+
+async fn up_inner(
+    ctx: &LifecycleCtx<'_>,
+    children: &mut Children,
+    records: &mut BTreeMap<String, ChildRecord>,
+    target: Option<&str>,
+    operation_id: String,
+    shutdown: Option<crate::shutdown::ShutdownSignal>,
+) -> Option<OpResult> {
     let began = Instant::now();
     let order = match plan_targets(ctx.file, target) {
         Ok(order) => order,
         Err(error) => {
             report::summary_failed("up", error.code(), began.elapsed());
-            return failed_op(operation_id, target, &error);
+            return Some(failed_op(operation_id, target, &error));
         }
     };
 
@@ -167,6 +210,12 @@ pub async fn up(
     // in a project of fourteen where one worker calls the other thirteen, the
     // thirteen have nothing to wait for.
     for wave in dag::waves(ctx.file, &order) {
+        if shutdown.as_ref().is_some_and(|signal| signal.requested()) {
+            report::plan_done();
+            rollback(ctx, children, records, &started, &mut results).await;
+            return None;
+        }
+
         let mut starting: Vec<String> = Vec::new();
         for key in &wave {
             if is_running(children, key) {
@@ -189,25 +238,28 @@ pub async fn up(
         // Bounded: a wave may hold every container in the file, and each one
         // can be a download, a process, or a VM. An operator's machine should
         // not have to survive all of them at once.
-        let outcomes: Vec<StartOutcome> =
-            futures::stream::iter(starting.into_iter().map(|key| async move {
+        let outcomes: Vec<StartOutcome> = futures::stream::iter(starting.into_iter().map(|key| {
+            let shutdown = shutdown.clone();
+            async move {
                 let began = Instant::now();
-                let outcome = start_one(ctx, &key).await;
+                let outcome = start_one_attempt(ctx, &key, shutdown).await;
                 (key, began.elapsed(), outcome)
-            }))
-            .buffer_unordered(max_parallel_workers)
-            .collect()
-            .await;
+            }
+        }))
+        .buffer_unordered(max_parallel_workers)
+        .collect()
+        .await;
 
         // The whole wave is awaited before a failure is acted on. Stopping
         // early would leave containers half-started, which is a worse state to
         // describe than one more container that came up and is then rolled
         // back.
         let mut failure: Option<(String, ComposeError)> = None;
+        let mut interrupted = false;
         for (key, took, outcome) in outcomes {
             let key = &key;
             match outcome {
-                Ok((record, child)) => {
+                StartAttempt::Ready(record, child) => {
                     report::ready(key, took);
                     records.insert(key.clone(), record);
                     children.insert(key.clone(), child);
@@ -219,7 +271,7 @@ pub async fn up(
                         error: None,
                     });
                 }
-                Err(error) => {
+                StartAttempt::Failed(error) => {
                     report::failed(
                         key,
                         error.code(),
@@ -235,19 +287,26 @@ pub async fn up(
                         failure = Some((key.clone(), error));
                     }
                 }
+                StartAttempt::Interrupted => interrupted = true,
             }
+        }
+
+        if interrupted {
+            report::plan_done();
+            rollback(ctx, children, records, &started, &mut results).await;
+            return None;
         }
 
         if let Some((_, error)) = failure {
             report::plan_done();
             rollback(ctx, children, records, &started, &mut results).await;
             report::summary_failed("up", error.code(), began.elapsed());
-            return OpResult {
+            return Some(OpResult {
                 operation_id,
                 status: OpStatus::Failed,
                 changed: !started.is_empty(),
                 containers: results,
-            };
+            });
         }
     }
 
@@ -264,12 +323,12 @@ pub async fn up(
     report::plan_done();
     let changed = results.iter().filter(|result| result.changed).count();
     report::summary_ok("up", changed, results.len(), began.elapsed());
-    OpResult {
+    Some(OpResult {
         operation_id,
         status: OpStatus::Ok,
         changed: changed > 0,
         containers: results,
-    }
+    })
 }
 
 /// Drops a leading `container '<name>': ` from a message that is already being
@@ -519,6 +578,46 @@ pub async fn down(
 /// start together and a shared `&mut` would serialise exactly what this exists
 /// to overlap.
 async fn start_one(ctx: &LifecycleCtx<'_>, key: &str) -> Result<(ChildRecord, Supervised)> {
+    match start_one_attempt(ctx, key, None).await {
+        StartAttempt::Ready(record, child) => Ok((record, child)),
+        StartAttempt::Failed(error) => Err(error),
+        StartAttempt::Interrupted => {
+            unreachable!("a start without a shutdown signal cannot be interrupted")
+        }
+    }
+}
+
+async fn start_one_attempt(
+    ctx: &LifecycleCtx<'_>,
+    key: &str,
+    shutdown: Option<crate::shutdown::ShutdownSignal>,
+) -> StartAttempt {
+    match start_one_until_shutdown(ctx, key, shutdown).await {
+        Ok((record, child)) => StartAttempt::Ready(record, child),
+        Err(StartFailure::Failed(error)) => StartAttempt::Failed(error),
+        Err(StartFailure::Interrupted) => StartAttempt::Interrupted,
+    }
+}
+
+async fn start_one_until_shutdown(
+    ctx: &LifecycleCtx<'_>,
+    key: &str,
+    mut shutdown: Option<crate::shutdown::ShutdownSignal>,
+) -> std::result::Result<(ChildRecord, Supervised), StartFailure> {
+    macro_rules! wait_or_interrupt {
+        ($future:expr) => {{
+            if let Some(signal) = shutdown.as_mut() {
+                tokio::select! {
+                    biased;
+                    _ = signal.wait() => return Err(StartFailure::Interrupted),
+                    result = $future => result,
+                }
+            } else {
+                $future.await
+            }
+        }};
+    }
+
     let container = ctx
         .file
         .containers
@@ -532,21 +631,19 @@ async fn start_one(ctx: &LifecycleCtx<'_>, key: &str) -> Result<(ChildRecord, Su
     // the container would be reported ready in milliseconds while the process
     // we started loses the `(namespace, worker_name)` lease and dies rejected.
     // Refuse instead, and say who is holding the name.
-    if ctx.engine.is_registered(ctx.project_namespace, key).await? {
+    if wait_or_interrupt!(ctx.engine.is_registered(ctx.project_namespace, key))? {
         return Err(ComposeError::ContainerNameTaken {
             container: key.to_string(),
             namespace: ctx.project_namespace.to_string(),
-        });
+        }
+        .into());
     }
 
     // Taken here, at the last moment nothing of ours is running yet. Readiness
     // reports differences against it, and a package install below can take
     // seconds — long enough for an unrelated worker to arrive and be mistaken
     // for the child we are about to start.
-    let baseline = ctx
-        .engine
-        .readiness_baseline(ctx.project_namespace, key)
-        .await?;
+    let baseline = wait_or_interrupt!(ctx.engine.readiness_baseline(ctx.project_namespace, key))?;
 
     // A package is fetched here rather than at validation time: resolving it
     // needs the registry, and `validate` is offline by contract.
@@ -554,8 +651,12 @@ async fn start_one(ctx: &LifecycleCtx<'_>, key: &str) -> Result<(ChildRecord, Su
         crate::config::WorkerSource::Package { reference } => {
             let range = container.version.as_deref().unwrap_or("*");
             report::starting(key, &format!("installing {reference}@{range}"));
-            let installed =
-                crate::registry::install(key, reference, range, ctx.package_cache).await?;
+            let installed = wait_or_interrupt!(crate::registry::install(
+                key,
+                reference,
+                range,
+                ctx.package_cache,
+            ))?;
             report::starting(
                 key,
                 &format!("starting {} {}", installed.name, installed.version),
@@ -579,7 +680,7 @@ async fn start_one(ctx: &LifecycleCtx<'_>, key: &str) -> Result<(ChildRecord, Su
     };
 
     let user_env = container.resolve_user_env(key)?;
-    let config = resolve_config(ctx, container, key, shipped_config).await?;
+    let config = wait_or_interrupt!(resolve_config(ctx, container, key, shipped_config))?;
     let worker_dir = container.worker_dir();
     let working_dir = resolve_working_dir(
         container.working_dir.as_deref(),
@@ -603,13 +704,21 @@ async fn start_one(ctx: &LifecycleCtx<'_>, key: &str) -> Result<(ChildRecord, Su
     };
 
     if let Some(script) = &container.scripts.pre_run {
-        hooks::await_pre_run(&spawn_ctx, script, container.scripts.pre_run_timeout)
-            .await
-            .map_err(|err| ComposeError::HookFailed {
-                container: key.to_string(),
-                hook_code: err.code(),
-                message: err.to_string(),
-            })?;
+        let Some(result) = hooks::await_pre_run_until_shutdown(
+            &spawn_ctx,
+            script,
+            container.scripts.pre_run_timeout,
+            shutdown.as_mut(),
+        )
+        .await
+        else {
+            return Err(StartFailure::Interrupted);
+        };
+        result.map_err(|err| ComposeError::HookFailed {
+            container: key.to_string(),
+            hook_code: err.code(),
+            message: err.to_string(),
+        })?;
     }
 
     let plan = spawn_plan(&spawn_ctx);
@@ -618,13 +727,17 @@ async fn start_one(ctx: &LifecycleCtx<'_>, key: &str) -> Result<(ChildRecord, Su
         // A bundle: publisher-controlled code, so it is booted in a VM instead
         // of run here. The handle that comes back is an ordinary child, so
         // readiness, stop, crash cascade and log capture below are unchanged.
-        None => vm_command(ctx, key, &start, &plan, config.as_ref())
-            .await
-            .map_err(|message| ComposeError::SpawnFailed {
+        None => wait_or_interrupt!(vm_command(ctx, key, &start, &plan, config.as_ref())).map_err(
+            |message| ComposeError::SpawnFailed {
                 container: key.to_string(),
                 message,
-            })?,
+            },
+        )?,
     };
+
+    if shutdown.as_ref().is_some_and(|signal| signal.requested()) {
+        return Err(StartFailure::Interrupted);
+    }
 
     let (child, output) =
         spawn_supervised_piped(command).map_err(|err| ComposeError::SpawnFailed {
@@ -635,24 +748,42 @@ async fn start_one(ctx: &LifecycleCtx<'_>, key: &str) -> Result<(ChildRecord, Su
     // starting is exactly what an operator needs when it does not.
     let capture = report::capture_output(key, output.stdout, output.stderr, ctx.log_dir);
 
-    let readiness = ctx
-        .engine
-        .wait_until_ready(
-            ctx.project_namespace,
-            key,
-            &child,
-            container.startup_timeout,
-            &baseline,
-            ctx.log_dir,
-        )
-        .await;
+    let readiness = if let Some(signal) = shutdown.as_mut() {
+        tokio::select! {
+            biased;
+            _ = signal.wait() => {
+                child.stop(ctx.file.stop_timeout).await;
+                fire_post_run(&spawn_ctx, container);
+                return Err(StartFailure::Interrupted);
+            }
+            readiness = ctx.engine.wait_until_ready(
+                ctx.project_namespace,
+                key,
+                &child,
+                container.startup_timeout,
+                &baseline,
+                ctx.log_dir,
+            ) => readiness,
+        }
+    } else {
+        ctx.engine
+            .wait_until_ready(
+                ctx.project_namespace,
+                key,
+                &child,
+                container.startup_timeout,
+                &baseline,
+                ctx.log_dir,
+            )
+            .await
+    };
 
     if let Err(error) = readiness {
         // The child is ours whether or not it registered; it must not outlive
         // the failed attempt.
         child.stop(ctx.file.stop_timeout).await;
         fire_post_run(&spawn_ctx, container);
-        return Err(error);
+        return Err(StartFailure::Failed(error));
     }
 
     // Registered: the engine can hear it now, so its own logging is the record
@@ -767,11 +898,16 @@ struct VmPlan {
 /// Runs `iii-worker __bundle-prepare` and reads the plan back.
 async fn prepare_vm(request: &serde_json::Value) -> std::result::Result<VmPlan, String> {
     let program = worker_binary()?;
-    let mut child = tokio::process::Command::new(&program)
+    let mut command = tokio::process::Command::new(&program);
+    command
         .arg("__bundle-prepare")
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    // `vm_command` is cancellation-safe: dropping this future after a shutdown
+    // signal must not leave its short-lived helper running.
+    command.kill_on_drop(true);
+    let mut child = command
         .spawn()
         .map_err(|err| format!("cannot run {}: {err}", program.display()))?;
 

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -413,6 +413,48 @@ impl Project {
         result
     }
 
+    pub(crate) async fn up_until_shutdown(
+        &self,
+        target: Option<&str>,
+        operation_id: String,
+        shutdown: crate::shutdown::ShutdownSignal,
+    ) -> Option<OpResult> {
+        let config_dir = self.config_dir();
+        let log_dir = self.log_dir();
+        let package_cache = self.package_cache();
+        let vm_dir = self.vm_dir();
+        let mut inner = self.inner.lock().await;
+        let Inner { children, state } = &mut *inner;
+        let file = self.file.read().await;
+
+        let ctx = LifecycleCtx {
+            file: &file,
+            engine: &self.engine,
+            compose_namespace: &self.compose_namespace,
+            project_namespace: &self.project_namespace,
+            engine_url: &self.engine_url,
+            config_dir: &config_dir,
+            log_dir: &log_dir,
+            package_cache: &package_cache,
+            vm_dir: &vm_dir,
+        };
+
+        let result = lifecycle::up_until_shutdown(
+            &ctx,
+            children,
+            &mut state.containers,
+            target,
+            operation_id,
+            shutdown,
+        )
+        .await;
+
+        let snapshot = state.clone();
+        drop(inner);
+        let _ = self.store.save(&snapshot);
+        result
+    }
+
     /// Applies a compose-file edit without dropping supervision of unchanged
     /// containers. Existing containers whose declarations changed are
     /// restarted in place; then the normal idempotent `up` path starts only

--- a/crates/iii-compose/src/shutdown.rs
+++ b/crates/iii-compose/src/shutdown.rs
@@ -1,0 +1,90 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Process shutdown shared by every phase of foreground compose startup.
+
+use tokio::sync::watch;
+
+#[cfg(any(unix, windows))]
+use crate::error::ComposeError;
+use crate::error::Result;
+
+/// A latched signal: once interrupted, every clone observes it immediately.
+#[derive(Clone)]
+pub(crate) struct ShutdownSignal {
+    receiver: watch::Receiver<bool>,
+}
+
+impl ShutdownSignal {
+    /// Installs the OS signal handlers before compose starts any child.
+    pub(crate) fn install() -> Result<Self> {
+        let (sender, receiver) = watch::channel(false);
+
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{SignalKind, signal};
+
+            // `signal` registers with Tokio before returning. A signal cannot
+            // therefore take the default terminate path in the gap before the
+            // listener task gets its first poll.
+            let mut interrupted = signal(SignalKind::interrupt()).map_err(signal_error)?;
+            let mut terminated = signal(SignalKind::terminate()).map_err(signal_error)?;
+            tokio::spawn(async move {
+                tokio::select! {
+                    _ = interrupted.recv() => {}
+                    _ = terminated.recv() => {}
+                }
+                let _ = sender.send(true);
+            });
+        }
+
+        #[cfg(windows)]
+        {
+            // Like the Unix streams, this installs the handler before it
+            // returns, rather than waiting for an async `ctrl_c()` future to
+            // receive its first poll.
+            let mut interrupted = tokio::signal::windows::ctrl_c().map_err(signal_error)?;
+            tokio::spawn(async move {
+                let _ = interrupted.recv().await;
+                let _ = sender.send(true);
+            });
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        tokio::spawn(async move {
+            let _ = tokio::signal::ctrl_c().await;
+            let _ = sender.send(true);
+        });
+
+        Ok(Self { receiver })
+    }
+
+    pub(crate) fn requested(&self) -> bool {
+        *self.receiver.borrow()
+    }
+
+    pub(crate) async fn wait(&mut self) {
+        if self.requested() {
+            return;
+        }
+        while self.receiver.changed().await.is_ok() {
+            if self.requested() {
+                return;
+            }
+        }
+        // The sender lives until it publishes a shutdown request. A closed
+        // channel here only happens while the runtime itself is going away.
+        std::future::pending::<()>().await;
+    }
+}
+
+#[cfg(any(unix, windows))]
+fn signal_error(error: std::io::Error) -> ComposeError {
+    ComposeError::SpawnFailed {
+        container: "<daemon>".to_string(),
+        message: format!("could not listen for shutdown signals: {error}"),
+    }
+}

--- a/engine/tests/compose_managed_engine_e2e.rs
+++ b/engine/tests/compose_managed_engine_e2e.rs
@@ -38,6 +38,47 @@ fn wait_for_port(port: u16, timeout: std::time::Duration) -> bool {
 }
 
 #[cfg(unix)]
+fn wait_for_exit(child: &mut std::process::Child, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if child.try_wait().unwrap().is_some() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    panic!("compose did not exit after the shutdown signal");
+}
+
+#[cfg(unix)]
+fn send_signal(child: &std::process::Child, signal: nix::sys::signal::Signal) {
+    nix::sys::signal::kill(nix::unistd::Pid::from_raw(child.id() as i32), signal).unwrap();
+}
+
+#[cfg(unix)]
+fn write_fixture_worker(
+    script: &std::path::Path,
+    ready: &std::path::Path,
+    stopped: &std::path::Path,
+    test_binary: &std::path::Path,
+) {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::write(
+        script,
+        format!(
+            "#!/bin/sh\nREADY_MARKER={}\nSTOPPED_MARKER={}\nTEST_BINARY={}\nexport READY_MARKER\non_stop() {{\n  kill \"$worker\" 2>/dev/null || true\n  wait \"$worker\" 2>/dev/null || true\n  printf stopped > \"$STOPPED_MARKER\"\n  exit 0\n}}\ntrap on_stop TERM INT\n\"$TEST_BINARY\" --ignored --exact managed_worker_fixture --nocapture &\nworker=$!\nwait \"$worker\"\n",
+            shell_quote(ready),
+            shell_quote(stopped),
+            shell_quote(test_binary),
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(script, std::fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+#[cfg(unix)]
 #[test]
 #[ignore]
 fn managed_worker_fixture() {
@@ -201,6 +242,190 @@ fn compose_without_engine_section_uses_and_preserves_an_external_engine() {
         engine_reachable,
         "external engine stopped accepting connections"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn signal_during_managed_engine_startup_stops_the_engine() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let project = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let probe = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = probe.local_addr().unwrap().port();
+    drop(probe);
+
+    let worker = project.path().join("worker.sh");
+    std::fs::write(&worker, "#!/bin/sh\nwhile :; do sleep 1; done\n").unwrap();
+    std::fs::set_permissions(&worker, std::fs::Permissions::from_mode(0o700)).unwrap();
+    std::fs::write(
+        project.path().join("worker-compose.yaml"),
+        format!(
+            "namespace: managed-test\nengine:\n  url: ws://127.0.0.1:{port}\n  workers:\n    iii-worker-manager:\n      host: 127.0.0.1\n      port: {port}\ncontainers:\n  probe:\n    worker: path://.\n    scripts:\n      run: ./worker.sh\n"
+        ),
+    )
+    .unwrap();
+
+    let generated_config = state.path().join("managed-early-signal/engine-config.yaml");
+    let mut child = iii_bin()
+        .current_dir(project.path())
+        .env("III_COMPOSE_STATE_DIR", state.path())
+        .args(["compose", "--namespace", "managed-early-signal", "--up"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run iii compose --up");
+
+    if !wait_for_file(&generated_config, Duration::from_secs(20)) {
+        send_signal(&child, nix::sys::signal::Signal::SIGTERM);
+        let _ = child.wait();
+        panic!("managed engine config was never created");
+    }
+    send_signal(&child, nix::sys::signal::Signal::SIGINT);
+    wait_for_exit(&mut child, Duration::from_secs(20));
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success(), "compose exited with {output:?}");
+    assert!(
+        !generated_config.exists(),
+        "managed engine config survived shutdown"
+    );
+    TcpListener::bind(("127.0.0.1", port)).expect("managed engine should be stopped");
+}
+
+#[cfg(unix)]
+#[test]
+fn signal_during_dependent_startup_rolls_back_every_started_process() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let project = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let probe = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = probe.local_addr().unwrap().port();
+    drop(probe);
+
+    let test_binary = std::env::current_exe().unwrap();
+    let root_ready = project.path().join("root.ready");
+    let root_stopped = project.path().join("root.stopped");
+    let root_script = project.path().join("root.sh");
+    write_fixture_worker(&root_script, &root_ready, &root_stopped, &test_binary);
+
+    let dependent_started = project.path().join("dependent.started");
+    let dependent_stopped = project.path().join("dependent.stopped");
+    let dependent_pid = project.path().join("dependent.pid");
+    let dependent_script = project.path().join("dependent.sh");
+    std::fs::write(
+        &dependent_script,
+        format!(
+            "#!/bin/sh\nprintf %s \"$$\" > {}\nprintf started > {}\non_stop() {{\n  printf stopped > {}\n  exit 0\n}}\ntrap on_stop TERM INT\nwhile :; do sleep 1; done\n",
+            shell_quote(&dependent_pid),
+            shell_quote(&dependent_started),
+            shell_quote(&dependent_stopped),
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&dependent_script, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+    std::fs::write(
+        project.path().join("worker-compose.yaml"),
+        format!(
+            "namespace: managed-test\nstartup_timeout: 60s\nstop_timeout: 5s\nengine:\n  url: ws://127.0.0.1:{port}\n  workers:\n    iii-worker-manager:\n      host: 127.0.0.1\n      port: {port}\ncontainers:\n  root:\n    worker: path://.\n    scripts:\n      run: ./root.sh\n  dependent:\n    worker: path://.\n    start_after: [root]\n    scripts:\n      run: ./dependent.sh\n"
+        ),
+    )
+    .unwrap();
+
+    let generated_config = state
+        .path()
+        .join("managed-dependent-signal/engine-config.yaml");
+    let mut child = iii_bin()
+        .current_dir(project.path())
+        .env("III_COMPOSE_STATE_DIR", state.path())
+        .args(["compose", "--namespace", "managed-dependent-signal", "--up"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run iii compose --up");
+
+    if !wait_for_file(&dependent_started, Duration::from_secs(30)) {
+        send_signal(&child, nix::sys::signal::Signal::SIGTERM);
+        let _ = child.wait();
+        panic!("dependent worker never entered startup");
+    }
+    let pid: i32 = std::fs::read_to_string(&dependent_pid)
+        .unwrap()
+        .parse()
+        .unwrap();
+    send_signal(&child, nix::sys::signal::Signal::SIGINT);
+    wait_for_exit(&mut child, Duration::from_secs(20));
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success(), "compose exited with {output:?}");
+    assert!(
+        root_stopped.exists(),
+        "ready root worker was not rolled back"
+    );
+    assert!(
+        dependent_stopped.exists(),
+        "starting dependent worker was not stopped"
+    );
+    assert!(
+        nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_err(),
+        "dependent worker process {pid} survived"
+    );
+    assert!(
+        !generated_config.exists(),
+        "managed engine config survived shutdown"
+    );
+    TcpListener::bind(("127.0.0.1", port)).expect("managed engine should be stopped");
+
+    // A clean restart on the same engine address and namespace proves that no
+    // old worker registration or process survived the interrupted attempt.
+    for marker in [
+        &root_ready,
+        &root_stopped,
+        &dependent_started,
+        &dependent_stopped,
+        &dependent_pid,
+    ] {
+        let _ = std::fs::remove_file(marker);
+    }
+    write_fixture_worker(
+        &dependent_script,
+        &dependent_started,
+        &dependent_stopped,
+        &test_binary,
+    );
+
+    let mut restarted = iii_bin()
+        .current_dir(project.path())
+        .env("III_COMPOSE_STATE_DIR", state.path())
+        .args(["compose", "--namespace", "managed-dependent-signal", "--up"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("restart iii compose --up");
+    if !wait_for_file(&dependent_started, Duration::from_secs(30)) {
+        send_signal(&restarted, nix::sys::signal::Signal::SIGTERM);
+        let output = restarted.wait_with_output().unwrap();
+        panic!("dependent worker was not ready after restart: {output:?}");
+    }
+    send_signal(&restarted, nix::sys::signal::Signal::SIGINT);
+    wait_for_exit(&mut restarted, Duration::from_secs(20));
+    let output = restarted.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "compose restart exited with {output:?}"
+    );
+    assert!(root_stopped.exists(), "root worker survived the restart");
+    assert!(
+        dependent_stopped.exists(),
+        "dependent worker survived the restart"
+    );
+    assert!(
+        !generated_config.exists(),
+        "managed engine config survived restart shutdown"
+    );
+    TcpListener::bind(("127.0.0.1", port)).expect("managed engine should be stopped after restart");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- install shutdown signal handlers before starting a managed engine or project workers
- cancel in-progress worker and pre-run hook startup safely, then roll back workers that already became ready
- stop the managed engine and remove its generated config after startup interruption
- add end-to-end coverage for interruption during managed-engine startup and dependent-worker startup, including an immediate clean restart

## Validation

- `cargo test -p iii-compose`
- `cargo test -p iii --test compose_managed_engine_e2e -- --nocapture --test-threads=1`
- `cargo clippy -p iii-compose --all-targets -- -D warnings`

## Notes

`cargo clippy --workspace --all-targets -- -D warnings` still reports unrelated existing warnings in `iii-init`, `iii-shell-client`, and `scaffolder-core`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful shutdown handling during Compose startup and service launch.
  * Interrupting startup now stops in-progress hooks, readiness checks, and preparation tasks.
* **Bug Fixes**
  * Automatically rolls back containers and processes started before shutdown.
  * Cleans up temporary engine configuration and releases reserved ports after interruption.
  * Prevents stale service registrations from affecting subsequent Compose restarts.
* **Reliability**
  * Shutdown signals are captured consistently before child processes begin, enabling cleaner exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->