### PR TITLE
fix(compose): clean up failed startup processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2814,6 +2814,7 @@ dependencies = [
  "tokio",
  "uuid",
  "windows-sys 0.60.2",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/iii-compose/Cargo.toml
+++ b/crates/iii-compose/Cargo.toml
@@ -67,3 +67,4 @@ windows-sys = { version = "0.60", features = [
 [dev-dependencies]
 tempfile = { workspace = true }
 jsonschema = { version = "0.30", default-features = false }
+wiremock = { workspace = true }

--- a/crates/iii-compose/src/hooks.rs
+++ b/crates/iii-compose/src/hooks.rs
@@ -8,8 +8,9 @@
 //!
 //! `pre_run` blocks the container's start and is budgeted: a hung migration
 //! must fail the container instead of holding the whole graph. `post_run` fires
-//! after the container's exit is confirmed and is never awaited — a cleanup
-//! script that hangs cannot be allowed to hold up a teardown.
+//! after the container's exit is confirmed and is not awaited by teardown. A
+//! project supervisor still owns it, so shutdown and timeout both kill and
+//! reap a cleanup script that hangs.
 //!
 //! Both run with the same environment and working directory as the container
 //! itself, and both get their own process group so a timeout can take their
@@ -19,6 +20,7 @@ use std::{process::Stdio, time::Duration};
 
 use colored::Colorize;
 use tokio::io::AsyncReadExt;
+use tokio::sync::{Mutex, watch};
 
 use crate::{
     manifest::StartSpec,
@@ -51,6 +53,125 @@ impl HookError {
             Self::Spawn { .. } => "HOOK_SPAWN_FAILED",
             Self::Failed { .. } => "HOOK_FAILED",
             Self::Timeout { .. } => "HOOK_TIMEOUT",
+        }
+    }
+}
+
+/// Owns every detached `post_run` task for one project.
+///
+/// Teardown does not wait for a cleanup hook, but project shutdown does. This
+/// keeps a short hook asynchronous without letting a hung hook outlive the
+/// compose process.
+#[derive(Default)]
+pub struct PostRunSupervisor {
+    state: Mutex<PostRunState>,
+    shutdown: watch::Sender<bool>,
+}
+
+#[derive(Default)]
+struct PostRunState {
+    shutting_down: bool,
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl PostRunSupervisor {
+    /// Starts one bounded cleanup hook and returns as soon as it is supervised.
+    pub async fn fire(&self, ctx: &SpawnCtx<'_>, script: &str, timeout: Duration) {
+        const HOOK: &str = "post_run";
+
+        let mut state = self.state.lock().await;
+        state.tasks.retain(|task| !task.is_finished());
+        if state.shutting_down {
+            return;
+        }
+
+        let container = ctx.container_key.to_string();
+        let mut hook = match spawn_hook(ctx, script) {
+            Ok(hook) => hook,
+            Err(err) => {
+                report::line(&format!(
+                    "{} {}",
+                    format!("[{HOOK}:{container}]").dimmed(),
+                    format!("could not start: {err}").red()
+                ));
+                return;
+            }
+        };
+        let mut shutdown = self.shutdown.subscribe();
+
+        state.tasks.push(tokio::spawn(async move {
+            let child = &mut hook.child;
+            let mut stdout = child.stdout.take();
+            let mut stderr = child.stderr.take();
+            let run = async {
+                let (status, out, err) =
+                    tokio::join!(child.wait(), read_all(&mut stdout), read_all(&mut stderr));
+                (status, out, err)
+            };
+
+            enum PostRunOutcome {
+                Finished((std::io::Result<std::process::ExitStatus>, String, String)),
+                TimedOut,
+                ShuttingDown,
+            }
+
+            let outcome = {
+                tokio::pin!(run);
+                let timer = tokio::time::sleep(timeout);
+                tokio::pin!(timer);
+                tokio::select! {
+                    biased;
+                    _ = shutdown.changed() => PostRunOutcome::ShuttingDown,
+                    result = &mut run => PostRunOutcome::Finished(result),
+                    _ = &mut timer => PostRunOutcome::TimedOut,
+                }
+            };
+
+            match outcome {
+                PostRunOutcome::Finished((status, out, err)) => {
+                    log_output(HOOK, &container, &out, &err);
+                    match status {
+                        Ok(status) if status.success() => {}
+                        Ok(status) => report::line(&format!(
+                            "{} {}",
+                            format!("[{HOOK}:{container}]").dimmed(),
+                            format!("exited with {}", status.code().unwrap_or(-1)).yellow()
+                        )),
+                        Err(err) => report::line(&format!(
+                            "{} {}",
+                            format!("[{HOOK}:{container}]").dimmed(),
+                            format!("could not be waited on: {err}").yellow()
+                        )),
+                    }
+                }
+                PostRunOutcome::TimedOut => {
+                    hook.kill_tree();
+                    let _ = hook.child.wait().await;
+                    report::line(&format!(
+                        "{} {}",
+                        format!("[{HOOK}:{container}]").dimmed(),
+                        format!("timed out after {}s", timeout.as_secs_f64()).yellow()
+                    ));
+                }
+                PostRunOutcome::ShuttingDown => {
+                    hook.kill_tree();
+                    let _ = hook.child.wait().await;
+                }
+            }
+        }));
+    }
+
+    /// Stops and reaps every cleanup hook that is still active.
+    pub async fn shutdown(&self) {
+        let tasks = {
+            let mut state = self.state.lock().await;
+            state.shutting_down = true;
+            self.shutdown.send_replace(true);
+            std::mem::take(&mut state.tasks)
+        };
+
+        for task in tasks {
+            let _ = task.await;
         }
     }
 }
@@ -152,47 +273,6 @@ pub(crate) async fn await_pre_run_until_shutdown(
     }
 }
 
-/// Fires `post_run` and returns immediately. Its outcome is logged; a failing
-/// cleanup script never turns into an error the caller has to handle.
-pub fn fire_post_run(ctx: &SpawnCtx<'_>, script: &str) {
-    const HOOK: &str = "post_run";
-
-    let container = ctx.container_key.to_string();
-    let mut hook = match spawn_hook(ctx, script) {
-        Ok(hook) => hook,
-        Err(err) => {
-            report::line(&format!(
-                "{} {}",
-                format!("[{HOOK}:{container}]").dimmed(),
-                format!("could not start: {err}").red()
-            ));
-            return;
-        }
-    };
-
-    tokio::spawn(async move {
-        let child = &mut hook.child;
-        let mut stdout = child.stdout.take();
-        let mut stderr = child.stderr.take();
-        let (status, out, err) =
-            tokio::join!(child.wait(), read_all(&mut stdout), read_all(&mut stderr));
-        log_output(HOOK, &container, &out, &err);
-        match status {
-            Ok(status) if status.success() => {}
-            Ok(status) => report::line(&format!(
-                "{} {}",
-                format!("[{HOOK}:{container}]").dimmed(),
-                format!("exited with {}", status.code().unwrap_or(-1)).yellow()
-            )),
-            Err(err) => report::line(&format!(
-                "{} {}",
-                format!("[{HOOK}:{container}]").dimmed(),
-                format!("could not be waited on: {err}").yellow()
-            )),
-        }
-    });
-}
-
 /// A hook process plus whatever the platform needs to take its descendants
 /// down: a process group on unix, a job object on windows.
 struct HookProcess {
@@ -215,6 +295,14 @@ impl HookProcess {
                 let _ = self.child.start_kill();
             }
         }
+    }
+}
+
+impl Drop for HookProcess {
+    fn drop(&mut self) {
+        // Last-resort cleanup for an abrupt runtime drop. Normal timeout and
+        // project shutdown kill and wait before this point.
+        self.kill_tree();
     }
 }
 

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -88,6 +88,7 @@ impl From<&ComposeError> for OpError {
 pub struct LifecycleCtx<'a> {
     pub file: &'a ComposeFile,
     pub engine: &'a EngineClient,
+    pub post_runs: &'a hooks::PostRunSupervisor,
     /// Namespace of the compose daemon that owns this project. Children use
     /// it for explicit per-call routing to `compose::*`.
     pub compose_namespace: &'a str,
@@ -753,7 +754,7 @@ async fn start_one_until_shutdown(
             biased;
             _ = signal.wait() => {
                 child.stop(ctx.file.stop_timeout).await;
-                fire_post_run(&spawn_ctx, container);
+                fire_post_run(ctx, &spawn_ctx, container).await;
                 return Err(StartFailure::Interrupted);
             }
             readiness = ctx.engine.wait_until_ready(
@@ -782,7 +783,7 @@ async fn start_one_until_shutdown(
         // The child is ours whether or not it registered; it must not outlive
         // the failed attempt.
         child.stop(ctx.file.stop_timeout).await;
-        fire_post_run(&spawn_ctx, container);
+        fire_post_run(ctx, &spawn_ctx, container).await;
         return Err(StartFailure::Failed(error));
     }
 
@@ -1026,7 +1027,7 @@ async fn stop_one(
             working_dir: &working_dir,
             user_env: &user_env,
         };
-        fire_post_run(&spawn_ctx, container);
+        fire_post_run(ctx, &spawn_ctx, container).await;
     }
 
     if let Some(record) = records.get_mut(key) {
@@ -1124,9 +1125,11 @@ async fn resolve_config(
     }))
 }
 
-fn fire_post_run(spawn_ctx: &SpawnCtx<'_>, container: &Container) {
+async fn fire_post_run(ctx: &LifecycleCtx<'_>, spawn_ctx: &SpawnCtx<'_>, container: &Container) {
     if let Some(script) = &container.scripts.post_run {
-        hooks::fire_post_run(spawn_ctx, script);
+        ctx.post_runs
+            .fire(spawn_ctx, script, ctx.file.stop_timeout)
+            .await;
     }
 }
 

--- a/crates/iii-compose/src/managed_engine.rs
+++ b/crates/iii-compose/src/managed_engine.rs
@@ -60,10 +60,27 @@ impl ManagedEngine {
                 })??;
         let config_path = materialize_engine_config(spec, &namespace_dir)?;
         let log_path = engine_log_path(&state_root, daemon_namespace);
-        let mut engine = Self::spawn_with_paths(&executable, &config_path, &log_path).await?;
-        engine.remove_config_on_stop = true;
+        let mut engine =
+            Self::spawn_with_materialized_config(&executable, &config_path, &log_path).await?;
         engine._namespace_lock = Some(namespace_lock);
         Ok(engine)
+    }
+
+    async fn spawn_with_materialized_config(
+        executable: &Path,
+        config_path: &Path,
+        log_path: &Path,
+    ) -> Result<Self> {
+        match Self::spawn_with_paths(executable, config_path, log_path).await {
+            Ok(mut engine) => {
+                engine.remove_config_on_stop = true;
+                Ok(engine)
+            }
+            Err(error) => {
+                let _ = std::fs::remove_file(config_path);
+                Err(error)
+            }
+        }
     }
 
     async fn spawn_with_paths(
@@ -985,6 +1002,30 @@ containers: {}
         assert!(
             !output.contains('\u{1b}') && !output.contains("forged title"),
             "terminal escape sequence was persisted in {output:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_start_removes_the_materialized_engine_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("fake-iii");
+        let namespace_dir = dir.path().join("daemon");
+        let config = materialize_engine_config(&engine_spec(), &namespace_dir).unwrap();
+        let log = namespace_dir.join("engine.log");
+        write_executable(&script, "#!/bin/sh\nexit 0\n");
+        std::fs::create_dir(&log).unwrap();
+
+        let error =
+            match ManagedEngine::spawn_with_materialized_config(&script, &config, &log).await {
+                Ok(_) => panic!("a directory cannot be opened as the engine log"),
+                Err(error) => error,
+            };
+
+        assert_eq!(error.code(), "IO_ERROR");
+        assert!(
+            !config.exists(),
+            "a failed managed-engine start left its generated config behind"
         );
     }
 

--- a/crates/iii-compose/src/process/windows.rs
+++ b/crates/iii-compose/src/process/windows.rs
@@ -124,15 +124,21 @@ fn spawn_supervised_inner(
         // Without a job there is no way to guarantee the worker's own children
         // come down with it, so refuse to supervise half-blind.
         let err = std::io::Error::last_os_error();
-        let _ = child.start_kill();
+        kill_and_reap(child);
         return Err(err);
     }
     let job = OwnedHandle(job);
 
-    if let Some(handle) = child.raw_handle() {
-        // A failed assignment leaves the child running outside the job: it can
-        // still be stopped by pid, only its descendants are not guaranteed.
-        unsafe { AssignProcessToJobObject(job.0, handle as HANDLE) };
+    let Some(handle) = child.raw_handle() else {
+        kill_and_reap(child);
+        return Err(std::io::Error::other(
+            "child handle disappeared before job assignment",
+        ));
+    };
+    if unsafe { AssignProcessToJobObject(job.0, handle as HANDLE) } == 0 {
+        let err = std::io::Error::last_os_error();
+        kill_and_reap(child);
+        return Err(err);
     }
 
     let (tx, exit) = watch::channel(None);
@@ -150,6 +156,15 @@ fn spawn_supervised_inner(
         },
         output,
     ))
+}
+
+/// Ends a child that could not be placed under supervision, then keeps its
+/// handle alive until the OS reports the exit.
+fn kill_and_reap(mut child: tokio::process::Child) {
+    let _ = child.start_kill();
+    tokio::spawn(async move {
+        let _ = child.wait().await;
+    });
 }
 
 impl Supervised {

--- a/crates/iii-compose/src/process/windows.rs
+++ b/crates/iii-compose/src/process/windows.rs
@@ -124,21 +124,17 @@ fn spawn_supervised_inner(
         // Without a job there is no way to guarantee the worker's own children
         // come down with it, so refuse to supervise half-blind.
         let err = std::io::Error::last_os_error();
-        kill_and_reap(child);
-        return Err(err);
+        return Err(kill_and_reap(child, err));
     }
     let job = OwnedHandle(job);
 
     let Some(handle) = child.raw_handle() else {
-        kill_and_reap(child);
-        return Err(std::io::Error::other(
-            "child handle disappeared before job assignment",
-        ));
+        let err = std::io::Error::other("child handle disappeared before job assignment");
+        return Err(kill_and_reap(child, err));
     };
     if unsafe { AssignProcessToJobObject(job.0, handle as HANDLE) } == 0 {
         let err = std::io::Error::last_os_error();
-        kill_and_reap(child);
-        return Err(err);
+        return Err(kill_and_reap(child, err));
     }
 
     let (tx, exit) = watch::channel(None);
@@ -159,12 +155,44 @@ fn spawn_supervised_inner(
 }
 
 /// Ends a child that could not be placed under supervision, then keeps its
-/// handle alive until the OS reports the exit.
-fn kill_and_reap(mut child: tokio::process::Child) {
-    let _ = child.start_kill();
-    tokio::spawn(async move {
-        let _ = child.wait().await;
+/// handle alive until the OS reports the exit. Cleanup failures are added to
+/// the setup error returned to the caller.
+fn kill_and_reap(mut child: tokio::process::Child, setup_error: std::io::Error) -> std::io::Error {
+    let pid = child.id();
+    let termination = child.start_kill().or_else(|start_error| {
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            return Ok(());
+        }
+
+        let handle = child.raw_handle().ok_or_else(|| {
+            std::io::Error::other(format!(
+                "start_kill failed ({start_error}) and the child handle is unavailable"
+            ))
+        })?;
+        if unsafe { TerminateProcess(handle as HANDLE, 1) } == 0 {
+            let fallback_error = std::io::Error::last_os_error();
+            return Err(std::io::Error::other(format!(
+                "start_kill failed ({start_error}); TerminateProcess also failed ({fallback_error})"
+            )));
+        }
+        Ok(())
     });
+
+    tokio::spawn(async move {
+        if let Err(error) = child.wait().await {
+            crate::report::line(&format!(
+                "[compose] could not reap process {} after supervision setup failed: {error}",
+                pid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
+            ));
+        }
+    });
+
+    match termination {
+        Ok(()) => setup_error,
+        Err(cleanup_error) => std::io::Error::other(format!(
+            "{setup_error}; failed to terminate the unsupervised child: {cleanup_error}"
+        )),
+    }
 }
 
 impl Supervised {

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -52,6 +52,7 @@ pub struct Project {
     /// Shared with every other project on this daemon: one socket, many
     /// projects.
     engine: Arc<EngineClient>,
+    post_runs: crate::hooks::PostRunSupervisor,
     store: StateStore,
     inner: Mutex<Inner>,
 }
@@ -103,6 +104,7 @@ impl Project {
             project_namespace,
             engine_url,
             engine,
+            post_runs: crate::hooks::PostRunSupervisor::default(),
             store,
             inner: Mutex::new(Inner {
                 children: BTreeMap::new(),
@@ -395,6 +397,7 @@ impl Project {
         let ctx = LifecycleCtx {
             file: &file,
             engine: &self.engine,
+            post_runs: &self.post_runs,
             compose_namespace: &self.compose_namespace,
             project_namespace: &self.project_namespace,
             engine_url: &self.engine_url,
@@ -430,6 +433,7 @@ impl Project {
         let ctx = LifecycleCtx {
             file: &file,
             engine: &self.engine,
+            post_runs: &self.post_runs,
             compose_namespace: &self.compose_namespace,
             project_namespace: &self.project_namespace,
             engine_url: &self.engine_url,
@@ -480,6 +484,7 @@ impl Project {
         let ctx = LifecycleCtx {
             file: &file,
             engine: &self.engine,
+            post_runs: &self.post_runs,
             compose_namespace: &self.compose_namespace,
             project_namespace: &self.project_namespace,
             engine_url: &self.engine_url,
@@ -542,6 +547,7 @@ impl Project {
             let ctx = LifecycleCtx {
                 file: &current,
                 engine: &self.engine,
+                post_runs: &self.post_runs,
                 compose_namespace: &self.compose_namespace,
                 project_namespace: &self.project_namespace,
                 engine_url: &self.engine_url,
@@ -568,6 +574,7 @@ impl Project {
         let ctx = LifecycleCtx {
             file: &file,
             engine: &self.engine,
+            post_runs: &self.post_runs,
             compose_namespace: &self.compose_namespace,
             project_namespace: &self.project_namespace,
             engine_url: &self.engine_url,
@@ -606,6 +613,7 @@ impl Project {
         let ctx = LifecycleCtx {
             file: &file,
             engine: &self.engine,
+            post_runs: &self.post_runs,
             compose_namespace: &self.compose_namespace,
             project_namespace: &self.project_namespace,
             engine_url: &self.engine_url,
@@ -636,6 +644,7 @@ impl Project {
         let ctx = LifecycleCtx {
             file: &file,
             engine: &self.engine,
+            post_runs: &self.post_runs,
             compose_namespace: &self.compose_namespace,
             project_namespace: &self.project_namespace,
             engine_url: &self.engine_url,
@@ -709,6 +718,7 @@ impl Project {
         inner.children.clear();
         drop(inner);
 
+        self.post_runs.shutdown().await;
         self.engine.shutdown().await;
     }
 
@@ -717,6 +727,7 @@ impl Project {
     pub async fn shutdown(&self) {
         let operation_id = "shutdown".to_string();
         self.down(None, operation_id).await;
+        self.post_runs.shutdown().await;
         let _ = self.store.clear();
         self.engine.shutdown().await;
     }

--- a/crates/iii-compose/src/registry.rs
+++ b/crates/iii-compose/src/registry.rs
@@ -19,7 +19,10 @@
 //!    artefact's whole identity, so a second `up` reuses the first one's work
 //!    and two projects on one machine share it.
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -33,13 +36,17 @@ pub const DEFAULT_REGISTRY: &str = "https://api.workers.iii.dev";
 /// there rather than in the compose file.
 pub const BUNDLE_MANIFEST: &str = "iii.worker.yaml";
 
-/// How long the registry has to answer. Resolution is a single small request;
-/// a minute means something is wrong, not slow.
-const RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+/// Registry resolution is small and idempotent. A short transport outage or
+/// overloaded server should not roll back an otherwise healthy project.
+const RESOLVE_ATTEMPTS: usize = 3;
+/// Three attempts keep the whole operation near the original one-minute
+/// budget, instead of multiplying that budget for every retry.
+const RESOLVE_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(20);
+const RESOLVE_RETRY_DELAY: Duration = Duration::from_millis(250);
 
 /// Downloads get their own budget: an artefact is megabytes over a link we do
 /// not control.
-const DOWNLOAD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// What the registry answers to `POST /resolve`.
 #[derive(Debug, Deserialize)]
@@ -350,18 +357,17 @@ async fn resolve_response(
     target: &str,
 ) -> Result<ResolveResponse> {
     let client = reqwest::Client::builder()
-        .timeout(RESOLVE_TIMEOUT)
+        .timeout(RESOLVE_ATTEMPT_TIMEOUT)
         .build()
         .map_err(|err| registry_error(container, registry, &err.to_string()))?;
 
-    let response = client
-        .post(format!("{registry}/resolve"))
-        .json(&serde_json::json!({
-            "worker": name,
-            "version": version_range,
-            "target": target,
-        }))
-        .send()
+    let endpoint = format!("{registry}/resolve");
+    let request = serde_json::json!({
+        "worker": name,
+        "version": version_range,
+        "target": target,
+    });
+    let response = send_resolve_request(&client, &endpoint, &request)
         .await
         .map_err(|err| registry_error(container, registry, &err.to_string()))?;
 
@@ -383,6 +389,33 @@ async fn resolve_response(
 
     check_names(container, registry, &resolved)?;
     Ok(resolved)
+}
+
+async fn send_resolve_request(
+    client: &reqwest::Client,
+    endpoint: &str,
+    request: &serde_json::Value,
+) -> std::result::Result<reqwest::Response, reqwest::Error> {
+    for attempt in 1..RESOLVE_ATTEMPTS {
+        let result = client.post(endpoint).json(request).send().await;
+        let should_retry = match &result {
+            Err(_) => true,
+            Ok(response) => {
+                let status = response.status();
+                status.is_server_error()
+                    || status == reqwest::StatusCode::REQUEST_TIMEOUT
+                    || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+            }
+        };
+
+        if !should_retry {
+            return result;
+        }
+
+        tokio::time::sleep(RESOLVE_RETRY_DELAY * attempt as u32).await;
+    }
+
+    client.post(endpoint).json(request).send().await
 }
 
 /// Whether a value from the registry may be used to build a path.
@@ -654,13 +687,82 @@ fn download_error(container: &str, url: &str, message: &str) -> ComposeError {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
     use super::*;
+    use wiremock::{Mock, MockServer, ResponseTemplate, matchers};
 
     #[test]
     fn a_reference_without_a_host_uses_the_default_registry() {
         let (registry, name) = split_reference("state");
         assert_eq!(registry, DEFAULT_REGISTRY);
         assert_eq!(name, "state");
+    }
+
+    #[tokio::test]
+    async fn resolve_retries_a_transient_server_failure() {
+        let server = MockServer::start().await;
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let responder_attempts = Arc::clone(&attempts);
+        Mock::given(matchers::method("POST"))
+            .and(matchers::path("/resolve"))
+            .respond_with(move |_: &wiremock::Request| {
+                if responder_attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    ResponseTemplate::new(503)
+                } else {
+                    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                        "graph": [{
+                            "name": "state",
+                            "version": "1.0.0",
+                            "type": "binary",
+                            "binaries": {}
+                        }]
+                    }))
+                }
+            })
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let resolved = resolve_response(
+            "state",
+            &server.uri(),
+            "state",
+            "1.0.0",
+            "x86_64-unknown-linux-gnu",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resolved.graph[0].name, "state");
+    }
+
+    #[tokio::test]
+    async fn resolve_does_not_retry_a_client_error() {
+        let server = MockServer::start().await;
+        Mock::given(matchers::method("POST"))
+            .and(matchers::path("/resolve"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "error": {"message": "version does not exist"}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let error = resolve_response(
+            "state",
+            &server.uri(),
+            "state",
+            "99.0.0",
+            "x86_64-unknown-linux-gnu",
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.code(), "PACKAGE_NOT_RESOLVED");
     }
 
     #[test]

--- a/crates/iii-compose/tests/cli.rs
+++ b/crates/iii-compose/tests/cli.rs
@@ -185,6 +185,34 @@ fn up_names_the_file_in_the_current_directory() {
 }
 
 #[test]
+fn production_docker_compose_command_matches_the_cli() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("engine/docker-compose.prod.yml");
+    let text = std::fs::read_to_string(&path).unwrap();
+    let document: serde_yaml::Value = serde_yaml::from_str(&text).unwrap();
+    let command = document["services"]["iii"]["command"]
+        .as_sequence()
+        .unwrap();
+    let args = std::iter::once("iii".to_string())
+        .chain(command.iter().map(|arg| arg.as_str().unwrap().to_string()))
+        .collect::<Vec<_>>();
+
+    let Wrapper::Compose(cli) = Wrapper::try_parse_from(args).unwrap();
+    let ComposeCommand::Serve {
+        explicit_daemon_namespace,
+        start,
+        ..
+    } = cli.plan().unwrap();
+
+    assert_eq!(explicit_daemon_namespace.as_deref(), Some("production"));
+    assert_eq!(
+        start.as_deref(),
+        Some(std::path::Path::new("/app/worker-compose.yaml"))
+    );
+}
+
+#[test]
 fn up_without_a_cli_namespace_defers_to_the_compose_file() {
     let ComposeCommand::Serve {
         explicit_daemon_namespace,

--- a/crates/iii-compose/tests/hooks.rs
+++ b/crates/iii-compose/tests/hooks.rs
@@ -5,7 +5,7 @@
 use std::{path::Path, time::Duration};
 
 use iii_compose::{
-    hooks::{await_pre_run, fire_post_run},
+    hooks::{PostRunSupervisor, await_pre_run},
     manifest::StartSpec,
     spawn::SpawnCtx,
 };
@@ -116,11 +116,15 @@ async fn post_run_fires_without_being_awaited() {
     let tmp = tempfile::tempdir().unwrap();
     let marker = tmp.path().join("drained.txt");
     let start = IDLE;
+    let post_runs = PostRunSupervisor::default();
 
-    fire_post_run(
-        &ctx(tmp.path(), &start, None),
-        &format!("sleep 0.1; echo $III_WORKER_NAME > {}", marker.display()),
-    );
+    post_runs
+        .fire(
+            &ctx(tmp.path(), &start, None),
+            &format!("sleep 0.1; echo $III_WORKER_NAME > {}", marker.display()),
+            Duration::from_secs(5),
+        )
+        .await;
 
     assert!(
         !marker.exists(),
@@ -133,9 +137,74 @@ async fn post_run_fires_without_being_awaited() {
 async fn a_failing_post_run_is_not_an_error() {
     let tmp = tempfile::tempdir().unwrap();
     let start = IDLE;
+    let post_runs = PostRunSupervisor::default();
 
     // Nothing to assert beyond "this returns and does not panic": a broken
     // cleanup script must never propagate into teardown.
-    fire_post_run(&ctx(tmp.path(), &start, None), "exit 9");
+    post_runs
+        .fire(
+            &ctx(tmp.path(), &start, None),
+            "exit 9",
+            Duration::from_secs(5),
+        )
+        .await;
     tokio::time::sleep(Duration::from_millis(200)).await;
+}
+
+#[tokio::test]
+async fn shutdown_stops_and_reaps_a_running_post_run() {
+    let tmp = tempfile::tempdir().unwrap();
+    let pid_file = tmp.path().join("post-run.pid");
+    let start = IDLE;
+    let post_runs = PostRunSupervisor::default();
+
+    post_runs
+        .fire(
+            &ctx(tmp.path(), &start, None),
+            &format!("echo $$ > {}; sleep 999", pid_file.display()),
+            Duration::from_secs(30),
+        )
+        .await;
+    let hook_pid = wait_for_file(&pid_file)
+        .await
+        .trim()
+        .parse::<u32>()
+        .unwrap();
+
+    post_runs.shutdown().await;
+
+    assert!(
+        !is_alive(hook_pid),
+        "post_run process {hook_pid} survived project shutdown"
+    );
+}
+
+#[tokio::test]
+async fn a_hung_post_run_times_out_and_leaves_nothing_running() {
+    let tmp = tempfile::tempdir().unwrap();
+    let pid_file = tmp.path().join("post-run.pid");
+    let start = IDLE;
+    let post_runs = PostRunSupervisor::default();
+
+    post_runs
+        .fire(
+            &ctx(tmp.path(), &start, None),
+            &format!("echo $$ > {}; sleep 999", pid_file.display()),
+            Duration::from_millis(400),
+        )
+        .await;
+    let hook_pid = wait_for_file(&pid_file)
+        .await
+        .trim()
+        .parse::<u32>()
+        .unwrap();
+
+    for _ in 0..100 {
+        if !is_alive(hook_pid) {
+            post_runs.shutdown().await;
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("post_run process {hook_pid} survived its timeout");
 }

--- a/crates/iii-compose/tests/start_script.rs
+++ b/crates/iii-compose/tests/start_script.rs
@@ -1,0 +1,65 @@
+//! Failure cleanup for the CI engine launcher.
+
+#![cfg(unix)]
+
+use std::{path::Path, process::Command};
+
+fn write_executable(path: &Path, contents: &str) {
+    use std::{io::Write as _, os::unix::fs::PermissionsExt};
+
+    let mut file = std::fs::File::create(path).unwrap();
+    file.write_all(contents.as_bytes()).unwrap();
+    drop(file);
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+#[test]
+fn timeout_stops_the_started_process_and_removes_its_pid_file() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let start_script = root.join("scripts/start-iii.sh");
+    let tmp = tempfile::tempdir().unwrap();
+    let binary = tmp.path().join("fake-iii");
+    let config = tmp.path().join("worker-compose.yaml");
+    let pid_file = tmp.path().join("launcher.pid");
+    let child_pid_file = tmp.path().join("child.pid");
+    let stopped_file = tmp.path().join("stopped");
+    let log_file = tmp.path().join("engine.log");
+
+    write_executable(
+        &binary,
+        "#!/bin/sh\ntrap 'printf stopped > \"$FAKE_STOP_FILE\"; exit 0' TERM INT\nprintf '%s' \"$$\" > \"$FAKE_PID_FILE\"\nwhile :; do sleep 1; done\n",
+    );
+    std::fs::write(&config, "engine: { workers: {} }\ncontainers: {}\n").unwrap();
+
+    let status = Command::new("bash")
+        .arg(start_script)
+        .args(["--binary", binary.to_str().unwrap()])
+        .args(["--config", config.to_str().unwrap()])
+        .args(["--port", "65500"])
+        .args(["--pid-file", pid_file.to_str().unwrap()])
+        .args(["--log-file", log_file.to_str().unwrap()])
+        .args(["--timeout", "1"])
+        .env("FAKE_PID_FILE", &child_pid_file)
+        .env("FAKE_STOP_FILE", &stopped_file)
+        .status()
+        .unwrap();
+
+    assert!(!status.success(), "the fake engine never becomes ready");
+    assert!(
+        stopped_file.exists(),
+        "the timeout did not terminate the started process"
+    );
+    assert!(
+        !pid_file.exists(),
+        "the timeout left a stale launcher pid file"
+    );
+
+    let child_pid = std::fs::read_to_string(child_pid_file)
+        .unwrap()
+        .parse::<i32>()
+        .unwrap();
+    assert!(
+        nix::sys::signal::kill(nix::unistd::Pid::from_raw(child_pid), None).is_err(),
+        "started process {child_pid} survived the timeout"
+    );
+}

--- a/crates/iii-compose/tests/start_script.rs
+++ b/crates/iii-compose/tests/start_script.rs
@@ -63,3 +63,49 @@ fn timeout_stops_the_started_process_and_removes_its_pid_file() {
         "started process {child_pid} survived the timeout"
     );
 }
+
+#[test]
+fn timeout_force_kills_a_process_that_ignores_sigterm() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let start_script = root.join("scripts/start-iii.sh");
+    let tmp = tempfile::tempdir().unwrap();
+    let binary = tmp.path().join("stubborn-iii");
+    let config = tmp.path().join("worker-compose.yaml");
+    let pid_file = tmp.path().join("launcher.pid");
+    let child_pid_file = tmp.path().join("child.pid");
+    let log_file = tmp.path().join("engine.log");
+
+    write_executable(
+        &binary,
+        "#!/usr/bin/env bash\ntrap '' TERM\nprintf '%s' \"$$\" > \"$FAKE_PID_FILE\"\nwhile :; do :; done\n",
+    );
+    std::fs::write(&config, "engine: { workers: {} }\ncontainers: {}\n").unwrap();
+
+    let status = Command::new("bash")
+        .arg(start_script)
+        .args(["--binary", binary.to_str().unwrap()])
+        .args(["--config", config.to_str().unwrap()])
+        .args(["--port", "65500"])
+        .args(["--pid-file", pid_file.to_str().unwrap()])
+        .args(["--log-file", log_file.to_str().unwrap()])
+        .args(["--timeout", "1"])
+        .env("FAKE_PID_FILE", &child_pid_file)
+        .env("III_START_CLEANUP_GRACE_SECONDS", "1")
+        .status()
+        .unwrap();
+
+    assert!(!status.success(), "the fake engine never becomes ready");
+    assert!(
+        !pid_file.exists(),
+        "forced cleanup left a stale launcher pid file"
+    );
+
+    let child_pid = std::fs::read_to_string(child_pid_file)
+        .unwrap()
+        .parse::<i32>()
+        .unwrap();
+    assert!(
+        nix::sys::signal::kill(nix::unistd::Pid::from_raw(child_pid), None).is_err(),
+        "SIGTERM-ignoring process {child_pid} survived SIGKILL escalation"
+    );
+}

--- a/engine/docker-compose.prod.yml
+++ b/engine/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
       - compose
       - --namespace
       - production
-      - up
+      - --up
       - --file
       - /app/worker-compose.yaml
     environment:

--- a/scripts/start-iii.sh
+++ b/scripts/start-iii.sh
@@ -7,6 +7,7 @@ PORT=""
 PID_FILE="/tmp/iii-engine.pid"
 LOG_FILE="/tmp/iii-engine.log"
 TIMEOUT=60
+CLEANUP_GRACE_SECONDS="${III_START_CLEANUP_GRACE_SECONDS:-15}"
 COMPOSE_FILE=""
 COMPOSE_NAMESPACE=""
 ENGINE_URL=""
@@ -86,6 +87,15 @@ cleanup_failed_start() {
 
   if kill -0 "$started_pid" 2>/dev/null; then
     kill "$started_pid" 2>/dev/null || true
+  fi
+  for _ in $(seq 1 "$CLEANUP_GRACE_SECONDS"); do
+    if ! kill -0 "$started_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+  if kill -0 "$started_pid" 2>/dev/null; then
+    kill -KILL "$started_pid" 2>/dev/null || true
   fi
   wait "$started_pid" 2>/dev/null || true
   rm -f "$PID_FILE"

--- a/scripts/start-iii.sh
+++ b/scripts/start-iii.sh
@@ -75,7 +75,22 @@ if [[ -n "$COMPOSE_FILE" ]]; then
 else
   "$BINARY" --config "$CONFIG" > "$LOG_FILE" 2>&1 &
 fi
-echo $! > "$PID_FILE"
+started_pid=$!
+echo "$started_pid" > "$PID_FILE"
+
+ready=false
+cleanup_failed_start() {
+  if [[ "$ready" == true ]]; then
+    return
+  fi
+
+  if kill -0 "$started_pid" 2>/dev/null; then
+    kill "$started_pid" 2>/dev/null || true
+  fi
+  wait "$started_pid" 2>/dev/null || true
+  rm -f "$PID_FILE"
+}
+trap cleanup_failed_start EXIT
 
 echo "Waiting for III Engine on port $PORT..."
 for _ in $(seq 1 "$TIMEOUT"); do
@@ -86,11 +101,13 @@ for _ in $(seq 1 "$TIMEOUT"); do
 
   if [[ -n "$COMPOSE_FILE" ]] && grep -Eq '^up: (nothing to do|[0-9]+ of [0-9]+ changed)' "$LOG_FILE"; then
     echo "III Engine and Compose workers are ready (PID: $pid)"
+    ready=true
     exit 0
   fi
 
   if [[ -z "$COMPOSE_FILE" ]] && nc -z 127.0.0.1 "$PORT" 2>/dev/null; then
     echo "III Engine is ready on port $PORT (PID: $(cat "$PID_FILE"))"
+    ready=true
     exit 0
   fi
   sleep 1


### PR DESCRIPTION
## Summary

- use the current Compose CLI syntax in the production Docker Compose file
- terminate and reap launcher processes when startup times out, including SIGKILL escalation
- supervise post-run hooks until completion, timeout, or project shutdown
- remove generated managed-engine configuration when spawn fails
- fail safely when Windows Job Object assignment does not succeed
- retry transient registry transport errors and retryable HTTP responses within the existing resolution budget

## Validation

- cargo fmt --all -- --check
- cargo clippy -p iii-compose --all-targets --all-features --locked -- -D warnings
- cargo test -p iii-compose
- cargo test -p iii --test compose_managed_engine_e2e --test compose_daemon_e2e
- cargo test -p iii
- bash -n scripts/start-iii.sh
- docker compose -f engine/docker-compose.prod.yml config
- full CI workflow: 31 of 31 jobs passed

## Context

This is a focused follow-up to #2074. It covers failure paths that could crash-loop the production service, leave active orphan processes, retain generated configuration after a failed start, or roll back Compose on a transient registry outage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Post-run tasks now run asynchronously under supervision, with timeouts and clean shutdown handling.
  - Registry lookups now retry transient failures automatically.
- **Bug Fixes**
  - Improved cleanup of failed or timed-out processes, including Windows process supervision.
  - Startup failures now terminate child processes, remove stale PID files, and clean temporary configuration.
  - Updated production startup command handling.
- **Tests**
  - Added coverage for hook lifecycle, retries, forced termination, startup failures, and production configuration parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->