### PR TITLE
Remove inaccurate mentions of iii as a 'worker mesh' and format SKILL.md files

### DIFF
--- a/engine/src/workers/engine_fn/README.md
+++ b/engine/src/workers/engine_fn/README.md
@@ -1,6 +1,6 @@
 # iii
 
-iii is a language agnostic runtime where services, agents, and tools are composed of the same
+iii is a language-agnostic runtime where services, agents, and tools are composed of the same
 things: workers, triggers, and functions. One engine process (default port `49134`) holds a live
 registry of every connected worker, every function those workers expose, and every trigger bound to
 them. Workers are independent processes that open a WebSocket to the engine and register
@@ -37,9 +37,11 @@ handlers without needing the worker name.
 
 ## Architecture
 
+The engine is the coordinator: one process that holds the registry and routes every invocation. The
+three primitives it routes between are:
+
 | Primitive | What it is                                                                                |
 | --------- | ----------------------------------------------------------------------------------------- |
-| Engine    | One coordinator process. Routes every invocation.                                         |
 | Worker    | A process that opens a WebSocket to the engine.                                           |
 | Function  | A named handler inside a worker, id `service::name`.                                      |
 | Trigger   | A `(type, config, function_id)` triple that causes a function to run when an event fires. |

--- a/engine/src/workers/engine_fn/README.md
+++ b/engine/src/workers/engine_fn/README.md
@@ -1,8 +1,15 @@
 # iii
 
-iii is a WebSocket-routed worker mesh. One engine process (default port `49134`) holds a live registry of every connected worker, every function those workers expose, and every trigger bound to them. Workers are independent processes that open a WebSocket to the engine and register **Functions** (`service::name` handlers) and **Triggers** (events that invoke those functions). There is no direct worker-to-worker traffic — every call routes through the engine.
+iii is a language agnostic runtime where services, agents, and tools are composed of the same
+things: workers, triggers, and functions. One engine process (default port `49134`) holds a live
+registry of every connected worker, every function those workers expose, and every trigger bound to
+them. Workers are independent processes that open a WebSocket to the engine and register
+**Functions** (`service::name` handlers) and **Triggers** (events that invoke those functions).
+There is no direct worker-to-worker traffic — every call routes through the engine.
 
-This registry worker documents the **`engine::*`** introspection surface (implemented in-process) and the **`worker::*`** lifecycle ops (implemented by the `iii-worker-ops` sidecar). It is always present in the engine and is not configured in `config.yaml`.
+This registry worker documents the **`engine::*`** introspection surface (implemented in-process)
+and the **`worker::*`** lifecycle ops (implemented by the `iii-worker-ops` sidecar). It is always
+present in the engine and is not configured in `config.yaml`.
 
 This worker is built into the engine and is always available; no install step is needed.
 
@@ -16,107 +23,124 @@ npx skills add iii-hq/iii --full-depth --skill iii
 
 ## Registry name vs runtime name
 
-| Surface | Name | Notes |
-|---|---|---|
-| Registry / manifest | **`iii`** | [`iii.worker.yaml`](iii.worker.yaml) `name:` field |
-| Engine runtime worker (in-process) | **`iii-engine-functions`** | Mandatory builtin; owns `engine::*` |
-| `engine::functions::list` owner for `engine::*` | **`iii-engine-functions`** | Until runtime name aligns with registry |
-| `worker::*` owner | **`iii-worker-ops`** | Sidecar daemon; not in-process |
+| Surface                                         | Name                       | Notes                                              |
+| ----------------------------------------------- | -------------------------- | -------------------------------------------------- |
+| Registry / manifest                             | **`iii`**                  | [`iii.worker.yaml`](iii.worker.yaml) `name:` field |
+| Engine runtime worker (in-process)              | **`iii-engine-functions`** | Mandatory builtin; owns `engine::*`                |
+| `engine::functions::list` owner for `engine::*` | **`iii-engine-functions`** | Until runtime name aligns with registry            |
+| `worker::*` owner                               | **`iii-worker-ops`**       | Sidecar daemon; not in-process                     |
 
-Use `engine::workers::info { name: "iii-engine-functions" }` (not `"iii"`) for full introspection of the in-process surface today. Filter with `engine::functions::list { prefix: "engine::", include_internal: true }` to list `engine::*` handlers without needing the worker name.
+Use `engine::workers::info { name: "iii-engine-functions" }` (not `"iii"`) for full introspection of
+the in-process surface today. Filter with
+`engine::functions::list { prefix: "engine::", include_internal: true }` to list `engine::*`
+handlers without needing the worker name.
 
 ## Architecture
 
-| Primitive | What it is |
-|---|---|
-| Engine | One coordinator process. Routes every invocation. |
-| Worker | A process that opens a WebSocket to the engine. |
-| Function | A named handler inside a worker, id `service::name`. |
-| Trigger | A `(type, config, function_id)` triple that causes a function to run when an event fires. |
+| Primitive | What it is                                                                                |
+| --------- | ----------------------------------------------------------------------------------------- |
+| Engine    | One coordinator process. Routes every invocation.                                         |
+| Worker    | A process that opens a WebSocket to the engine.                                           |
+| Function  | A named handler inside a worker, id `service::name`.                                      |
+| Trigger   | A `(type, config, function_id)` triple that causes a function to run when an event fires. |
 
-Every call is `caller → engine → handler`. The function id is the only contract between any two workers.
+Every call is `caller → engine → handler`. The function id is the only contract between any two
+workers.
 
 ## Functions — `engine::*`
 
-Implemented in-process by mandatory worker **`iii-engine-functions`**. Filter lists with `prefix`, `search`, or `worker`. By default, `engine::functions::list`, `engine::triggers::list`, and `engine::registered-triggers::list` hide internal `engine::*` rows unless `include_internal: true`.
+Implemented in-process by mandatory worker **`iii-engine-functions`**. Filter lists with `prefix`,
+`search`, or `worker`. By default, `engine::functions::list`, `engine::triggers::list`, and
+`engine::registered-triggers::list` hide internal `engine::*` rows unless `include_internal: true`.
 
-For exact request/response JSON Schemas, call `engine::functions::info { function_id: "engine::…" }`.
+For exact request/response JSON Schemas, call
+`engine::functions::info { function_id: "engine::…" }`.
 
-| Function | Description |
-|---|---|
-| `engine::channels::create` | Create a streaming channel pair (writer + reader refs). |
-| `engine::functions::list` | List registered functions with their owning worker name. |
-| `engine::functions::info` | Inspect one function: schemas, owner, and registered triggers. |
-| `engine::triggers::list` | List trigger types registered with the engine. |
-| `engine::triggers::info` | Inspect one trigger type: schemas, owner, and live instance count. |
-| `engine::registered-triggers::list` | List registered trigger instances (subscriber rows). |
-| `engine::registered-triggers::info` | Inspect one registered trigger with denormalized trigger and function detail. |
-| `engine::workers::list` | List workers connected to the engine (WebSocket-connected only). |
-| `engine::workers::info` | Inspect one connected worker's full surface (functions, trigger types, registered triggers). |
-| `engine::workers::register` | Register worker metadata (called by SDK workers on connect). |
+| Function                            | Description                                                                                  |
+| ----------------------------------- | -------------------------------------------------------------------------------------------- |
+| `engine::channels::create`          | Create a streaming channel pair (writer + reader refs).                                      |
+| `engine::functions::list`           | List registered functions with their owning worker name.                                     |
+| `engine::functions::info`           | Inspect one function: schemas, owner, and registered triggers.                               |
+| `engine::triggers::list`            | List trigger types registered with the engine.                                               |
+| `engine::triggers::info`            | Inspect one trigger type: schemas, owner, and live instance count.                           |
+| `engine::registered-triggers::list` | List registered trigger instances (subscriber rows).                                         |
+| `engine::registered-triggers::info` | Inspect one registered trigger with denormalized trigger and function detail.                |
+| `engine::workers::list`             | List workers connected to the engine (WebSocket-connected only).                             |
+| `engine::workers::info`             | Inspect one connected worker's full surface (functions, trigger types, registered triggers). |
+| `engine::workers::register`         | Register worker metadata (called by SDK workers on connect).                                 |
 
 ### `engine::functions::list` filters
 
-| Field | Type | Description |
-|---|---|---|
-| `prefix` | string | Exact prefix match on `function_id`. |
-| `search` | string | Case-insensitive substring on `function_id` and `description`. |
-| `worker` | string | Exact worker-name match. |
-| `include_internal` | boolean | Include `engine::*` rows. Defaults to `false`. |
+| Field              | Type    | Description                                                    |
+| ------------------ | ------- | -------------------------------------------------------------- |
+| `prefix`           | string  | Exact prefix match on `function_id`.                           |
+| `search`           | string  | Case-insensitive substring on `function_id` and `description`. |
+| `worker`           | string  | Exact worker-name match.                                       |
+| `include_internal` | boolean | Include `engine::*` rows. Defaults to `false`.                 |
 
 ## Functions — `worker::*`
 
-Implemented by sidecar **`iii-worker-ops`** (auto-injected daemon). Each op is also available as `iii worker <cmd>` on the CLI. In `engine::functions::list`, these appear under worker name **`iii-worker-ops`**, not `iii`.
+Implemented by sidecar **`iii-worker-ops`** (auto-injected daemon). Each op is also available as
+`iii worker <cmd>` on the CLI. In `engine::functions::list`, these appear under worker name
+**`iii-worker-ops`**, not `iii`.
 
-For exact parameter and response shapes, call `engine::functions::info { function_id: "worker::add" }` or `worker::schema { function_id: "worker::add" }`.
+For exact parameter and response shapes, call
+`engine::functions::info { function_id: "worker::add" }` or
+`worker::schema { function_id: "worker::add" }`.
 
-| Function | Description |
-|---|---|
-| `worker::add` | Install a worker from registry or OCI; writes `iii.config.yaml`, caches under `~/.iii/managed/{name}/`, pins `iii.lock`. |
+| Function         | Description                                                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `worker::add`    | Install a worker from registry or OCI; writes `iii.config.yaml`, caches under `~/.iii/managed/{name}/`, pins `iii.lock`.          |
 | `worker::remove` | Drop a worker's config entry. Leaves cached artifacts on disk — pair with `worker::clear` to reclaim space. Requires `yes: true`. |
-| `worker::update` | Re-pin registry workers to latest semver and rewrite `iii.lock`. OCI-sourced workers are skipped. |
-| `worker::start` | Spawn a configured worker. Default `wait: true` blocks until the engine sees the WS handshake. |
-| `worker::stop` | Graceful shutdown. Requires `yes: true`. Does not touch config, lock, or cache. |
-| `worker::list` | Union of config entries, managed artifacts, and running processes. Includes daemon-managed builtins. |
-| `worker::clear` | Delete cached artifacts under `~/.iii/managed/{name}/`. Requires `yes: true`. Does not touch config or lock. |
-| `worker::schema` | JSON Schemas for every op plus `default_timeout_ms` and `idempotent` hints. |
+| `worker::update` | Re-pin registry workers to latest semver and rewrite `iii.lock`. OCI-sourced workers are skipped.                                 |
+| `worker::start`  | Spawn a configured worker. Default `wait: true` blocks until the engine sees the WS handshake.                                    |
+| `worker::stop`   | Graceful shutdown. Requires `yes: true`. Does not touch config, lock, or cache.                                                   |
+| `worker::list`   | Union of config entries, managed artifacts, and running processes. Includes daemon-managed builtins.                              |
+| `worker::clear`  | Delete cached artifacts under `~/.iii/managed/{name}/`. Requires `yes: true`. Does not touch config or lock.                      |
+| `worker::schema` | JSON Schemas for every op plus `default_timeout_ms` and `idempotent` hints.                                                       |
 
-> **Note:** `worker::add` with `source.kind: "local"` works over the trigger as well as the CLI; the `path` is resolved on the engine/daemon host (not the caller). Destructive ops (`remove`, `stop`, `clear`) require `yes: true` (boolean, not string).
+> **Note:** `worker::add` with `source.kind: "local"` works over the trigger as well as the CLI; the
+> `path` is resolved on the engine/daemon host (not the caller). Destructive ops (`remove`, `stop`,
+> `clear`) require `yes: true` (boolean, not string).
 
-Merge `worker::list` with `engine::workers::list` by `name` for a complete worker picture — daemon-managed providers such as `iii-http` may not appear in `engine::workers::list` even when serving traffic.
+Merge `worker::list` with `engine::workers::list` by `name` for a complete worker picture —
+daemon-managed providers such as `iii-http` may not appear in `engine::workers::list` even when
+serving traffic.
 
 ## Trigger types
 
 ### Reactive — owned by `iii-engine-functions`
 
-| Trigger type | Description |
-|---|---|
+| Trigger type                  | Description                                                                                                                              |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `engine::functions-available` | Fires when the function registry changes (polled every 5s). Payload includes `event: "functions_changed"` and the current function list. |
-| `engine::workers-available` | Fires when worker metadata is updated via `engine::workers::register`. |
+| `engine::workers-available`   | Fires when worker metadata is updated via `engine::workers::register`.                                                                   |
 
 ### Custom — owned by `iii-worker-ops`
 
-| Trigger type | Description |
-|---|---|
-| `worker` | Worker lifecycle events emitted by every `worker::*` op. Subscribe with `operations` / `stages` / `workers` filters. |
+| Trigger type | Description                                                                                                          |
+| ------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `worker`     | Worker lifecycle events emitted by every `worker::*` op. Subscribe with `operations` / `stages` / `workers` filters. |
 
 ## Before you build
 
 Run these reads before authoring a new worker — the capability you need may already exist:
 
 1. `engine::functions::list` — every function on this engine (filter with `prefix` or `search`).
-2. `directory::registry::workers::list` — every worker in the public registry. Prefer `worker::add { source: { kind: "registry", name: "…" } }` over re-implementing.
+2. `directory::registry::workers::list` — every worker in the public registry. Prefer
+   `worker::add { source: { kind: "registry", name: "…" } }` over re-implementing.
 
 Only hand-author a worker when both come up empty.
 
 ## Canonical trigger types (other workers)
 
-Pass these literal strings as `type` in `registerTrigger`. Provider READMEs on the registry are authoritative when versions drift.
+Pass these literal strings as `type` in `registerTrigger`. Provider READMEs on the registry are
+authoritative when versions drift.
 
-| `type` | Provider | Config keys |
-|---|---|---|
-| `http` | `iii-http` | `{ http_method, api_path }` |
-| `cron` | `iii-cron` | `{ expression }` — 7 fields: sec min hr dom mon dow year |
-| `queue` | `iii-queue` | `{ queue, retries }` |
-| `state` | `iii-state` | `{ scope, condition_function_id }` |
-| `stream` | `iii-stream` | `{ stream_name }` |
+| `type`   | Provider     | Config keys                                              |
+| -------- | ------------ | -------------------------------------------------------- |
+| `http`   | `iii-http`   | `{ http_method, api_path }`                              |
+| `cron`   | `iii-cron`   | `{ expression }` — 7 fields: sec min hr dom mon dow year |
+| `queue`  | `iii-queue`  | `{ queue, retries }`                                     |
+| `state`  | `iii-state`  | `{ scope, condition_function_id }`                       |
+| `stream` | `iii-stream` | `{ stream_name }`                                        |

--- a/engine/src/workers/engine_fn/skills/SKILL.md
+++ b/engine/src/workers/engine_fn/skills/SKILL.md
@@ -1,40 +1,56 @@
 ---
 name: iii
-description: WebSocket-routed worker mesh — the engine's Function/Trigger/Worker model and the iii-sdk surface for authoring them. Teaches the ordered way to gain a capability before writing code — (1) check functions already registered in the engine, (2) search the public registry via iii-directory, (3) build a worker. Single self-contained skill — meant for system-prompt injection; do not re-fetch.
+description:
+  How iii works and the and the iii sdk surface for authoring workers, triggers, and functions.
+  Teaches the ordered way to gain a capability before writing code — (1) check functions already
+  registered in the engine, (2) search the public registry via iii-directory, (3) build a worker.
+  Single self-contained skill — meant for system-prompt injection; do not re-fetch.
 ---
 
 # iii
 
-iii is a WebSocket-routed worker mesh. One engine process (default port `49134`) holds a live registry of every connected worker, every function those workers expose, and every trigger bound to them. Workers are independent OS processes that open a WebSocket to the engine and register **Functions** (`service::name` handlers) and **Triggers** (the events that invoke those Functions). There is no direct worker-to-worker traffic — every call routes through the engine, which makes the language, runtime, and physical location of any worker invisible to its callers.
+iii is a language agnostic runtime where services, agents, and tools are composed of the same
+things: workers, triggers, and functions. One engine process (default port `49134`) holds a live
+registry of every connected worker, every function those workers expose, and every trigger bound to
+them. Workers are independent OS processes that open a WebSocket to the engine and register
+**Functions** (`service::name` handlers) and **Triggers** (the events that invoke those Functions).
+There is no direct worker-to-worker traffic — every call routes through the engine, which makes the
+language, runtime, and physical location of any worker invisible to its callers.
 
 **You extend yourself by writing iii workers.** A few lines get you on the bus:
 
 ```ts
-import { registerWorker } from 'iii-sdk'
+import { registerWorker } from "iii-sdk";
 
-const iii = registerWorker(process.env.III_ENGINE_URL!, { workerName: 'demo' })
+const iii = registerWorker(process.env.III_ENGINE_URL!, { workerName: "demo" });
 
-iii.registerFunction('demo::add', async (payload: { a: number; b: number }) => {
-  return { c: payload.a + payload.b }
-})
+iii.registerFunction("demo::add", async (payload: { a: number; b: number }) => {
+  return { c: payload.a + payload.b };
+});
 ```
 
-The instant the handshake completes, `demo::add` is callable from any worker (and the harness itself) via `iii.trigger({ function_id: 'demo::add', payload: { a: 2, b: 3 } })`. No restart, no registration with the harness — the engine routes it automatically.
+The instant the handshake completes, `demo::add` is callable from any worker (and the harness
+itself) via `iii.trigger({ function_id: 'demo::add', payload: { a: 2, b: 3 } })`. No restart, no
+registration with the harness — the engine routes it automatically.
 
 ## The four primitives
 
-| Primitive | What it is | Owned by |
-|---|---|---|
-| Engine | One coordinator process. Routes every invocation. | The operator |
-| Worker | A process that opens a WebSocket to the engine. | Anyone who writes one |
-| Function | A named handler inside a worker, id `service::name`. Stable across worker restarts. | The registering worker |
-| Trigger | A `(type, config, function_id)` triple. Causes a function to run when an event fires. | A worker (the type-publisher) + a caller (the binding) |
+| Primitive | What it is                                                                            | Owned by                                               |
+| --------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Engine    | One coordinator process. Routes every invocation.                                     | The operator                                           |
+| Worker    | A process that opens a WebSocket to the engine.                                       | Anyone who writes one                                  |
+| Function  | A named handler inside a worker, id `service::name`. Stable across worker restarts.   | The registering worker                                 |
+| Trigger   | A `(type, config, function_id)` triple. Causes a function to run when an event fires. | A worker (the type-publisher) + a caller (the binding) |
 
 Three consequences worth internalising:
 
-1. **No worker-to-worker traffic.** Every call is `worker → engine → worker`. Workers never address each other directly. Location and language are invisible.
-2. **No restart coordination.** Restarting a worker is invisible to callers as long as it re-registers the same function ids. Two workers registering the same function id = automatic load-balance.
-3. **No polling unless you opt in.** Triggers are the engine's push channel. The engine fans events out to bound functions when the underlying source fires.
+1. **No worker-to-worker traffic.** Every call is `worker → engine → worker`. Workers never address
+   each other directly. Location and language are invisible.
+2. **No restart coordination.** Restarting a worker is invisible to callers as long as it
+   re-registers the same function ids. Two workers registering the same function id = automatic
+   load-balance.
+3. **No polling unless you opt in.** Triggers are the engine's push channel. The engine fans events
+   out to bound functions when the underlying source fires.
 
 The function id is the only contract between any two workers.
 
@@ -47,11 +63,13 @@ graph TD
   External["external event (request, timer, queue, ...)"] -->|"native protocol"| Provider
 ```
 
-Every edge to the engine is a WebSocket. A trigger-type provider terminates some native protocol — an inbound request, a timer, a queue message — and translates it into engine traffic.
+Every edge to the engine is a WebSocket. A trigger-type provider terminates some native protocol —
+an inbound request, a timer, a queue message — and translates it into engine traffic.
 
 ## Need a capability? Discover before you build — in this order
 
-The most common harness mistake is reimplementing something that already exists, or hardwiring one worker out of habit. Work the steps in order; stop at the first that satisfies the need.
+The most common harness mistake is reimplementing something that already exists, or hardwiring one
+worker out of habit. Work the steps in order; stop at the first that satisfies the need.
 
 **1. Look at what is already registered in the engine.** The capability may be one call away.
 
@@ -63,7 +81,8 @@ The most common harness mistake is reimplementing something that already exists,
 
 If a registered function fits, just call it: `iii.trigger({ function_id, payload })`.
 
-**2. Search the public registry.** If nothing registered fits, look for a worker to install. This goes through the `iii-directory` worker:
+**2. Search the public registry.** If nothing registered fits, look for a worker to install. This
+goes through the `iii-directory` worker:
 
 ```jsonc
 // directory::registry::workers::list { search: 'image resize' }
@@ -72,9 +91,11 @@ If a registered function fits, just call it: `iii.trigger({ function_id, payload
 //   → that worker's README, config keys, API reference, and skills.
 ```
 
-When one fits, install it: `worker::add { source: { kind: 'registry', name: '<worker>' }, wait: true }`.
+When one fits, install it:
+`worker::add { source: { kind: 'registry', name: '<worker>' }, wait: true }`.
 
-`iii-directory` is itself a registry worker, so confirm it is connected before calling `directory::*`:
+`iii-directory` is itself a registry worker, so confirm it is connected before calling
+`directory::*`:
 
 ```jsonc
 // engine::functions::list { prefix: 'directory::' }
@@ -82,9 +103,15 @@ When one fits, install it: `worker::add { source: { kind: 'registry', name: '<wo
 // worker::add { source: { kind: 'registry', name: 'iii-directory' }, wait: true }
 ```
 
-**3. Build a worker.** Only when steps 1 and 2 both come up empty. Author it with the SDK (below), then deploy it. Discover the deployment/runtime surface the same way as any other capability — `directory::registry::workers::list` / `::info` and its skill — rather than assuming a worker name. (`worker::add { kind: 'local', path }` works over the bus, but `path` resolves on the **engine/daemon host**, not on the caller — so it only helps when your code already lives on that host. For un-published code that lives elsewhere, run it via a runtime/sandbox worker.)
+**3. Build a worker.** Only when steps 1 and 2 both come up empty. Author it with the SDK (below),
+then deploy it. Discover the deployment/runtime surface the same way as any other capability —
+`directory::registry::workers::list` / `::info` and its skill — rather than assuming a worker name.
+(`worker::add { kind: 'local', path }` works over the bus, but `path` resolves on the
+**engine/daemon host**, not on the caller — so it only helps when your code already lives on that
+host. For un-published code that lives elsewhere, run it via a runtime/sandbox worker.)
 
-> Discover in order. Don't jump to a worker you remember; the registry may hold a better fit, and the right surface is whatever the live engine and registry report — not training-data recall.
+> Discover in order. Don't jump to a worker you remember; the registry may hold a better fit, and
+> the right surface is whatever the live engine and registry report — not training-data recall.
 
 ## The TypeScript SDK in brief
 
@@ -93,66 +120,77 @@ import {
   registerWorker, // factory; opens the WS from your code's perspective synchronously
   TriggerAction, // .Void() | .Enqueue({ queue })
   InvocationError, // typed error thrown by iii.trigger()
-} from 'iii-sdk'
-import { Logger } from '@iii-dev/helpers/observability' // OTel-aware structured logger; falls back to console.*
+} from "iii-sdk";
+import { Logger } from "@iii-dev/helpers/observability"; // OTel-aware structured logger; falls back to console.*
 
 const iii = registerWorker(process.env.III_ENGINE_URL!, {
-  workerName: 'my-worker', // appears in engine::workers::list
+  workerName: "my-worker", // appears in engine::workers::list
   invocationTimeoutMs: 30_000,
   reconnectionConfig: { maxRetries: -1 }, // -1 = infinite (the default)
-})
+});
 
 // Publish a function. Same handler shape regardless of how the invocation arrives.
-const ref = iii.registerFunction('svc::do-thing', async (payload) => ({ ok: true }), {
+const ref = iii.registerFunction("svc::do-thing", async (payload) => ({ ok: true }), {
   description, // JSON-Schema-shaped metadata
   request_format,
   response_format,
-})
-ref.id // 'svc::do-thing'
-ref.unregister() // drop just this function, keep the WS open
+});
+ref.id; // 'svc::do-thing'
+ref.unregister(); // drop just this function, keep the WS open
 
 // Invoke. Three modes — same method, different `action`.
-await iii.trigger({ function_id, payload, timeoutMs })
-await iii.trigger({ function_id, payload, action: TriggerAction.Void() })
-await iii.trigger({ function_id, payload, action: TriggerAction.Enqueue({ queue }) })
+await iii.trigger({ function_id, payload, timeoutMs });
+await iii.trigger({ function_id, payload, action: TriggerAction.Void() });
+await iii.trigger({ function_id, payload, action: TriggerAction.Enqueue({ queue }) });
 
 // Bind a function to an event.
-iii.registerTrigger({ type, function_id, config })
+iii.registerTrigger({ type, function_id, config });
 
 // Publish a new event source other workers can bind to.
-iii.registerTriggerType({ id, description }, { registerTrigger, unregisterTrigger })
+iii.registerTriggerType({ id, description }, { registerTrigger, unregisterTrigger });
 
-await iii.shutdown() // graceful close; engine evicts this worker's functions immediately
+await iii.shutdown(); // graceful close; engine evicts this worker's functions immediately
 ```
 
-`registerWorker(url, options?)` opens the WebSocket synchronously from your code's perspective — there is no separate `await connect()`. The handle queues calls until the handshake lands.
+`registerWorker(url, options?)` opens the WebSocket synchronously from your code's perspective —
+there is no separate `await connect()`. The handle queues calls until the handshake lands.
 
-Schemas in `registerFunction` (`description`, `request_format`, `response_format`) are JSON-Schema-shaped **metadata** — the engine does not validate payloads against them today. Declare them anyway: they surface in `engine::functions::info`, document the contract for the next caller, and reserve a slot for future runtime validation.
+Schemas in `registerFunction` (`description`, `request_format`, `response_format`) are
+JSON-Schema-shaped **metadata** — the engine does not validate payloads against them today. Declare
+them anyway: they surface in `engine::functions::info`, document the contract for the next caller,
+and reserve a slot for future runtime validation.
 
 ### The three invocation modes
 
-| `action` | Caller blocks? | Retries? | Returns | Use when |
-|---|---|---|---|---|
-| (omitted) | yes | no | the function's result | you need the value to continue |
-| `TriggerAction.Void()` | no | no | `null` | one-way notification, no result needed |
-| `TriggerAction.Enqueue({ queue })` | no | yes | `{ messageReceiptId }` | slow/unreliable work; the queue handles retry + back-pressure |
+| `action`                           | Caller blocks? | Retries? | Returns                | Use when                                                      |
+| ---------------------------------- | -------------- | -------- | ---------------------- | ------------------------------------------------------------- |
+| (omitted)                          | yes            | no       | the function's result  | you need the value to continue                                |
+| `TriggerAction.Void()`             | no             | no       | `null`                 | one-way notification, no result needed                        |
+| `TriggerAction.Enqueue({ queue })` | no             | yes      | `{ messageReceiptId }` | slow/unreliable work; the queue handles retry + back-pressure |
 
 ### Errors
 
-- **Throw inside the handler** → propagates to the caller as `InvocationError` (carries `code`, `function_id`, `stacktrace`). Use for unexpected failures a retry might fix.
-- **Return a structured value** (`{ ok: false, reason }`) → the call succeeds; the caller branches on the shape. Use for expected failures (validation, not-found, business rules).
+- **Throw inside the handler** → propagates to the caller as `InvocationError` (carries `code`,
+  `function_id`, `stacktrace`). Use for unexpected failures a retry might fix.
+- **Return a structured value** (`{ ok: false, reason }`) → the call succeeds; the caller branches
+  on the shape. Use for expected failures (validation, not-found, business rules).
 
 Rule of thumb: if a retry might succeed, throw; if it will fail the same way, return a value.
 
 ### Lifecycle
 
-- `iii.shutdown()` flushes pending traffic and closes the WS; the engine evicts the worker's functions immediately and resolves in-flight calls to it as `invocation_stopped`.
-- `ref.unregister()` removes one registration (`FunctionRef`, `Trigger`, or `TriggerTypeRef`) without touching the others.
-- The SDK reconnects automatically with backoff and **replays registrations verbatim** — never re-register manually. Callers see `invocation_stopped` during the disconnect window; treat it as cancellation, not transient failure.
+- `iii.shutdown()` flushes pending traffic and closes the WS; the engine evicts the worker's
+  functions immediately and resolves in-flight calls to it as `invocation_stopped`.
+- `ref.unregister()` removes one registration (`FunctionRef`, `Trigger`, or `TriggerTypeRef`)
+  without touching the others.
+- The SDK reconnects automatically with backoff and **replays registrations verbatim** — never
+  re-register manually. Callers see `invocation_stopped` during the disconnect window; treat it as
+  cancellation, not transient failure.
 
 ## Triggers — discover the type, don't hardcode it
 
-A trigger's `type` is a literal string published by some worker, and its `config` shape is defined by that worker. There is no fixed catalogue — discover what is available rather than assuming:
+A trigger's `type` is a literal string published by some worker, and its `config` shape is defined
+by that worker. There is no fixed catalogue — discover what is available rather than assuming:
 
 ```jsonc
 // engine::triggers::list             → every trigger TYPE currently published (legal `type:` values).
@@ -164,45 +202,56 @@ Then bind, passing the literal type string and the `config` its schema requires:
 
 ```ts
 iii.registerTrigger({
-  type: '<type from the list above>',
-  function_id: 'svc::handler',
+  type: "<type from the list above>",
+  function_id: "svc::handler",
   config: {
     /* keys per the type's schema */
   },
-})
+});
 ```
 
 Two cautions that apply to every trigger type:
 
-- `registerTrigger` succeeds at the engine even when the `type` provider is **not connected** or the `config` keys are wrong — the binding lands but never fires. Confirm the provider is up (`engine::triggers::list` shows the type) and copy `config` keys from the type's schema, not from memory.
-- The bound function receives whatever payload **that trigger type** delivers (its request schema in `engine::triggers::info`) and must return whatever shape that type expects. The handler contract is the trigger type's, not a generic one — check the schema before writing the handler.
+- `registerTrigger` succeeds at the engine even when the `type` provider is **not connected** or the
+  `config` keys are wrong — the binding lands but never fires. Confirm the provider is up
+  (`engine::triggers::list` shows the type) and copy `config` keys from the type's schema, not from
+  memory.
+- The bound function receives whatever payload **that trigger type** delivers (its request schema in
+  `engine::triggers::info`) and must return whatever shape that type expects. The handler contract
+  is the trigger type's, not a generic one — check the schema before writing the handler.
 
 ### Custom trigger types — the deepest leverage
 
-`registerTriggerType` turns your worker's native event source (a webhook hit, a file change, a row update) into something the whole bus can react to without polling. Keep a `{ trigger_id → { function_id, config } }` table in memory and walk it when the source fires:
+`registerTriggerType` turns your worker's native event source (a webhook hit, a file change, a row
+update) into something the whole bus can react to without polling. Keep a
+`{ trigger_id → { function_id, config } }` table in memory and walk it when the source fires:
 
 ```ts
-type FsWatchConfig = { path: string; recursive?: boolean }
-const bindings = new Map<string, { function_id: string; config: FsWatchConfig }>()
+type FsWatchConfig = { path: string; recursive?: boolean };
+const bindings = new Map<string, { function_id: string; config: FsWatchConfig }>();
 
 iii.registerTriggerType<FsWatchConfig>(
-  { id: 'fs::watch', description: 'Fires when a file under `path` changes.' },
+  { id: "fs::watch", description: "Fires when a file under `path` changes." },
   {
     async registerTrigger({ id, function_id, config }) {
-      bindings.set(id, { function_id, config })
-      startWatching(id, config)
+      bindings.set(id, { function_id, config });
+      startWatching(id, config);
     },
     async unregisterTrigger({ id }) {
-      stopWatching(id)
-      bindings.delete(id)
+      stopWatching(id);
+      bindings.delete(id);
     },
   },
-)
+);
 
 function onChange(triggerId: string, path: string) {
-  const binding = bindings.get(triggerId)
-  if (!binding) return
-  iii.trigger({ function_id: binding.function_id, payload: { path }, action: TriggerAction.Void() })
+  const binding = bindings.get(triggerId);
+  if (!binding) return;
+  iii.trigger({
+    function_id: binding.function_id,
+    payload: { path },
+    action: TriggerAction.Void(),
+  });
 }
 ```
 
@@ -210,7 +259,8 @@ From the caller's side, your custom type is indistinguishable from any built-in 
 
 ## Worker lifecycle — `worker::*` ops
 
-Install, run, and remove workers. Each op is also `iii worker <cmd>` on the CLI. Fetch exact request/response shapes from the engine rather than trusting this list:
+Install, run, and remove workers. Each op is also `iii worker <cmd>` on the CLI. Fetch exact
+request/response shapes from the engine rather than trusting this list:
 
 ```jsonc
 // engine::functions::info { function_id: 'worker::add' }   → request/response JSON Schema,
@@ -219,47 +269,63 @@ Install, run, and remove workers. Each op is also `iii worker <cmd>` on the CLI.
 // On a malformed payload the W105 error envelope's details.hint points back at worker::schema.
 ```
 
-| Op | Does |
-|---|---|
-| `worker::add` | Install from registry or OCI; writes `iii.config.yaml`, caches under `~/.iii/managed/{name}/`, pins `iii.lock`. |
-| `worker::remove` | Drop the config entry (keeps the cache). Requires `yes: true`. |
-| `worker::update` | Re-pin registry workers to latest semver (OCI skipped). |
-| `worker::start` | Spawn a configured worker. `wait: true` (default) blocks until the WS handshake. |
-| `worker::stop` | Graceful shutdown. Requires `yes: true`. |
-| `worker::list` | Installed + running state, including daemon-managed builtins. |
-| `worker::clear` | Delete cached artifacts (keeps config). Requires `yes: true`. |
-| `worker::schema` | JSON Schemas for every op. |
+| Op               | Does                                                                                                            |
+| ---------------- | --------------------------------------------------------------------------------------------------------------- |
+| `worker::add`    | Install from registry or OCI; writes `iii.config.yaml`, caches under `~/.iii/managed/{name}/`, pins `iii.lock`. |
+| `worker::remove` | Drop the config entry (keeps the cache). Requires `yes: true`.                                                  |
+| `worker::update` | Re-pin registry workers to latest semver (OCI skipped).                                                         |
+| `worker::start`  | Spawn a configured worker. `wait: true` (default) blocks until the WS handshake.                                |
+| `worker::stop`   | Graceful shutdown. Requires `yes: true`.                                                                        |
+| `worker::list`   | Installed + running state, including daemon-managed builtins.                                                   |
+| `worker::clear`  | Delete cached artifacts (keeps config). Requires `yes: true`.                                                   |
+| `worker::schema` | JSON Schemas for every op.                                                                                      |
 
-- **`worker::add` source variants:** `{ kind: 'registry', name, version? }`, `{ kind: 'oci', reference }`, and `{ kind: 'local', path }` — `path` is resolved on the **engine/daemon host** (works over the trigger as well as the CLI).
-- **Consent:** `remove`, `stop`, and `clear` require exactly `yes: true` (the boolean, not `"true"`).
+- **`worker::add` source variants:** `{ kind: 'registry', name, version? }`,
+  `{ kind: 'oci', reference }`, and `{ kind: 'local', path }` — `path` is resolved on the
+  **engine/daemon host** (works over the trigger as well as the CLI).
+- **Consent:** `remove`, `stop`, and `clear` require exactly `yes: true` (the boolean, not
+  `"true"`).
 - Reach for `worker::list` before any other op when you don't already know what is installed.
 
 ## Discovery surface
 
-| Call | Returns |
-|---|---|
-| `engine::functions::list` | Every function across all workers. Filter `prefix` / `search`. |
-| `engine::functions::info { function_id }` | One function's schemas, description, owning worker. |
-| `engine::workers::list` | Every WS-connected worker. |
-| `engine::triggers::list` | Every trigger TYPE published (legal `type:` values). |
-| `engine::triggers::info { id }` | One trigger type's config / return schema + provider. |
-| `engine::registered-triggers::list` | Every trigger INSTANCE bound. Filter `function_id` / `worker`. |
-| `worker::list` | Installed + running workers, including daemon-managed builtins. |
-| `directory::registry::workers::list` | Workers published in the public registry. Filter `search`. |
-| `directory::registry::workers::info { name }` | A registry worker's README, config, API reference, and skills. |
+| Call                                                        | Returns                                                                       |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `engine::functions::list`                                   | Every function across all workers. Filter `prefix` / `search`.                |
+| `engine::functions::info { function_id }`                   | One function's schemas, description, owning worker.                           |
+| `engine::workers::list`                                     | Every WS-connected worker.                                                    |
+| `engine::triggers::list`                                    | Every trigger TYPE published (legal `type:` values).                          |
+| `engine::triggers::info { id }`                             | One trigger type's config / return schema + provider.                         |
+| `engine::registered-triggers::list`                         | Every trigger INSTANCE bound. Filter `function_id` / `worker`.                |
+| `worker::list`                                              | Installed + running workers, including daemon-managed builtins.               |
+| `directory::registry::workers::list`                        | Workers published in the public registry. Filter `search`.                    |
+| `directory::registry::workers::info { name }`               | A registry worker's README, config, API reference, and skills.                |
 | `directory::skills::list` / `directory::skills::get { id }` | The markdown how-to a worker shipped — deeper than `engine::functions::info`. |
 
-`engine::workers::list` only sees WS-connected workers; some daemon-managed providers serve traffic without opening an engine WS, so merge it with `worker::list` by `name` for the full picture.
+`engine::workers::list` only sees WS-connected workers; some daemon-managed providers serve traffic
+without opening an engine WS, so merge it with `worker::list` by `name` for the full picture.
 
 ## Trust runtime probes over introspection
 
-`engine::*::list` reads can come back empty for blurred reasons: an older engine that lacks the surface, a store that lags live state, or genuinely nothing registered. **Disambiguate with a runtime probe** — call the function with `iii.trigger(...)`. If the probe succeeds, the registration is live regardless of what `*::list` reported. Don't unbind or re-register on the strength of an empty list alone; you'll churn a working worker.
+`engine::*::list` reads can come back empty for blurred reasons: an older engine that lacks the
+surface, a store that lags live state, or genuinely nothing registered. **Disambiguate with a
+runtime probe** — call the function with `iii.trigger(...)`. If the probe succeeds, the registration
+is live regardless of what `*::list` reported. Don't unbind or re-register on the strength of an
+empty list alone; you'll churn a working worker.
 
 ## Anti-patterns
 
-- **Polling instead of a trigger type.** A function on a timer reading a queue / file / table every N seconds is almost always wrappable as a custom trigger type. See [Custom trigger types](#custom-trigger-types--the-deepest-leverage).
-- **Reinventing what exists.** Run the discovery steps (`engine::functions::list`, then `directory::registry::workers::list`) before authoring anything.
-- **Hardwiring a remembered worker.** Pick the capability the live engine and registry surface, in order — not the one you reached for last time.
-- **Side-channel state between workers.** Don't have workers read each other's files or hit each other's endpoints; route every cross-worker call through `iii.trigger`, and use a shared-state worker (discover one in the registry) for shared key/value.
-- **Catching the wrong error type.** `iii.trigger()` throws `InvocationError`; catch that specifically or you lose `code` / `function_id` / `stacktrace`.
-- **Trusting introspection over runtime probes.** An empty `*::list` can mean lag, not absence — a successful `iii.trigger()` is the authoritative signal.
+- **Polling instead of a trigger type.** A function on a timer reading a queue / file / table every
+  N seconds is almost always wrappable as a custom trigger type. See
+  [Custom trigger types](#custom-trigger-types--the-deepest-leverage).
+- **Reinventing what exists.** Run the discovery steps (`engine::functions::list`, then
+  `directory::registry::workers::list`) before authoring anything.
+- **Hardwiring a remembered worker.** Pick the capability the live engine and registry surface, in
+  order — not the one you reached for last time.
+- **Side-channel state between workers.** Don't have workers read each other's files or hit each
+  other's endpoints; route every cross-worker call through `iii.trigger`, and use a shared-state
+  worker (discover one in the registry) for shared key/value.
+- **Catching the wrong error type.** `iii.trigger()` throws `InvocationError`; catch that
+  specifically or you lose `code` / `function_id` / `stacktrace`.
+- **Trusting introspection over runtime probes.** An empty `*::list` can mean lag, not absence — a
+  successful `iii.trigger()` is the authoritative signal.

--- a/engine/src/workers/engine_fn/skills/SKILL.md
+++ b/engine/src/workers/engine_fn/skills/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: iii
 description:
-  How iii works and the and the iii sdk surface for authoring workers, triggers, and functions.
-  Teaches the ordered way to gain a capability before writing code — (1) check functions already
-  registered in the engine, (2) search the public registry via iii-directory, (3) build a worker.
-  Single self-contained skill — meant for system-prompt injection; do not re-fetch.
+  How iii works and the iii SDK surface for authoring workers, triggers, and functions. Teaches the
+  ordered way to gain a capability before writing code — (1) check functions already registered in
+  the engine, (2) search the public registry via iii-directory, (3) build a worker. Single
+  self-contained skill — meant for system-prompt injection; do not re-fetch.
 ---
 
 # iii
 
-iii is a language agnostic runtime where services, agents, and tools are composed of the same
+iii is a language-agnostic runtime where services, agents, and tools are composed of the same
 things: workers, triggers, and functions. One engine process (default port `49134`) holds a live
 registry of every connected worker, every function those workers expose, and every trigger bound to
 them. Workers are independent OS processes that open a WebSocket to the engine and register
@@ -33,11 +33,13 @@ The instant the handshake completes, `demo::add` is callable from any worker (an
 itself) via `iii.trigger({ function_id: 'demo::add', payload: { a: 2, b: 3 } })`. No restart, no
 registration with the harness — the engine routes it automatically.
 
-## The four primitives
+## The three primitives
+
+The engine is the coordinator, owned by the operator: one process that holds the registry and routes
+every invocation between the three primitives below.
 
 | Primitive | What it is                                                                            | Owned by                                               |
 | --------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| Engine    | One coordinator process. Routes every invocation.                                     | The operator                                           |
 | Worker    | A process that opens a WebSocket to the engine.                                       | Anyone who writes one                                  |
 | Function  | A named handler inside a worker, id `service::name`. Stable across worker restarts.   | The registering worker                                 |
 | Trigger   | A `(type, config, function_id)` triple. Causes a function to run when an event fires. | A worker (the type-publisher) + a caller (the binding) |


### PR DESCRIPTION
## What

Remove "mesh" mentions when they describe iii as a mesh

## Why

iii is not a mesh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved readability and consistency across engine function and skill documentation.
  - Added a clearer architecture overview and refined explanations of the engine’s coordinating role.
  - Updated guidance on language-agnostic workers, triggers, functions, SDK usage, and runtime concepts.
  - Corrected terminology, capitalization, descriptions, and documentation structure.
  - Reformatted examples, lists, and tables for easier navigation without changing documented behavior or APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->