### PR TITLE
fix(compose): expose the compose project directory

### DIFF
--- a/crates/iii-compose/src/config.rs
+++ b/crates/iii-compose/src/config.rs
@@ -162,7 +162,12 @@ impl ComposeFile {
             path: path.clone(),
             source,
         })?;
-        let canonical = std::fs::canonicalize(&path).unwrap_or(path);
+        let canonical = std::fs::canonicalize(&path)
+            .or_else(|_| std::path::absolute(&path))
+            .map_err(|source| ComposeError::Io {
+                path: path.clone(),
+                source,
+            })?;
         Self::parse(&text, canonical)
     }
 

--- a/crates/iii-compose/src/spawn.rs
+++ b/crates/iii-compose/src/spawn.rs
@@ -152,12 +152,16 @@ pub fn spawn_plan(ctx: &SpawnCtx<'_>) -> SpawnPlan {
         "III_COMPOSE_NAMESPACE".to_string(),
         ctx.compose_namespace.to_string(),
     );
+    let compose_file = ctx
+        .compose_file
+        .canonicalize()
+        .or_else(|_| std::path::absolute(ctx.compose_file))
+        .unwrap_or_else(|_| ctx.compose_file.to_path_buf());
     env.insert(
         "III_COMPOSE_FILE".to_string(),
-        ctx.compose_file.to_string_lossy().to_string(),
+        compose_file.to_string_lossy().to_string(),
     );
-    let compose_dir = ctx
-        .compose_file
+    let compose_dir = compose_file
         .parent()
         .filter(|path| !path.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
@@ -298,6 +302,26 @@ mod tests {
         assert_eq!(plan.env["III_WORKER_NAME"], "api");
         assert!(!plan.env.contains_key("III_CONFIG"));
         assert_eq!(plan.working_dir, PathBuf::from("/srv/app/workers/api"));
+    }
+
+    #[test]
+    fn relative_compose_file_contract_is_canonical() {
+        let canonical_cwd = std::env::current_dir().unwrap().canonicalize().unwrap();
+        let temp = tempfile::tempdir_in(&canonical_cwd).unwrap();
+        let absolute_file = temp.path().join("worker-compose.yaml");
+        std::fs::write(&absolute_file, "containers: {}").unwrap();
+        let relative_file = absolute_file.strip_prefix(&canonical_cwd).unwrap();
+        let expected_file = absolute_file.canonicalize().unwrap();
+        let expected_dir = expected_file.parent().unwrap();
+
+        let start = StartSpec::Shell("cargo run".to_string());
+        let user_env = BTreeMap::new();
+        let mut context = ctx(&start, None, &user_env);
+        context.compose_file = relative_file;
+        let plan = spawn_plan(&context);
+
+        assert_eq!(Path::new(&plan.env["III_COMPOSE_FILE"]), expected_file);
+        assert_eq!(Path::new(&plan.env["III_COMPOSE_DIR"]), expected_dir);
     }
 
     #[test]

--- a/crates/iii-compose/src/spawn.rs
+++ b/crates/iii-compose/src/spawn.rs
@@ -8,7 +8,7 @@
 //!
 //! A child's environment is **built**, not inherited. The daemon composes it
 //! from three layers — a host baseline, the container's declared
-//! `env_file`/`environment`, and seven reserved variables the daemon owns — and
+//! `env_file`/`environment`, and eight reserved variables the daemon owns — and
 //! the child is spawned with that map and nothing else. A compose project then
 //! starts the same way regardless of which shell launched the daemon, and a
 //! stale `III_URL` in the operator's environment can never point a child at the
@@ -27,10 +27,10 @@ use crate::manifest::StartSpec;
 /// Environment variables the daemon owns for every child.
 ///
 /// Not because static configuration outranks an environment variable, which
-/// would be the wrong way round for most settings. Because each of these seven
+/// would be the wrong way round for most settings. Because each of these eight
 /// is already declared in the compose file, and a second declaration of the
 /// same thing is a disagreement nobody resolves. Each earns its place
-/// separately, so adding an eighth is a decision, not a habit:
+/// separately, so adding a ninth is a decision, not a habit:
 ///
 /// - `III_URL` is the daemon's own connection. Readiness is observed over it,
 ///   so a container pointed at another engine is invisible to the daemon that
@@ -41,19 +41,22 @@ use crate::manifest::StartSpec;
 ///   and `compose::status` before it could work at all; short of that, compose
 ///   waits in one place while the child registers in another. Both are already
 ///   declared, by `namespace:` and by the container key.
-/// - `III_COMPOSE_NAMESPACE` and `III_COMPOSE_FILE` let a managed worker reach
-///   the daemon and project that started it. The daemon namespace is not the
-///   project namespace, and one daemon may own several compose files, so both
-///   values are required for an unambiguous control-plane call.
+/// - `III_COMPOSE_NAMESPACE`, `III_COMPOSE_FILE`, and `III_COMPOSE_DIR` let a
+///   managed worker reach the daemon and project that started it, and resolve
+///   project-owned paths. The daemon namespace is not the project namespace,
+///   and one daemon may own several compose files, so the namespace and file
+///   are required for an unambiguous control-plane call. The directory is the
+///   canonical parent of that file.
 /// - `III_CONFIG` and `III_CONFIG_NAME` are two halves of one delivery: the
 ///   merged value is written to the file and published to the entry. Pointing
 ///   the child at a different file leaves it reading one value while the
 ///   configuration worker holds another.
-pub const RESERVED_ENV: [&str; 7] = [
+pub const RESERVED_ENV: [&str; 8] = [
     "III_URL",
     "III_NAMESPACE",
     "III_COMPOSE_NAMESPACE",
     "III_COMPOSE_FILE",
+    "III_COMPOSE_DIR",
     "III_CONFIG",
     "III_CONFIG_NAME",
     "III_WORKER_NAME",
@@ -152,6 +155,15 @@ pub fn spawn_plan(ctx: &SpawnCtx<'_>) -> SpawnPlan {
     env.insert(
         "III_COMPOSE_FILE".to_string(),
         ctx.compose_file.to_string_lossy().to_string(),
+    );
+    let compose_dir = ctx
+        .compose_file
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    env.insert(
+        "III_COMPOSE_DIR".to_string(),
+        compose_dir.to_string_lossy().to_string(),
     );
     env.insert("III_WORKER_NAME".to_string(), ctx.container_key.to_string());
     match ctx.config_path {
@@ -282,6 +294,7 @@ mod tests {
         assert_eq!(plan.env["III_NAMESPACE"], "orders-1234abcd");
         assert_eq!(plan.env["III_COMPOSE_NAMESPACE"], "compose-host");
         assert_eq!(plan.env["III_COMPOSE_FILE"], "/srv/app/worker-compose.yaml");
+        assert_eq!(plan.env["III_COMPOSE_DIR"], "/srv/app");
         assert_eq!(plan.env["III_WORKER_NAME"], "api");
         assert!(!plan.env.contains_key("III_CONFIG"));
         assert_eq!(plan.working_dir, PathBuf::from("/srv/app/workers/api"));

--- a/crates/iii-compose/tests/environment.rs
+++ b/crates/iii-compose/tests/environment.rs
@@ -187,6 +187,7 @@ fn a_container_is_told_which_configuration_entry_is_its_own() {
         plan.env["III_COMPOSE_FILE"],
         "/srv/finance/worker-compose.yaml"
     );
+    assert_eq!(plan.env["III_COMPOSE_DIR"], "/srv/finance");
     // The container key still names the worker. They are different questions:
     // one is what the engine routes to, the other is where the configuration
     // lives — and it is exactly their conflation that made the id global.

--- a/docs/next/understanding-iii/compose.mdx
+++ b/docs/next/understanding-iii/compose.mdx
@@ -67,11 +67,11 @@ reports a duplicate for every other worker as well.
   [Namespaces](./namespaces).
 </Note>
 
-## Why the daemon owns seven variables
+## Why the daemon owns eight variables
 
-A container's environment is its own, with seven exceptions the daemon sets and refuses to let a
+A container's environment is its own, with eight exceptions the daemon sets and refuses to let a
 container replace. The rule is not that static configuration outranks an environment variable, which
-would be the wrong way round for most settings. It is that each of these seven is already declared
+would be the wrong way round for most settings. It is that each of these eight is already declared
 somewhere in the compose file, and a second declaration of the same thing is a disagreement nobody
 resolves.
 
@@ -85,10 +85,12 @@ either would mean compose waiting in one place while the child registers in anot
 would have to be threaded through readiness, the child record and `compose::status` before it could
 work at all. Both are already declared: the namespace by the file, the name by the container key.
 
-`III_COMPOSE_NAMESPACE` and `III_COMPOSE_FILE` identify the supervisor and project that started the
-container. The project namespace cannot route to the daemon namespace, and one daemon can supervise
-several files, so a managed worker needs both values to make an explicit, unambiguous `compose::*`
-call. Letting the container replace either value could send a lifecycle edit to another project.
+`III_COMPOSE_NAMESPACE`, `III_COMPOSE_FILE`, and `III_COMPOSE_DIR` identify the supervisor and
+project that started the container. The project namespace cannot route to the daemon namespace, and
+one daemon can supervise several files, so a managed worker needs the namespace and file to make an
+explicit, unambiguous `compose::*` call. The directory is the canonical parent of the file and gives
+workers one stable base for project-owned data. Letting the container replace these values could
+send a lifecycle edit to another project or write data outside that project.
 
 `III_CONFIG` and `III_CONFIG_NAME` are two halves of one delivery. Compose merges the configuration,
 writes it to the file the first names, and publishes the same value to the entry the second names. A

--- a/docs/next/understanding-iii/compose.mdx.skill.md
+++ b/docs/next/understanding-iii/compose.mdx.skill.md
@@ -63,11 +63,11 @@ reports a duplicate for every other worker as well.
   [Namespaces](./namespaces).
 </Note>
 
-## Why the daemon owns seven variables
+## Why the daemon owns eight variables
 
-A container's environment is its own, with seven exceptions the daemon sets and refuses to let a
+A container's environment is its own, with eight exceptions the daemon sets and refuses to let a
 container replace. The rule is not that static configuration outranks an environment variable, which
-would be the wrong way round for most settings. It is that each of these seven is already declared
+would be the wrong way round for most settings. It is that each of these eight is already declared
 somewhere in the compose file, and a second declaration of the same thing is a disagreement nobody
 resolves.
 
@@ -81,10 +81,12 @@ either would mean compose waiting in one place while the child registers in anot
 would have to be threaded through readiness, the child record and `compose::status` before it could
 work at all. Both are already declared: the namespace by the file, the name by the container key.
 
-`III_COMPOSE_NAMESPACE` and `III_COMPOSE_FILE` identify the supervisor and project that started the
-container. The project namespace cannot route to the daemon namespace, and one daemon can supervise
-several files, so a managed worker needs both values to make an explicit, unambiguous `compose::*`
-call. Letting the container replace either value could send a lifecycle edit to another project.
+`III_COMPOSE_NAMESPACE`, `III_COMPOSE_FILE`, and `III_COMPOSE_DIR` identify the supervisor and
+project that started the container. The project namespace cannot route to the daemon namespace, and
+one daemon can supervise several files, so a managed worker needs the namespace and file to make an
+explicit, unambiguous `compose::*` call. The directory is the canonical parent of the file and gives
+workers one stable base for project-owned data. Letting the container replace these values could
+send a lifecycle edit to another project or write data outside that project.
 
 `III_CONFIG` and `III_CONFIG_NAME` are two halves of one delivery. Compose merges the configuration,
 writes it to the file the first names, and publishes the same value to the entry the second names. A

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -522,6 +522,7 @@ Three layers apply, lowest to highest.
 | `III_NAMESPACE`    | The project's namespace.                                                |
 | `III_COMPOSE_NAMESPACE` | The supervising Compose daemon's namespace for explicit `compose::*` routing. |
 | `III_COMPOSE_FILE` | Canonical path of the compose file that owns this container.             |
+| `III_COMPOSE_DIR`  | Canonical directory that contains the owning compose file.                |
 | `III_WORKER_NAME`  | The container key.                                                      |
 | `III_CONFIG`       | Path to the resolved configuration file. Absent when there is none.     |
 | `III_CONFIG_NAME`  | The configuration entry the container owns. Absent when it declares none. |
@@ -530,7 +531,7 @@ Declaring a reserved variable in `environment` or an `env_file` fails with `RESE
 in both cases at `compose::validate` time.
 
 <Note>
-  For why the daemon owns these seven rather than treating them as defaults a container can replace,
+  For why the daemon owns these eight rather than treating them as defaults a container can replace,
   see [Understanding iii / Compose](../understanding-iii/compose).
 </Note>
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -516,6 +516,7 @@ Three layers apply, lowest to highest.
 | `III_NAMESPACE`    | The project's namespace.                                                |
 | `III_COMPOSE_NAMESPACE` | The supervising Compose daemon's namespace for explicit `compose::*` routing. |
 | `III_COMPOSE_FILE` | Canonical path of the compose file that owns this container.             |
+| `III_COMPOSE_DIR`  | Canonical directory that contains the owning compose file.                |
 | `III_WORKER_NAME`  | The container key.                                                      |
 | `III_CONFIG`       | Path to the resolved configuration file. Absent when there is none.     |
 | `III_CONFIG_NAME`  | The configuration entry the container owns. Absent when it declares none. |
@@ -524,7 +525,7 @@ Declaring a reserved variable in `environment` or an `env_file` fails with `RESE
 in both cases at `compose::validate` time.
 
 <Note>
-  For why the daemon owns these seven rather than treating them as defaults a container can replace,
+  For why the daemon owns these eight rather than treating them as defaults a container can replace,
   see [Understanding iii / Compose](../understanding-iii/compose).
 </Note>
 


### PR DESCRIPTION
## Summary

- expose the canonical Compose project directory to every managed worker through III_COMPOSE_DIR
- reserve the variable so container configuration cannot override the runtime contract
- document the new environment variable and its path-resolution purpose

## Related

- Worker path support: https://github.com/iii-hq/workers/pull/936

## Validation

- cargo test -p iii-compose
- cargo clippy -p iii-compose --all-targets --all-features --locked -- -D warnings
- cargo fmt --all -- --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the reserved `III_COMPOSE_DIR` environment variable to Compose containers.
  * The variable identifies the canonical directory containing the Compose file, defaulting to the current directory when needed.
  * Helps keep project-owned data scoped to the correct Compose directory.

* **Documentation**
  * Updated Compose environment variable documentation to describe the new variable and revised reserved-variable count.

* **Tests**
  * Added coverage confirming the directory value is correctly populated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->