### PR TITLE
fix(compose): honor CLI namespace and engine precedence

### DIFF
--- a/crates/iii-compose/src/cli.rs
+++ b/crates/iii-compose/src/cli.rs
@@ -11,8 +11,8 @@
 //! `iii trigger` from there, naming the project with `file=`.
 //!
 //! `iii compose --up` is the same daemon with the first call already made. The
-//! initial compose file decides engine ownership: an `engine:` section starts
-//! a managed engine, while its absence requires `--engine` or `III_URL`.
+//! compose file is still read without `--up` when it exists, so its engine URL
+//! and namespace configure the daemon without also starting the project.
 //!
 //! The compose process never backgrounds itself; only the managed engine child
 //! does. That is the shape a process supervisor already wants, and it hands
@@ -34,14 +34,15 @@ pub const DEFAULT_COMPOSE_FILE: &str = "worker-compose.yaml";
 
 #[derive(Args, Debug, Clone)]
 pub struct ComposeCli {
-    /// Existing engine WebSocket address. Falls back to III_URL when the
-    /// compose file does not declare an engine section.
+    /// Existing engine WebSocket address. Overrides the compose file and
+    /// III_URL. The local default is used when none of them supplies a URL.
     ///
     #[arg(long, value_name = "URL")]
     pub engine: Option<String>,
 
-    /// Namespace this daemon answers `compose::*` in. Several attach to one
-    /// engine; this is what tells them apart.
+    /// Namespace this daemon answers `compose::*` in and applies to every
+    /// project it loads. Several daemons attach to one engine; this is what
+    /// tells them apart.
     ///
     /// It is the address an operator reaches exactly one of them with:
     /// `iii trigger compose::up --namespace <NS> file=<PATH>`. With `--up`, an
@@ -53,7 +54,8 @@ pub struct ComposeCli {
     #[arg(short = 'n', long = "namespace", value_name = "NS")]
     pub ns: Option<String>,
 
-    /// Serve with one project brought up first, starting its declared engine.
+    /// Serve with one project brought up first, starting its declared engine
+    /// unless `--engine` selects an existing one.
     #[arg(long)]
     pub up: bool,
 
@@ -73,9 +75,11 @@ pub enum ComposeCommand {
         /// A namespace set on the CLI. `None` is resolved after the initial
         /// compose file is loaded, so `--up` can inherit the file namespace.
         explicit_daemon_namespace: Option<String>,
-        /// A project to bring up before the first call arrives. `None` is a
-        /// daemon that starts holding nothing.
-        start: Option<PathBuf>,
+        /// The compose file used to configure this invocation. A bare daemon
+        /// tolerates it being absent; `--up` requires it.
+        file: PathBuf,
+        /// Whether to bring `file` up before the first call arrives.
+        start: bool,
     },
 }
 
@@ -88,22 +92,20 @@ impl ComposeCli {
 
         let explicit_daemon_namespace = self.validated_namespace()?;
 
-        // A missing `--file` is not "no file": it is the same fallback a call
-        // with no `file=` gets, the compose file in the working directory.
-        let start = self.up.then(|| {
-            self.file
-                .clone()
-                .unwrap_or_else(|| PathBuf::from(DEFAULT_COMPOSE_FILE))
-        });
+        // A missing `--file` is not "no file": the default file still supplies
+        // daemon configuration even when the project is not brought up yet.
+        let file = self
+            .file
+            .clone()
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_COMPOSE_FILE));
 
         Ok(ComposeCommand::Serve {
-            // Keep the environment out of the parsed plan. An `engine:`
-            // section owns its managed engine and ignores a process-wide
-            // III_URL, while an explicit --engine is a contradictory request
-            // we can report to the operator.
+            // Keep the environment out of the parsed plan. File, environment,
+            // and default resolution all happen together after the file load.
             explicit_engine_url: self.engine.clone().filter(|url| !url.trim().is_empty()),
             explicit_daemon_namespace,
-            start,
+            file,
+            start: self.up,
         })
     }
 
@@ -147,9 +149,8 @@ impl ComposeCli {
         }
     }
 
-    /// `--engine` > `III_URL`. There is deliberately no external-engine
-    /// default: without an `engine:` section the operator must name the engine
-    /// Compose is allowed to use.
+    /// Returns the explicit process-level engine selection. File and default
+    /// resolution happens after the compose file is loaded.
     pub fn requested_engine_url(&self) -> Option<String> {
         self.engine
             .clone()

--- a/crates/iii-compose/src/config.rs
+++ b/crates/iii-compose/src/config.rs
@@ -41,7 +41,7 @@ pub const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
 /// Default teardown grace between the polite stop and the forced kill.
 pub const DEFAULT_STOP_TIMEOUT: Duration = crate::process::DEFAULT_STOP_GRACE;
 
-pub const DEFAULT_MANAGED_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+pub const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
 
 pub const CONFIGURABLE_ENGINE_WORKERS: &[&str] = &[
     "configuration",
@@ -277,7 +277,7 @@ fn validate_engine(raw: RawEngineSpec) -> Result<EngineSpec> {
     let url = match raw.url {
         Some(url) if url.trim().is_empty() => return Err(ComposeError::InvalidManagedEngineUrl),
         Some(url) => url.trim().to_string(),
-        None => DEFAULT_MANAGED_ENGINE_URL.to_string(),
+        None => DEFAULT_ENGINE_URL.to_string(),
     };
 
     Ok(EngineSpec {

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -41,8 +41,18 @@ const SUPERVISION_INTERVAL: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Clone)]
 pub enum EnginePolicy {
-    Managed { owner: PathBuf, spec: EngineSpec },
+    Managed {
+        owner: PathBuf,
+        spec: EngineSpec,
+    },
     External,
+    /// An external engine selected while the invocation file still contains
+    /// `engine:`. `expected` is tracked when that section supplied the URL;
+    /// `None` means an explicit CLI URL overrides the section entirely.
+    ExternalFile {
+        owner: PathBuf,
+        expected: Option<EngineSpec>,
+    },
 }
 
 impl EnginePolicy {
@@ -51,6 +61,20 @@ impl EnginePolicy {
             owner: file.path.clone(),
             spec: spec.clone(),
         })
+    }
+
+    pub fn external_from_file(file: &ComposeFile) -> Self {
+        Self::ExternalFile {
+            owner: file.path.clone(),
+            expected: file.engine.clone(),
+        }
+    }
+
+    pub fn external_overriding(file: &ComposeFile) -> Self {
+        Self::ExternalFile {
+            owner: file.path.clone(),
+            expected: None,
+        }
     }
 
     fn validate_project(&self, file: &ComposeFile) -> Result<()> {
@@ -64,6 +88,20 @@ impl EnginePolicy {
                 Err(ComposeError::EngineSectionRequiresManagedStart { path })
             }
             Self::External => Ok(()),
+            Self::ExternalFile { owner, expected } if &path == owner => {
+                if expected.as_ref().is_some_and(|spec| engine != Some(spec)) {
+                    Err(ComposeError::EngineRestartRequired { path })
+                } else {
+                    Ok(())
+                }
+            }
+            Self::ExternalFile { owner, .. } if engine.is_some() => {
+                Err(ComposeError::EngineAlreadyOwned {
+                    owner: owner.clone(),
+                    path,
+                })
+            }
+            Self::ExternalFile { .. } => Ok(()),
             Self::Managed { owner, spec } if &path == owner => {
                 if engine == Some(spec) {
                     Ok(())
@@ -124,6 +162,9 @@ pub struct Daemon {
     /// This machine's identity — the `--id`, and the namespace it answers
     /// `compose::*` in. `id=` on a call is checked against it.
     pub daemon_namespace: String,
+    /// An explicit CLI namespace for every project loaded by this daemon.
+    /// When absent, each project keeps the namespace from its own file.
+    project_namespace_override: Option<String>,
     pub engine_url: String,
     engine: Arc<EngineClient>,
     engine_policy: EnginePolicy,
@@ -154,6 +195,7 @@ impl Daemon {
     pub fn start(
         requested_engine_url: String,
         daemon_namespace: String,
+        project_namespace_override: Option<String>,
         engine_policy: EnginePolicy,
     ) -> Arc<Self> {
         // A managed file is the sole engine source. Public callers receive the
@@ -161,7 +203,7 @@ impl Daemon {
         // different engines even if a stale URL was passed separately.
         let engine_url = match &engine_policy {
             EnginePolicy::Managed { spec, .. } => spec.url.clone(),
-            EnginePolicy::External => requested_engine_url,
+            EnginePolicy::External | EnginePolicy::ExternalFile { .. } => requested_engine_url,
         };
         // The name stays fixed and the *namespace* carries the identity, so
         // the lease is `(daemon_namespace, compose)`: two machines coexist, and two
@@ -175,6 +217,7 @@ impl Daemon {
         let daemon = Arc::new(Self {
             worker_name: DAEMON_WORKER_NAME.to_string(),
             daemon_namespace,
+            project_namespace_override,
             engine_url,
             engine,
             engine_policy,
@@ -194,6 +237,13 @@ impl Daemon {
     /// The registration rejection that stopped this daemon, if any.
     pub fn fatal_error(&self) -> Option<iii_sdk::Error> {
         self.engine.fatal_error()
+    }
+
+    fn project_namespace(&self, file: &ComposeFile) -> String {
+        crate::namespace::project_namespace(
+            self.project_namespace_override.as_deref(),
+            file.namespace.as_deref(),
+        )
     }
 
     /// The project `file` declares, loading it if this is the first time.
@@ -223,11 +273,12 @@ impl Daemon {
             self.engine_policy.validate_project(&compose)?;
             // Validate before announcing: a project that cannot start is better
             // refused here than half-started later.
-            let namespace = crate::namespace::project_namespace(None, compose.namespace.as_deref());
+            let namespace = self.project_namespace(&compose);
             crate::manifest::validate_offline(&compose, &namespace)?;
 
             let project = Project::open(
                 &self.daemon_namespace,
+                namespace.clone(),
                 compose,
                 Arc::clone(&self.engine),
                 self.engine_url.clone(),
@@ -615,7 +666,7 @@ impl Daemon {
 
         let current = crate::ComposeFile::parse(&edited, path)?;
         self.engine_policy.validate_project(&current)?;
-        let namespace = crate::namespace::project_namespace(None, current.namespace.as_deref());
+        let namespace = self.project_namespace(&current);
         crate::manifest::validate_offline(&current, &namespace)?;
 
         // Claim or load the old project before replacing the file: cleanup of
@@ -761,7 +812,7 @@ impl Daemon {
         }
         let compose = ComposeFile::load(file)?;
         self.engine_policy.validate_project(&compose)?;
-        let namespace = crate::namespace::project_namespace(None, compose.namespace.as_deref());
+        let namespace = self.project_namespace(&compose);
         crate::manifest::validate_offline(&compose, &namespace)
     }
 
@@ -1233,6 +1284,7 @@ mod tests {
         let daemon = Daemon::start(
             "ws://127.0.0.1:1/ws".to_string(),
             "managed-url-test".to_string(),
+            None,
             policy,
         );
 

--- a/crates/iii-compose/src/error.rs
+++ b/crates/iii-compose/src/error.rs
@@ -304,12 +304,17 @@ pub enum ComposeError {
     #[error("managed engine could not start: {message}")]
     EngineSpawnFailed { message: String },
 
-    #[error("managed engine cannot listen at {engine_url}: {source}")]
+    #[error("managed engine cannot listen at {listener}: {source}")]
     ManagedEngineListenerUnavailable {
-        engine_url: String,
+        listener: String,
         #[source]
         source: std::io::Error,
     },
+
+    #[error(
+        "engine.url uses port {url_port}, but iii-worker-manager listens on port {listener_port}"
+    )]
+    ManagedEngineEndpointMismatch { url_port: u16, listener_port: u16 },
 
     #[error(
         "managed engine exited with {code}{}",
@@ -533,6 +538,7 @@ impl ComposeError {
             Self::EngineCallFailed { .. } => "ENGINE_CALL_FAILED",
             Self::EngineSpawnFailed { .. } => "ENGINE_SPAWN_FAILED",
             Self::ManagedEngineListenerUnavailable { .. } => "MANAGED_ENGINE_LISTENER_UNAVAILABLE",
+            Self::ManagedEngineEndpointMismatch { .. } => "MANAGED_ENGINE_ENDPOINT_MISMATCH",
             Self::EngineExited { .. } => "ENGINE_EXITED",
             Self::EngineReadinessTimeout { .. } => "ENGINE_STARTUP_TIMEOUT",
             Self::FunctionsInWrongNamespace { .. } => "FUNCTIONS_IN_WRONG_NAMESPACE",

--- a/crates/iii-compose/src/error.rs
+++ b/crates/iii-compose/src/error.rs
@@ -46,18 +46,6 @@ pub enum ComposeError {
     #[error("engine.url must not be blank when it is set")]
     InvalidManagedEngineUrl,
 
-    #[error(
-        "worker-compose.yaml has no engine section. Pass --engine <ws-url> or set III_URL to \
-         connect this Compose invocation to an existing engine"
-    )]
-    EngineUrlRequired,
-
-    #[error(
-        "--engine cannot be combined with the engine section in worker-compose.yaml. \
-         Remove --engine or remove engine: to use an existing engine"
-    )]
-    EngineUrlConflictsWithManaged,
-
     #[error("--file requires --up")]
     FileRequiresUp,
 
@@ -316,6 +304,13 @@ pub enum ComposeError {
     #[error("managed engine could not start: {message}")]
     EngineSpawnFailed { message: String },
 
+    #[error("managed engine cannot listen at {engine_url}: {source}")]
+    ManagedEngineListenerUnavailable {
+        engine_url: String,
+        #[source]
+        source: std::io::Error,
+    },
+
     #[error(
         "managed engine exited with {code}{}",
         match .tail {
@@ -496,8 +491,6 @@ impl ComposeError {
             Self::EngineWorkerIsInjected { .. } => "ENGINE_WORKER_IS_INJECTED",
             Self::InvalidEngineWorkerConfig { .. } => "INVALID_ENGINE_WORKER_CONFIG",
             Self::InvalidManagedEngineUrl => "INVALID_MANAGED_ENGINE_URL",
-            Self::EngineUrlRequired => "ENGINE_URL_REQUIRED",
-            Self::EngineUrlConflictsWithManaged => "ENGINE_URL_CONFLICTS_WITH_MANAGED",
             Self::FileRequiresUp => "FILE_REQUIRES_UP",
             Self::EngineSectionRequiresManagedStart { .. } => {
                 "ENGINE_SECTION_REQUIRES_MANAGED_START"
@@ -539,6 +532,7 @@ impl ComposeError {
             Self::ConfigPublishFailed { .. } => "CONFIG_PUBLISH_FAILED",
             Self::EngineCallFailed { .. } => "ENGINE_CALL_FAILED",
             Self::EngineSpawnFailed { .. } => "ENGINE_SPAWN_FAILED",
+            Self::ManagedEngineListenerUnavailable { .. } => "MANAGED_ENGINE_LISTENER_UNAVAILABLE",
             Self::EngineExited { .. } => "ENGINE_EXITED",
             Self::EngineReadinessTimeout { .. } => "ENGINE_STARTUP_TIMEOUT",
             Self::FunctionsInWrongNamespace { .. } => "FUNCTIONS_IN_WRONG_NAMESPACE",

--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -52,26 +52,38 @@ pub enum EngineMode {
     External { url: String },
 }
 
-/// Resolves engine ownership only after the initial compose file has been
-/// parsed. The file is authoritative for managed mode; an explicit CLI URL is
-/// contradictory there, while a process-wide environment URL is ignored. In
-/// external mode the CLI wins over the environment.
+/// Resolves the engine URL and ownership after the compose file is parsed.
+///
+/// An explicit CLI URL always selects an external engine. Without one, an
+/// `engine:` section is managed only when `--up` starts that file; a bare
+/// daemon connects to its URL without taking ownership. File configuration
+/// wins over the process environment, and the local engine address is the
+/// final fallback.
 pub fn resolve_engine_mode(
     file: Option<&ComposeFile>,
-    explicit_engine_url: Option<String>,
-    environment_engine_url: Option<String>,
-) -> Result<EngineMode> {
-    match file.and_then(|file| file.engine.as_ref()) {
-        Some(_) if explicit_engine_url.is_some() => {
-            Err(ComposeError::EngineUrlConflictsWithManaged)
-        }
-        Some(engine) => Ok(EngineMode::Managed {
+    start: bool,
+    explicit_engine_url: Option<&str>,
+    environment_engine_url: Option<&str>,
+) -> EngineMode {
+    if let Some(url) = explicit_engine_url {
+        return EngineMode::External {
+            url: url.to_string(),
+        };
+    }
+
+    if start && let Some(engine) = file.and_then(|file| file.engine.as_ref()) {
+        return EngineMode::Managed {
             url: engine.url.clone(),
-        }),
-        None => explicit_engine_url
-            .or(environment_engine_url)
-            .map(|url| EngineMode::External { url })
-            .ok_or(ComposeError::EngineUrlRequired),
+        };
+    }
+
+    let url = file
+        .and_then(|file| file.engine.as_ref())
+        .map(|engine| engine.url.as_str())
+        .or(environment_engine_url)
+        .unwrap_or(config::DEFAULT_ENGINE_URL);
+    EngineMode::External {
+        url: url.to_string(),
     }
 }
 
@@ -99,8 +111,9 @@ pub async fn run(cli: ComposeCli) -> i32 {
         ComposeCommand::Serve {
             explicit_engine_url,
             explicit_daemon_namespace,
+            file,
             start,
-        } => match serve(explicit_engine_url, explicit_daemon_namespace, start).await {
+        } => match serve(explicit_engine_url, explicit_daemon_namespace, file, start).await {
             Ok(()) => 0,
             Err(err) => report_error(&err),
         },
@@ -109,33 +122,54 @@ pub async fn run(cli: ComposeCli) -> i32 {
 
 /// Serves `compose::*` until asked to stop.
 ///
-/// `start` is the project `iii compose --up` named. Without it no project is
-/// loaded: a daemon that has just started knows nothing, and the first
-/// `compose::up file=…` is what teaches it — which is what lets one daemon hold
-/// several projects without being restarted for each.
+/// `file` configures the daemon when it exists. `start` controls only whether
+/// that file is also brought up before the first remote call.
 async fn serve(
     explicit_engine_url: Option<String>,
     explicit_daemon_namespace: Option<String>,
-    start: Option<std::path::PathBuf>,
+    file: std::path::PathBuf,
+    start: bool,
 ) -> Result<()> {
     use colored::Colorize;
 
-    // Ownership is a property of the file, so load it before spawning the
-    // engine. Invalid YAML and missing external URLs must fail with no child
-    // process left behind.
-    let initial_file = start.as_ref().map(ComposeFile::load).transpose()?;
+    // Parse before any child is started. A bare daemon can run outside a
+    // project, but an existing default file still supplies its URL and
+    // namespace.
+    let initial_file = load_invocation_file(&file, start)?;
     let daemon_namespace =
-        resolve_daemon_namespace(explicit_daemon_namespace, initial_file.as_ref());
+        resolve_daemon_namespace(explicit_daemon_namespace.clone(), initial_file.as_ref());
     let environment_engine_url = std::env::var("III_URL")
         .ok()
         .filter(|url| !url.trim().is_empty());
     let engine_mode = resolve_engine_mode(
         initial_file.as_ref(),
-        explicit_engine_url,
-        environment_engine_url,
-    )?;
+        start,
+        explicit_engine_url.as_deref(),
+        environment_engine_url.as_deref(),
+    );
     let engine_url = match &engine_mode {
         EngineMode::Managed { url } | EngineMode::External { url } => url.clone(),
+    };
+
+    let engine_policy = match &engine_mode {
+        EngineMode::Managed { .. } => {
+            let Some(policy) = initial_file
+                .as_ref()
+                .and_then(daemon::EnginePolicy::managed)
+            else {
+                unreachable!("managed mode is selected only from an engine section");
+            };
+            policy
+        }
+        EngineMode::External { .. } => {
+            match initial_file.as_ref().filter(|file| file.engine.is_some()) {
+                Some(file) if explicit_engine_url.is_some() => {
+                    daemon::EnginePolicy::external_overriding(file)
+                }
+                Some(file) => daemon::EnginePolicy::external_from_file(file),
+                None => daemon::EnginePolicy::External,
+            }
+        }
     };
 
     // Install this before the first owned process starts. Signal delivery uses
@@ -145,22 +179,16 @@ async fn serve(
 
     let managed_engine = match engine_mode {
         EngineMode::Managed { .. } => {
-            let spec = initial_file
-                .as_ref()
-                .and_then(|file| file.engine.as_ref())
-                .expect("managed mode requires an engine section");
+            let Some(owner) = initial_file.as_ref() else {
+                unreachable!("managed mode is selected only from a compose file");
+            };
+            let Some(spec) = owner.engine.as_ref() else {
+                unreachable!("managed mode is selected only from an engine section");
+            };
             let engine = managed_engine::ManagedEngine::start(spec, &daemon_namespace).await?;
             println!("engine {}", "started".green());
             println!("  {} {}", "pid:".dimmed(), engine.pid());
-            println!(
-                "  {} {}",
-                "owner:".dimmed(),
-                initial_file
-                    .as_ref()
-                    .expect("managed mode requires an owner file")
-                    .path
-                    .display()
-            );
+            println!("  {} {}", "owner:".dimmed(), owner.path.display());
             println!(
                 "  {} {}",
                 "config:".dimmed(),
@@ -174,18 +202,15 @@ async fn serve(
         EngineMode::External { .. } => None,
     };
 
-    let engine_policy = initial_file
-        .as_ref()
-        .and_then(daemon::EnginePolicy::managed)
-        .unwrap_or(daemon::EnginePolicy::External);
-
     let result = if shutdown.requested() {
         Ok(())
     } else {
+        let start_file = start.then_some(file);
         serve_daemon(
             engine_url,
             daemon_namespace,
-            start,
+            explicit_daemon_namespace,
+            start_file,
             managed_engine.as_ref(),
             engine_policy,
             shutdown,
@@ -211,9 +236,22 @@ fn resolve_daemon_namespace(
     )
 }
 
+fn load_invocation_file(file: &std::path::Path, required: bool) -> Result<Option<ComposeFile>> {
+    match ComposeFile::load(file) {
+        Ok(file) => Ok(Some(file)),
+        Err(ComposeError::Io { source, .. })
+            if !required && source.kind() == std::io::ErrorKind::NotFound =>
+        {
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
 async fn serve_daemon(
     engine_url: String,
     daemon_namespace: String,
+    project_namespace_override: Option<String>,
     start: Option<std::path::PathBuf>,
     managed_engine: Option<&managed_engine::ManagedEngine>,
     engine_policy: daemon::EnginePolicy,
@@ -221,7 +259,12 @@ async fn serve_daemon(
 ) -> Result<()> {
     use colored::Colorize;
 
-    let daemon = daemon::Daemon::start(engine_url, daemon_namespace, engine_policy);
+    let daemon = daemon::Daemon::start(
+        engine_url,
+        daemon_namespace,
+        project_namespace_override,
+        engine_policy,
+    );
     remote::register(&daemon);
 
     // Announce only once the engine has accepted this daemon. A rejection
@@ -388,7 +431,7 @@ fn report_error(err: &ComposeError) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{ComposeFile, resolve_daemon_namespace};
+    use super::{ComposeFile, load_invocation_file, resolve_daemon_namespace};
 
     fn compose_with_namespace() -> ComposeFile {
         ComposeFile::parse(
@@ -433,5 +476,33 @@ mod tests {
             resolve_daemon_namespace(None, Some(&compose)),
             crate::namespace::DEFAULT_NAMESPACE
         );
+    }
+
+    #[test]
+    fn bare_compose_loads_an_existing_default_file_for_configuration() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("worker-compose.yaml");
+        std::fs::write(
+            &path,
+            "namespace: orders\nengine: { workers: {} }\ncontainers: {}\n",
+        )
+        .unwrap();
+
+        let loaded = load_invocation_file(&path, false).unwrap();
+
+        assert_eq!(
+            loaded.and_then(|file| file.namespace).as_deref(),
+            Some("orders")
+        );
+    }
+
+    #[test]
+    fn bare_compose_tolerates_a_missing_default_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("worker-compose.yaml");
+
+        let loaded = load_invocation_file(&path, false).unwrap();
+
+        assert!(loaded.is_none());
     }
 }

--- a/crates/iii-compose/src/managed_engine.rs
+++ b/crates/iii-compose/src/managed_engine.rs
@@ -44,6 +44,7 @@ impl ManagedEngine {
     /// Starts the current `iii` executable with output detached from compose's
     /// terminal and captured below this daemon namespace's state directory.
     pub async fn start(spec: &EngineSpec, daemon_namespace: &str) -> Result<Self> {
+        ensure_listener_available(&spec.url)?;
         let executable =
             std::env::current_exe().map_err(|err| ComposeError::EngineSpawnFailed {
                 message: format!("could not locate the current iii executable: {err}"),
@@ -268,7 +269,13 @@ fn materialize_engine_config(spec: &EngineSpec, namespace_dir: &Path) -> Result<
     Ok(path)
 }
 
-fn worker_manager_config_from_url(engine_url: &str) -> Result<serde_yaml::Value> {
+struct EngineEndpoint {
+    bind_host: String,
+    worker_host: String,
+    port: u16,
+}
+
+fn engine_endpoint(engine_url: &str) -> Result<EngineEndpoint> {
     let url = url::Url::parse(engine_url).map_err(|_| ComposeError::EngineSpawnFailed {
         message: "engine.url must be a valid ws:// or wss:// URL".to_string(),
     })?;
@@ -277,9 +284,12 @@ fn worker_manager_config_from_url(engine_url: &str) -> Result<serde_yaml::Value>
             message: "engine.url must be a valid ws:// or wss:// URL".to_string(),
         });
     }
-    let host = match url.host() {
-        Some(url::Host::Ipv6(address)) => format!("[{address}]"),
-        Some(host) => host.to_string(),
+    let (bind_host, worker_host) = match url.host() {
+        Some(url::Host::Ipv6(address)) => (address.to_string(), format!("[{address}]")),
+        Some(host) => {
+            let host = host.to_string();
+            (host.clone(), host)
+        }
         None => {
             return Err(ComposeError::EngineSpawnFailed {
                 message: "engine.url must include a host".to_string(),
@@ -291,14 +301,33 @@ fn worker_manager_config_from_url(engine_url: &str) -> Result<serde_yaml::Value>
         .ok_or_else(|| ComposeError::EngineSpawnFailed {
             message: "engine.url must include a port".to_string(),
         })?;
+    Ok(EngineEndpoint {
+        bind_host,
+        worker_host,
+        port,
+    })
+}
+
+fn ensure_listener_available(engine_url: &str) -> Result<()> {
+    let endpoint = engine_endpoint(engine_url)?;
+    std::net::TcpListener::bind((endpoint.bind_host.as_str(), endpoint.port))
+        .map(drop)
+        .map_err(|source| ComposeError::ManagedEngineListenerUnavailable {
+            engine_url: engine_url.to_string(),
+            source,
+        })
+}
+
+fn worker_manager_config_from_url(engine_url: &str) -> Result<serde_yaml::Value> {
+    let endpoint = engine_endpoint(engine_url)?;
     let config = serde_yaml::Mapping::from_iter([
         (
             serde_yaml::Value::String("host".to_string()),
-            serde_yaml::Value::String(host),
+            serde_yaml::Value::String(endpoint.worker_host),
         ),
         (
             serde_yaml::Value::String("port".to_string()),
-            serde_yaml::Value::Number(port.into()),
+            serde_yaml::Value::Number(endpoint.port.into()),
         ),
     ]);
 
@@ -837,6 +866,17 @@ containers: {}
             )
             .unwrap()
         );
+    }
+
+    #[test]
+    fn occupied_managed_engine_listener_is_refused() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let error = ensure_listener_available(&format!("ws://127.0.0.1:{port}"))
+            .expect_err("an occupied managed listener must be rejected");
+
+        assert_eq!(error.code(), "MANAGED_ENGINE_LISTENER_UNAVAILABLE");
     }
 
     #[test]

--- a/crates/iii-compose/src/managed_engine.rs
+++ b/crates/iii-compose/src/managed_engine.rs
@@ -956,7 +956,7 @@ engine:
   workers:
     iii-worker-manager:
       host: 0.0.0.0
-      port: ${ENGINE_PORT:60123}
+      port: 60123
 containers: {}
 "#,
             "/srv/app/worker-compose.yaml",

--- a/crates/iii-compose/src/managed_engine.rs
+++ b/crates/iii-compose/src/managed_engine.rs
@@ -29,6 +29,8 @@ const ENGINE_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
 const ENGINE_LOG_ARCHIVES: usize = 3;
 const ENGINE_LOCK_FILE: &str = "engine.lock";
 const ENGINE_CONFIG_FILE: &str = "engine-config.yaml";
+const DEFAULT_WORKER_MANAGER_HOST: &str = "0.0.0.0";
+const DEFAULT_WORKER_MANAGER_PORT: u16 = 49134;
 
 /// The engine process owned by one foreground compose invocation.
 pub struct ManagedEngine {
@@ -44,7 +46,7 @@ impl ManagedEngine {
     /// Starts the current `iii` executable with output detached from compose's
     /// terminal and captured below this daemon namespace's state directory.
     pub async fn start(spec: &EngineSpec, daemon_namespace: &str) -> Result<Self> {
-        ensure_listener_available(&spec.url)?;
+        ensure_listener_available(spec)?;
         let executable =
             std::env::current_exe().map_err(|err| ComposeError::EngineSpawnFailed {
                 message: format!("could not locate the current iii executable: {err}"),
@@ -269,8 +271,8 @@ fn materialize_engine_config(spec: &EngineSpec, namespace_dir: &Path) -> Result<
     Ok(path)
 }
 
+#[derive(Debug)]
 struct EngineEndpoint {
-    bind_host: String,
     worker_host: String,
     port: u16,
 }
@@ -284,12 +286,9 @@ fn engine_endpoint(engine_url: &str) -> Result<EngineEndpoint> {
             message: "engine.url must be a valid ws:// or wss:// URL".to_string(),
         });
     }
-    let (bind_host, worker_host) = match url.host() {
-        Some(url::Host::Ipv6(address)) => (address.to_string(), format!("[{address}]")),
-        Some(host) => {
-            let host = host.to_string();
-            (host.clone(), host)
-        }
+    let worker_host = match url.host() {
+        Some(url::Host::Ipv6(address)) => format!("[{address}]"),
+        Some(host) => host.to_string(),
         None => {
             return Err(ComposeError::EngineSpawnFailed {
                 message: "engine.url must include a host".to_string(),
@@ -301,21 +300,87 @@ fn engine_endpoint(engine_url: &str) -> Result<EngineEndpoint> {
         .ok_or_else(|| ComposeError::EngineSpawnFailed {
             message: "engine.url must include a port".to_string(),
         })?;
-    Ok(EngineEndpoint {
-        bind_host,
-        worker_host,
-        port,
-    })
+    Ok(EngineEndpoint { worker_host, port })
 }
 
-fn ensure_listener_available(engine_url: &str) -> Result<()> {
-    let endpoint = engine_endpoint(engine_url)?;
-    std::net::TcpListener::bind((endpoint.bind_host.as_str(), endpoint.port))
+fn effective_listener_endpoint(spec: &EngineSpec) -> Result<EngineEndpoint> {
+    let url_endpoint = engine_endpoint(&spec.url)?;
+    let Some(config) = spec.workers.get("iii-worker-manager") else {
+        return Ok(url_endpoint);
+    };
+    let mapping = config
+        .as_mapping()
+        .expect("engine worker mappings are validated while the compose file is parsed");
+    let field = |name: &str| mapping.get(serde_yaml::Value::String(name.to_string()));
+    let worker_host = match field("host") {
+        Some(serde_yaml::Value::String(host)) => expand_engine_env_references(host)?,
+        Some(_) => {
+            return Err(ComposeError::EngineSpawnFailed {
+                message: "iii-worker-manager host must be a string".to_string(),
+            });
+        }
+        None => DEFAULT_WORKER_MANAGER_HOST.to_string(),
+    };
+    let port = match field("port") {
+        Some(serde_yaml::Value::Number(port)) => {
+            port.as_u64().and_then(|port| u16::try_from(port).ok())
+        }
+        Some(serde_yaml::Value::String(port)) => expand_engine_env_references(port)?.parse().ok(),
+        Some(_) => None,
+        None => Some(DEFAULT_WORKER_MANAGER_PORT),
+    }
+    .ok_or_else(|| ComposeError::EngineSpawnFailed {
+        message: "iii-worker-manager port must resolve to an integer from 0 to 65535".to_string(),
+    })?;
+
+    if port != url_endpoint.port {
+        return Err(ComposeError::ManagedEngineEndpointMismatch {
+            url_port: url_endpoint.port,
+            listener_port: port,
+        });
+    }
+
+    Ok(EngineEndpoint { worker_host, port })
+}
+
+/// Expands the `${NAME:default}` syntax used by the engine config loader.
+fn expand_engine_env_references(text: &str) -> Result<String> {
+    let mut output = String::with_capacity(text.len());
+    let mut rest = text;
+
+    while let Some(start) = rest.find("${") {
+        output.push_str(&rest[..start]);
+        let reference = &rest[start + 2..];
+        let Some(end) = reference.find('}') else {
+            output.push_str(&rest[start..]);
+            return Ok(output);
+        };
+        let body = &reference[..end];
+        let (name, default) = body
+            .split_once(':')
+            .map_or((body, None), |(name, default)| (name, Some(default)));
+        let value = std::env::var(name)
+            .ok()
+            .or_else(|| default.map(str::to_string))
+            .ok_or_else(|| ComposeError::EngineSpawnFailed {
+                message: format!(
+                    "environment variable '{name}' is required by iii-worker-manager config"
+                ),
+            })?;
+        output.push_str(&value);
+        rest = &reference[end + 1..];
+    }
+
+    output.push_str(rest);
+    Ok(output)
+}
+
+fn ensure_listener_available(spec: &EngineSpec) -> Result<()> {
+    let endpoint = effective_listener_endpoint(spec)?;
+    let listener = format!("{}:{}", endpoint.worker_host, endpoint.port);
+    std::net::TcpListener::bind(&listener)
         .map(drop)
-        .map_err(|source| ComposeError::ManagedEngineListenerUnavailable {
-            engine_url: engine_url.to_string(),
-            source,
-        })
+        .map_err(|source| ComposeError::ManagedEngineListenerUnavailable { listener, source })
 }
 
 fn worker_manager_config_from_url(engine_url: &str) -> Result<serde_yaml::Value> {
@@ -872,11 +937,38 @@ containers: {}
     fn occupied_managed_engine_listener_is_refused() {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
+        let mut spec = engine_spec();
+        spec.url = format!("ws://127.0.0.1:{port}");
+        spec.workers.remove("iii-worker-manager");
 
-        let error = ensure_listener_available(&format!("ws://127.0.0.1:{port}"))
+        let error = ensure_listener_available(&spec)
             .expect_err("an occupied managed listener must be rejected");
 
         assert_eq!(error.code(), "MANAGED_ENGINE_LISTENER_UNAVAILABLE");
+    }
+
+    #[test]
+    fn explicit_worker_manager_port_must_match_the_engine_url() {
+        let spec = crate::ComposeFile::parse(
+            r#"
+engine:
+  url: ws://127.0.0.1:50123
+  workers:
+    iii-worker-manager:
+      host: 0.0.0.0
+      port: ${ENGINE_PORT:60123}
+containers: {}
+"#,
+            "/srv/app/worker-compose.yaml",
+        )
+        .unwrap()
+        .engine
+        .unwrap();
+
+        let error = effective_listener_endpoint(&spec)
+            .expect_err("different URL and listener ports must be rejected");
+
+        assert_eq!(error.code(), "MANAGED_ENGINE_ENDPOINT_MISMATCH");
     }
 
     #[test]

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -32,7 +32,6 @@ use crate::{
     engine::EngineClient,
     error::Result,
     lifecycle::{self, Children, LifecycleCtx, OpResult},
-    namespace::project_namespace,
     process::Supervised,
     state::{ChildStatus, DaemonState, Reconciliation, StateStore, reconcile},
 };
@@ -73,16 +72,15 @@ impl Project {
     /// Loads a project, adopts whatever survived a previous run, and returns
     /// it ready to be operated.
     ///
-    /// A project is its compose file. Its namespace comes from that file's
-    /// `name:` and addresses its workers; the two are different questions and
-    /// nothing else names the project.
+    /// `project_namespace` is already resolved by the daemon so an explicit
+    /// CLI namespace cannot be lost while the project is opened.
     pub async fn open(
         daemon_namespace: &str,
+        project_namespace: String,
         file: ComposeFile,
         engine: Arc<EngineClient>,
         engine_url: String,
     ) -> Result<Arc<Self>> {
-        let project_namespace = project_namespace(None, file.namespace.as_deref());
         let store = StateStore::for_project(daemon_namespace, &file.path)?;
         let file_path = file.path.clone();
 

--- a/crates/iii-compose/tests/cli.rs
+++ b/crates/iii-compose/tests/cli.rs
@@ -134,7 +134,7 @@ fn a_programmatic_file_without_up_is_refused() {
 }
 
 #[test]
-fn an_explicit_engine_beats_the_environment_and_there_is_no_default_external_url() {
+fn requested_engine_url_reports_only_cli_or_environment_values() {
     // The only test that touches III_URL, so no other test can race it.
     unsafe { std::env::set_var("III_URL", "ws://from-env:1") };
 
@@ -164,24 +164,21 @@ fn a_project_namespace_still_comes_from_the_file_or_default() {
 
 #[test]
 fn bare_compose_starts_holding_nothing() {
-    let ComposeCommand::Serve { start, .. } =
+    let ComposeCommand::Serve { file, start, .. } =
         parse(&["iii", "compose", "--engine", "ws://shared:49134"])
             .plan()
             .unwrap();
-    assert_eq!(
-        start, None,
-        "a bare daemon learns about a project from a call"
-    );
+    assert_eq!(file, std::path::Path::new("worker-compose.yaml"));
+    assert!(!start, "a bare daemon must not start the default file");
 }
 
 #[test]
 fn up_names_the_file_in_the_current_directory() {
     // The point of the flag: in a project directory, one option starts it.
-    let ComposeCommand::Serve { start, .. } = parse(&["iii", "compose", "--up"]).plan().unwrap();
-    assert_eq!(
-        start.as_deref(),
-        Some(std::path::Path::new("worker-compose.yaml"))
-    );
+    let ComposeCommand::Serve { file, start, .. } =
+        parse(&["iii", "compose", "--up"]).plan().unwrap();
+    assert_eq!(file, std::path::Path::new("worker-compose.yaml"));
+    assert!(start);
 }
 
 #[test]
@@ -201,15 +198,14 @@ fn production_docker_compose_command_matches_the_cli() {
     let Wrapper::Compose(cli) = Wrapper::try_parse_from(args).unwrap();
     let ComposeCommand::Serve {
         explicit_daemon_namespace,
+        file,
         start,
         ..
     } = cli.plan().unwrap();
 
     assert_eq!(explicit_daemon_namespace.as_deref(), Some("production"));
-    assert_eq!(
-        start.as_deref(),
-        Some(std::path::Path::new("/app/worker-compose.yaml"))
-    );
+    assert_eq!(file, std::path::Path::new("/app/worker-compose.yaml"));
+    assert!(start);
 }
 
 #[test]
@@ -221,11 +217,11 @@ fn up_without_a_cli_namespace_defers_to_the_compose_file() {
     } = parse(&["iii", "compose", "--up"]).plan().unwrap();
 
     assert_eq!(explicit_daemon_namespace, None);
-    assert!(start.is_some());
+    assert!(start);
 }
 
 #[test]
-fn engine_section_selects_managed_mode_and_forbids_an_external_url() {
+fn up_uses_the_file_engine_when_the_cli_does_not_override_it() {
     let managed = ComposeFile::parse(
         "engine: { workers: {} }\ncontainers: {}\n",
         "/srv/app/worker-compose.yaml",
@@ -233,24 +229,12 @@ fn engine_section_selects_managed_mode_and_forbids_an_external_url() {
     .unwrap();
 
     assert_eq!(
-        resolve_engine_mode(Some(&managed), None, None).unwrap(),
-        EngineMode::Managed {
-            url: "ws://127.0.0.1:49134".to_string()
-        }
-    );
-    assert_eq!(
-        resolve_engine_mode(Some(&managed), Some("ws://other:1".to_string()), None,)
-            .unwrap_err()
-            .code(),
-        "ENGINE_URL_CONFLICTS_WITH_MANAGED"
-    );
-    assert_eq!(
         resolve_engine_mode(
             Some(&managed),
+            true,
             None,
-            Some("ws://global-environment:49134".to_string()),
-        )
-        .unwrap(),
+            Some("ws://global-environment:49134"),
+        ),
         EngineMode::Managed {
             url: "ws://127.0.0.1:49134".to_string()
         },
@@ -259,7 +243,39 @@ fn engine_section_selects_managed_mode_and_forbids_an_external_url() {
 }
 
 #[test]
-fn compose_without_engine_section_requires_an_external_url() {
+fn explicit_engine_overrides_the_file_engine_with_up() {
+    let managed = ComposeFile::parse(
+        "engine: { workers: {} }\ncontainers: {}\n",
+        "/srv/app/worker-compose.yaml",
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolve_engine_mode(Some(&managed), true, Some("ws://other:1"), None),
+        EngineMode::External {
+            url: "ws://other:1".to_string()
+        }
+    );
+}
+
+#[test]
+fn bare_compose_connects_to_the_file_engine_without_owning_it() {
+    let managed = ComposeFile::parse(
+        "engine: { url: 'ws://file-engine:49134', workers: {} }\ncontainers: {}\n",
+        "/srv/app/worker-compose.yaml",
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolve_engine_mode(Some(&managed), false, None, None),
+        EngineMode::External {
+            url: "ws://file-engine:49134".to_string()
+        }
+    );
+}
+
+#[test]
+fn explicit_engine_beats_the_environment_without_an_engine_section() {
     let external = ComposeFile::parse(
         "containers:\n  api:\n    worker: path://./api\n",
         "/srv/app/worker-compose.yaml",
@@ -269,29 +285,40 @@ fn compose_without_engine_section_requires_an_external_url() {
     assert_eq!(
         resolve_engine_mode(
             Some(&external),
-            Some("ws://shared:49134".to_string()),
-            Some("ws://environment:49134".to_string()),
-        )
-        .unwrap(),
+            true,
+            Some("ws://shared:49134"),
+            Some("ws://environment:49134"),
+        ),
         EngineMode::External {
             url: "ws://shared:49134".to_string()
         }
     );
+}
+
+#[test]
+fn compose_without_an_engine_source_uses_the_local_default() {
+    let external = ComposeFile::parse(
+        "containers:\n  api:\n    worker: path://./api\n",
+        "/srv/app/worker-compose.yaml",
+    )
+    .unwrap();
+
     assert_eq!(
-        resolve_engine_mode(Some(&external), None, None)
-            .unwrap_err()
-            .code(),
-        "ENGINE_URL_REQUIRED"
+        resolve_engine_mode(Some(&external), true, None, None),
+        EngineMode::External {
+            url: "ws://127.0.0.1:49134".to_string()
+        }
     );
 }
 
 #[test]
 fn up_takes_a_file_of_its_own() {
-    let ComposeCommand::Serve { start, .. } =
+    let ComposeCommand::Serve { file, start, .. } =
         parse(&["iii", "compose", "--up", "-f", "./other.yaml"])
             .plan()
             .unwrap();
-    assert_eq!(start.as_deref(), Some(std::path::Path::new("./other.yaml")));
+    assert_eq!(file, std::path::Path::new("./other.yaml"));
+    assert!(start);
 }
 
 #[test]
@@ -310,6 +337,6 @@ fn the_namespace_reads_the_same_on_either_side_of_the_up_flag() {
             ..
         } = cli.plan().unwrap();
         assert_eq!(explicit_daemon_namespace.as_deref(), Some("orders"));
-        assert!(start.is_some(), "{args:?} should still enable --up");
+        assert!(start, "{args:?} should still enable --up");
     }
 }

--- a/crates/iii-compose/tests/project_cache.rs
+++ b/crates/iii-compose/tests/project_cache.rs
@@ -43,6 +43,7 @@ fn daemon() -> Arc<Daemon> {
     Daemon::start(
         "ws://127.0.0.1:1/ws".to_string(),
         format!("cache-test-{}", std::process::id()),
+        None,
         EnginePolicy::External,
     )
 }
@@ -108,6 +109,24 @@ async fn the_same_file_reached_twice_is_still_one_project() {
     assert!(Arc::ptr_eq(&first, &second));
 }
 
+#[tokio::test]
+async fn explicit_cli_namespace_overrides_the_project_file_namespace() {
+    isolate_state();
+    let tmp = project_dir();
+    let file = tmp.path().join("worker-compose.yaml");
+    std::fs::write(&file, COMPOSE).unwrap();
+    let daemon = Daemon::start(
+        "ws://127.0.0.1:1/ws".to_string(),
+        "test".to_string(),
+        Some("test".to_string()),
+        EnginePolicy::External,
+    );
+
+    let project = daemon.project(&file).await.unwrap();
+
+    assert_eq!(project.project_namespace, "test");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_load_that_failed_is_retried_rather_than_cached() {
     let tmp = project_dir();
@@ -138,6 +157,29 @@ async fn external_daemon_rejects_a_project_that_tries_to_own_an_engine() {
         Ok(_) => panic!("external daemon must reject engine ownership"),
     };
     assert_eq!(err.code(), "ENGINE_SECTION_REQUIRES_MANAGED_START");
+}
+
+#[tokio::test]
+async fn explicit_external_engine_overrides_the_owner_file_engine_section() {
+    isolate_state();
+    let tmp = project_dir();
+    let file = tmp.path().join("worker-compose.yaml");
+    std::fs::write(
+        &file,
+        "engine: { url: 'ws://ignored:49134', workers: {} }\ncontainers:\n  api:\n    worker: path://./workers/api\n    scripts:\n      run: ./api\n",
+    )
+    .unwrap();
+    let initial = iii_compose::ComposeFile::load(&file).unwrap();
+    let daemon = Daemon::start(
+        "ws://127.0.0.1:1/ws".to_string(),
+        format!("external-override-test-{}", std::process::id()),
+        None,
+        EnginePolicy::external_overriding(&initial),
+    );
+
+    let project = daemon.project(&file).await.unwrap();
+
+    assert_eq!(project.engine_url, "ws://127.0.0.1:1/ws");
 }
 
 #[tokio::test]
@@ -178,6 +220,7 @@ async fn managed_daemon_requires_restart_when_its_owner_engine_section_changes()
     let daemon = Daemon::start(
         "ws://127.0.0.1:1/ws".to_string(),
         format!("managed-change-test-{}", std::process::id()),
+        None,
         policy,
     );
     let err = match daemon.project(&file).await {
@@ -198,6 +241,7 @@ async fn up_rechecks_the_owner_engine_section_after_the_project_is_cached() {
     let daemon = Daemon::start(
         "ws://127.0.0.1:1/ws".to_string(),
         format!("managed-cached-change-test-{}", std::process::id()),
+        None,
         EnginePolicy::managed(&initial).unwrap(),
     );
     daemon
@@ -232,6 +276,7 @@ async fn managed_daemon_rejects_a_second_engine_owner() {
     let daemon = Daemon::start(
         "ws://127.0.0.1:1/ws".to_string(),
         format!("managed-owner-test-{}", std::process::id()),
+        None,
         EnginePolicy::managed(&initial).unwrap(),
     );
     let err = match daemon.project(&other).await {
@@ -260,6 +305,7 @@ fn managed_mutation_fixture(
     let daemon = Daemon::start(
         "ws://127.0.0.1:1/ws".to_string(),
         format!("managed-mutation-test-{}", std::process::id()),
+        None,
         EnginePolicy::managed(&initial).unwrap(),
     );
     (tmp, file, daemon)

--- a/crates/iii-compose/tests/start_script.rs
+++ b/crates/iii-compose/tests/start_script.rs
@@ -160,3 +160,51 @@ fn explicit_engine_overrides_the_compose_file_engine() {
     .unwrap();
     std::fs::remove_file(pid_file).unwrap();
 }
+
+#[test]
+fn compose_file_without_engine_uses_the_cli_fallback() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let start_script = root.join("scripts/start-iii.sh");
+    let tmp = tempfile::tempdir().unwrap();
+    let binary = tmp.path().join("fake-iii");
+    let config = tmp.path().join("worker-compose.yaml");
+    let pid_file = tmp.path().join("launcher.pid");
+    let args_file = tmp.path().join("args");
+    let log_file = tmp.path().join("engine.log");
+
+    write_executable(
+        &binary,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$FAKE_ARGS_FILE\"\nprintf 'up: 1 of 1 changed\\n'\nwhile :; do sleep 1; done\n",
+    );
+    std::fs::write(&config, "containers: {}\n").unwrap();
+
+    let status = Command::new("bash")
+        .arg(start_script)
+        .args(["--binary", binary.to_str().unwrap()])
+        .args(["--config", config.to_str().unwrap()])
+        .args(["--compose-file", config.to_str().unwrap()])
+        .args(["--port", "49134"])
+        .args(["--pid-file", pid_file.to_str().unwrap()])
+        .args(["--log-file", log_file.to_str().unwrap()])
+        .args(["--timeout", "3"])
+        .env("FAKE_ARGS_FILE", &args_file)
+        .status()
+        .unwrap();
+
+    assert!(status.success());
+    let args = std::fs::read_to_string(args_file).unwrap();
+    assert!(!args.contains("--engine\n"));
+    assert!(args.contains("--up\n--file\n"));
+
+    let child_pid = std::fs::read_to_string(&pid_file)
+        .unwrap()
+        .trim()
+        .parse::<i32>()
+        .unwrap();
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(child_pid),
+        nix::sys::signal::Signal::SIGTERM,
+    )
+    .unwrap();
+    std::fs::remove_file(pid_file).unwrap();
+}

--- a/crates/iii-compose/tests/start_script.rs
+++ b/crates/iii-compose/tests/start_script.rs
@@ -109,3 +109,54 @@ fn timeout_force_kills_a_process_that_ignores_sigterm() {
         "SIGTERM-ignoring process {child_pid} survived SIGKILL escalation"
     );
 }
+
+#[test]
+fn explicit_engine_overrides_the_compose_file_engine() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let start_script = root.join("scripts/start-iii.sh");
+    let tmp = tempfile::tempdir().unwrap();
+    let binary = tmp.path().join("fake-iii");
+    let config = tmp.path().join("worker-compose.yaml");
+    let pid_file = tmp.path().join("launcher.pid");
+    let args_file = tmp.path().join("args");
+    let log_file = tmp.path().join("engine.log");
+
+    write_executable(
+        &binary,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$FAKE_ARGS_FILE\"\nprintf 'up: 1 of 1 changed\\n'\nwhile :; do sleep 1; done\n",
+    );
+    std::fs::write(
+        &config,
+        "engine: { url: ws://127.0.0.1:49134 }\ncontainers: {}\n",
+    )
+    .unwrap();
+
+    let status = Command::new("bash")
+        .arg(start_script)
+        .args(["--binary", binary.to_str().unwrap()])
+        .args(["--config", config.to_str().unwrap()])
+        .args(["--port", "49134"])
+        .args(["--pid-file", pid_file.to_str().unwrap()])
+        .args(["--log-file", log_file.to_str().unwrap()])
+        .args(["--timeout", "3"])
+        .args(["--engine", "ws://127.0.0.1:49200"])
+        .env("FAKE_ARGS_FILE", &args_file)
+        .status()
+        .unwrap();
+
+    assert!(status.success());
+    let args = std::fs::read_to_string(args_file).unwrap();
+    assert!(args.contains("--engine\nws://127.0.0.1:49200\n"));
+
+    let child_pid = std::fs::read_to_string(&pid_file)
+        .unwrap()
+        .trim()
+        .parse::<i32>()
+        .unwrap();
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(child_pid),
+        nix::sys::signal::Signal::SIGTERM,
+    )
+    .unwrap();
+    std::fs::remove_file(pid_file).unwrap();
+}

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -38,7 +38,7 @@ iii [OPTIONS] [COMMAND]
 
 Serve worker-compose projects: supervise each one's workers as a graph.
 
-Without `--up`, projects are started and stopped through `iii trigger compose::*`, naming one with `id=`; the command only starts the daemon. With `--up`, it also starts the initial project and the engine declared by its compose file.
+Without `--up`, worker-compose.yaml supplies daemon defaults but no project starts. Projects are then managed through `compose::*` calls. With `--up`, the initial project also starts, together with its declared engine unless `--engine` selects an existing one.
 
 ```text
 iii compose [OPTIONS]
@@ -46,9 +46,9 @@ iii compose [OPTIONS]
 
 | Option | Description |
 | ------ | ----------- |
-| `--engine <URL>` | Existing engine WebSocket address. Falls back to III_URL when the compose file does not declare an engine section |
-| `-n, --namespace <NS>` | Namespace this daemon answers `compose::*` in. Several attach to one engine; this is what tells them apart |
-| `--up` | Serve with one project brought up first, starting its declared engine |
+| `--engine <URL>` | Existing engine WebSocket address. Overrides the compose file and III_URL. The local default is used when none of them supplies a URL |
+| `-n, --namespace <NS>` | Namespace this daemon answers `compose::*` in and applies to every project it loads. Several daemons attach to one engine; this is what tells them apart |
+| `--up` | Serve with one project brought up first, starting its declared engine unless `--engine` selects an existing one |
 | `-f, --file <PATH>` | The compose file. Only valid with `--up`. Defaults to `./worker-compose.yaml`, the same fallback `compose::up` uses when a call names no file |
 
 ### `iii project`

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -36,7 +36,7 @@ iii [OPTIONS] [COMMAND]
 
 Serve worker-compose projects: supervise each one's workers as a graph.
 
-Without `--up`, projects are started and stopped through `iii trigger compose::*`, naming one with `id=`; the command only starts the daemon. With `--up`, it also starts the initial project and the engine declared by its compose file.
+Without `--up`, worker-compose.yaml supplies daemon defaults but no project starts. Projects are then managed through `compose::*` calls. With `--up`, the initial project also starts, together with its declared engine unless `--engine` selects an existing one.
 
 ```text
 iii compose [OPTIONS]
@@ -44,9 +44,9 @@ iii compose [OPTIONS]
 
 | Option | Description |
 | ------ | ----------- |
-| `--engine <URL>` | Existing engine WebSocket address. Falls back to III_URL when the compose file does not declare an engine section |
-| `-n, --namespace <NS>` | Namespace this daemon answers `compose::*` in. Several attach to one engine; this is what tells them apart |
-| `--up` | Serve with one project brought up first, starting its declared engine |
+| `--engine <URL>` | Existing engine WebSocket address. Overrides the compose file and III_URL. The local default is used when none of them supplies a URL |
+| `-n, --namespace <NS>` | Namespace this daemon answers `compose::*` in and applies to every project it loads. Several daemons attach to one engine; this is what tells them apart |
+| `--up` | Serve with one project brought up first, starting its declared engine unless `--engine` selects an existing one |
 | `-f, --file <PATH>` | The compose file. Only valid with `--up`. Defaults to `./worker-compose.yaml`, the same fallback `compose::up` uses when a call names no file |
 
 ### `iii project`

--- a/docs/next/upgrading/workers-to-compose.mdx
+++ b/docs/next/upgrading/workers-to-compose.mdx
@@ -147,7 +147,7 @@ For a managed engine, the file owns both lifecycles:
 iii compose --namespace dev --up --file worker-compose.yaml
 ```
 
-The daemon namespace (`dev`) addresses `compose::*`; the file's `namespace:` is the namespace of
+The explicit namespace (`dev`) addresses `compose::*` and overrides the file's `namespace:` for
 its containers. Changing `engine:` while the daemon runs returns `ENGINE_RESTART_REQUIRED`; stop
 and restart that Compose invocation. A second file with `engine:` returns `ENGINE_ALREADY_OWNED`.
 
@@ -160,9 +160,9 @@ iii --config config.yaml
 iii compose --namespace dev --engine ws://127.0.0.1:49134 --up --file worker-compose.yaml
 ```
 
-Run those commands under separate supervisors. `III_URL` may replace `--engine`. An external
-Compose file without either fails with `ENGINE_URL_REQUIRED`; a file with `engine:` cannot be
-started with explicit `--engine`.
+Run those commands under separate supervisors. Explicit `--engine` has highest priority and may
+override an `engine.url` in the Compose file. Without either value, Compose uses `III_URL`, then
+defaults to `ws://127.0.0.1:49134`.
 
 Verify the migration:
 
@@ -177,8 +177,6 @@ iii trigger engine::triggers::list
 - `UNSUPPORTED_CONFIG_WORKERS`: direct `config.yaml` still contains project workers.
 - `UNSUPPORTED_ENGINE_WORKER`: `engine.workers` contains a project or unknown worker.
 - `ENGINE_WORKER_IS_INJECTED`: remove an automatically supplied internal worker.
-- `ENGINE_URL_REQUIRED`: external mode has no `--engine` or `III_URL`.
-- `ENGINE_URL_CONFLICTS_WITH_MANAGED`: remove explicit `--engine` or remove `engine:`.
 - `ENGINE_RESTART_REQUIRED`: restart Compose to apply a changed engine section.
 - `ENGINE_ALREADY_OWNED`: start the second managed file in a separate Compose invocation.
 - `ENGINE_SECTION_REQUIRES_MANAGED_START`: an external daemon was asked to load a managed file.

--- a/docs/next/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/next/upgrading/workers-to-compose.mdx.skill.md
@@ -143,7 +143,7 @@ For a managed engine, the file owns both lifecycles:
 iii compose --namespace dev --up --file worker-compose.yaml
 ```
 
-The daemon namespace (`dev`) addresses `compose::*`; the file's `namespace:` is the namespace of
+The explicit namespace (`dev`) addresses `compose::*` and overrides the file's `namespace:` for
 its containers. Changing `engine:` while the daemon runs returns `ENGINE_RESTART_REQUIRED`; stop
 and restart that Compose invocation. A second file with `engine:` returns `ENGINE_ALREADY_OWNED`.
 
@@ -156,9 +156,9 @@ iii --config config.yaml
 iii compose --namespace dev --engine ws://127.0.0.1:49134 --up --file worker-compose.yaml
 ```
 
-Run those commands under separate supervisors. `III_URL` may replace `--engine`. An external
-Compose file without either fails with `ENGINE_URL_REQUIRED`; a file with `engine:` cannot be
-started with explicit `--engine`.
+Run those commands under separate supervisors. Explicit `--engine` has highest priority and may
+override an `engine.url` in the Compose file. Without either value, Compose uses `III_URL`, then
+defaults to `ws://127.0.0.1:49134`.
 
 Verify the migration:
 
@@ -173,8 +173,6 @@ iii trigger engine::triggers::list
 - `UNSUPPORTED_CONFIG_WORKERS`: direct `config.yaml` still contains project workers.
 - `UNSUPPORTED_ENGINE_WORKER`: `engine.workers` contains a project or unknown worker.
 - `ENGINE_WORKER_IS_INJECTED`: remove an automatically supplied internal worker.
-- `ENGINE_URL_REQUIRED`: external mode has no `--engine` or `III_URL`.
-- `ENGINE_URL_CONFLICTS_WITH_MANAGED`: remove explicit `--engine` or remove `engine:`.
 - `ENGINE_RESTART_REQUIRED`: restart Compose to apply a changed engine section.
 - `ENGINE_ALREADY_OWNED`: start the second managed file in a separate Compose invocation.
 - `ENGINE_SECTION_REQUIRES_MANAGED_START`: an external daemon was asked to load a managed file.

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -16,8 +16,8 @@ exposes the `compose::*` functions there, so every project operation is a normal
 [trigger](./triggers), addressed to one daemon with `--namespace`.
 
 `iii compose` is intentionally a verbless top-level daemon command, analogous to `iii console`.
-The `--up` flag loads a project; the file's optional `engine:` section decides whether Compose
-owns an engine or connects to an external one.
+It reads `worker-compose.yaml` when the file exists so the namespace and engine URL can configure
+the daemon. The `--up` flag also loads the file as a project and starts its containers.
 
 ## The daemon
 
@@ -27,18 +27,18 @@ iii compose [OPTIONS]
 
 | Option           | Description                                                                            |
 | ---------------- | -------------------------------------------------------------------------------------- |
-| `-n, --namespace <NS>` | Namespace this daemon answers `compose::*` in. Overrides the initial file namespace.   |
-| `--engine <URL>` | Existing engine WebSocket address. Falls back to `III_URL` in external mode.           |
+| `-n, --namespace <NS>` | Namespace for the daemon and every project it loads. Overrides file namespaces.       |
+| `--engine <URL>` | Existing engine WebSocket address. Overrides the file, `III_URL`, and local default.   |
 
 A daemon holds any number of projects, and any number of daemons share one engine. What tells them
 apart is the namespace: the worker name is always `compose`, so the engine leases `(namespace,
 compose)` to one connection. Two daemons with different namespaces coexist; a second claiming one
 that is taken is refused at registration with `DAEMON_ALREADY_SERVING`.
 
-With `iii compose --up`, the daemon inherits `namespace:` from the initial compose file when
-`--namespace` is absent. If the file has no namespace, or if the daemon starts without an initial
-file, it uses `default`. The engine refuses a second daemon claiming a namespace that is already
-served.
+The daemon inherits `namespace:` from `worker-compose.yaml` when `--namespace` is absent. If the
+file has no namespace, or if the daemon starts outside a project, it uses `default`. An explicit
+CLI namespace also overrides `namespace:` for every project loaded by that daemon. The engine
+refuses a second daemon claiming a namespace that is already served.
 
 ```text
 $ iii compose --engine ws://127.0.0.1:49134
@@ -74,10 +74,10 @@ names no file. The daemon then stays in the foreground and serves, so every othe
 If `--namespace` is absent, this initial `--up` also uses the file's `namespace:` for the compose
 daemon. An explicit CLI namespace has priority over the file.
 
-When the file contains `engine:`, Compose materializes an engine-only config under
+When the file contains `engine:` and no explicit `--engine` is present, Compose materializes an engine-only config under
 `~/.iii/compose/<daemon-namespace>/engine-config.yaml`, starts the engine, and removes the generated
-file after a clean shutdown. The Compose file is the source of truth; explicit `--engine` is an
-error, and a process-wide `III_URL` is ignored.
+file after a clean shutdown. An explicit `--engine` takes priority and connects to that existing
+engine instead. A process-wide `III_URL` does not override a managed file engine.
 
 ```text
 $ iii compose --up -n orders
@@ -104,8 +104,8 @@ the engine output.
 A project that does not start ends the command with `PROJECT_DID_NOT_START`. Rollback has already
 stopped whatever came up, so there is nothing left to supervise.
 
-Without `engine:`, Compose never starts or stops an engine. Supply the external URL explicitly or
-through `III_URL`; there is no default external endpoint.
+Without `engine:`, Compose never starts or stops an engine. It uses `--engine`, then `III_URL`, then
+the local default `ws://127.0.0.1:49134`.
 
 ```bash
 iii compose --up --engine ws://127.0.0.1:49134

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -10,8 +10,8 @@ exposes the `compose::*` functions there, so every project operation is a normal
 [trigger](./triggers), addressed to one daemon with `--namespace`.
 
 `iii compose` is intentionally a verbless top-level daemon command, analogous to `iii console`.
-The `--up` flag loads a project; the file's optional `engine:` section decides whether Compose
-owns an engine or connects to an external one.
+It reads `worker-compose.yaml` when the file exists so the namespace and engine URL can configure
+the daemon. The `--up` flag also loads the file as a project and starts its containers.
 
 ## The daemon
 
@@ -21,18 +21,18 @@ iii compose [OPTIONS]
 
 | Option           | Description                                                                            |
 | ---------------- | -------------------------------------------------------------------------------------- |
-| `-n, --namespace <NS>` | Namespace this daemon answers `compose::*` in. Overrides the initial file namespace.   |
-| `--engine <URL>` | Existing engine WebSocket address. Falls back to `III_URL` in external mode.           |
+| `-n, --namespace <NS>` | Namespace for the daemon and every project it loads. Overrides file namespaces.       |
+| `--engine <URL>` | Existing engine WebSocket address. Overrides the file, `III_URL`, and local default.   |
 
 A daemon holds any number of projects, and any number of daemons share one engine. What tells them
 apart is the namespace: the worker name is always `compose`, so the engine leases `(namespace,
 compose)` to one connection. Two daemons with different namespaces coexist; a second claiming one
 that is taken is refused at registration with `DAEMON_ALREADY_SERVING`.
 
-With `iii compose --up`, the daemon inherits `namespace:` from the initial compose file when
-`--namespace` is absent. If the file has no namespace, or if the daemon starts without an initial
-file, it uses `default`. The engine refuses a second daemon claiming a namespace that is already
-served.
+The daemon inherits `namespace:` from `worker-compose.yaml` when `--namespace` is absent. If the
+file has no namespace, or if the daemon starts outside a project, it uses `default`. An explicit
+CLI namespace also overrides `namespace:` for every project loaded by that daemon. The engine
+refuses a second daemon claiming a namespace that is already served.
 
 ```text
 $ iii compose --engine ws://127.0.0.1:49134
@@ -68,10 +68,10 @@ names no file. The daemon then stays in the foreground and serves, so every othe
 If `--namespace` is absent, this initial `--up` also uses the file's `namespace:` for the compose
 daemon. An explicit CLI namespace has priority over the file.
 
-When the file contains `engine:`, Compose materializes an engine-only config under
+When the file contains `engine:` and no explicit `--engine` is present, Compose materializes an engine-only config under
 `~/.iii/compose/<daemon-namespace>/engine-config.yaml`, starts the engine, and removes the generated
-file after a clean shutdown. The Compose file is the source of truth; explicit `--engine` is an
-error, and a process-wide `III_URL` is ignored.
+file after a clean shutdown. An explicit `--engine` takes priority and connects to that existing
+engine instead. A process-wide `III_URL` does not override a managed file engine.
 
 ```text
 $ iii compose --up -n orders
@@ -98,8 +98,8 @@ the engine output.
 A project that does not start ends the command with `PROJECT_DID_NOT_START`. Rollback has already
 stopped whatever came up, so there is nothing left to supervise.
 
-Without `engine:`, Compose never starts or stops an engine. Supply the external URL explicitly or
-through `III_URL`; there is no default external endpoint.
+Without `engine:`, Compose never starts or stops an engine. It uses `--engine`, then `III_URL`, then
+the local default `ws://127.0.0.1:49134`.
 
 ```bash
 iii compose --up --engine ws://127.0.0.1:49134

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -159,10 +159,10 @@ enum Commands {
 
     /// Serve worker-compose projects: supervise each one's workers as a graph.
     ///
-    /// Without `--up`, projects are started and stopped through
-    /// `iii trigger compose::*`, naming one with `id=`; the command only
-    /// starts the daemon. With `--up`, it also starts the initial project and
-    /// the engine declared by its compose file.
+    /// Without `--up`, worker-compose.yaml supplies daemon defaults but no
+    /// project starts. Projects are then managed through `compose::*` calls.
+    /// With `--up`, the initial project also starts, together with its declared
+    /// engine unless `--engine` selects an existing one.
     Compose(iii_compose::ComposeCli),
 
     /// Generate the committed MDX CLI reference page from this binary's
@@ -365,9 +365,9 @@ async fn main() -> anyhow::Result<()> {
             let exit_code = cli::project::run(args.clone()).await;
             std::process::exit(exit_code);
         }
-        // Compose owns its own lifecycle. The initial worker-compose.yaml
-        // decides whether `--up` starts a managed engine or connects to the URL
-        // supplied through --engine / III_URL.
+        // Compose owns its own lifecycle. Its file supplies daemon defaults;
+        // an explicit --engine overrides them, and --up decides whether an
+        // unoverridden engine section starts a managed engine.
         Some(Commands::Compose(args)) => {
             if cli_args.config.is_some() {
                 anyhow::bail!(

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -141,6 +141,7 @@ async fn start_daemon_named(port: u16, daemon_namespace: &str) -> Arc<Daemon> {
     let daemon = Daemon::start(
         format!("ws://127.0.0.1:{port}"),
         daemon_namespace.to_string(),
+        None,
         iii_compose::daemon::EnginePolicy::External,
     );
     remote::register(&daemon);

--- a/engine/tests/compose_managed_engine_e2e.rs
+++ b/engine/tests/compose_managed_engine_e2e.rs
@@ -244,6 +244,110 @@ fn compose_without_engine_section_uses_and_preserves_an_external_engine() {
     );
 }
 
+#[test]
+fn cli_engine_overrides_file_engine_and_preserves_the_external_engine() {
+    let project = tempfile::tempdir().unwrap();
+    let probe = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = probe.local_addr().unwrap().port();
+    drop(probe);
+    let ignored_probe = TcpListener::bind("127.0.0.1:0").unwrap();
+    let ignored_port = ignored_probe.local_addr().unwrap().port();
+    drop(ignored_probe);
+
+    let config = project.path().join("config.yaml");
+    std::fs::write(
+        &config,
+        format!(
+            "workers:\n  - name: iii-worker-manager\n    config:\n      host: 127.0.0.1\n      port: {port}\n"
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        project.path().join("worker-compose.yaml"),
+        format!(
+            "namespace: file-namespace\nengine:\n  url: ws://127.0.0.1:{ignored_port}\n  workers: {{}}\ncontainers:\n  missing:\n    worker: path://./does-not-exist\n"
+        ),
+    )
+    .unwrap();
+
+    let mut engine = iii_bin()
+        .current_dir(project.path())
+        .args(["--config", config.to_str().unwrap()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("start directly supervised engine");
+    if !wait_for_port(port, std::time::Duration::from_secs(20)) {
+        let _ = engine.kill();
+        let _ = engine.wait();
+        panic!("external engine never became ready");
+    }
+
+    let output = iii_bin()
+        .current_dir(project.path())
+        .args([
+            "compose",
+            "--engine",
+            &format!("ws://127.0.0.1:{port}"),
+            "--namespace",
+            "cli-namespace",
+            "--up",
+        ])
+        .output()
+        .expect("run external compose --up");
+    let terminal = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let engine_survived = engine.try_wait().unwrap().is_none();
+    let engine_reachable = std::net::TcpStream::connect(("127.0.0.1", port)).is_ok();
+    let _ = engine.kill();
+    let _ = engine.wait();
+
+    assert!(!output.status.success(), "missing project worker must fail");
+    assert!(terminal.contains("compose serving"), "{terminal}");
+    assert!(terminal.contains("namespace: cli-namespace"), "{terminal}");
+    assert!(!terminal.contains("engine started"), "{terminal}");
+    assert!(engine_survived, "Compose stopped the external engine");
+    assert!(
+        engine_reachable,
+        "external engine stopped accepting connections"
+    );
+}
+
+#[test]
+fn compose_up_rejects_an_occupied_managed_engine_listener() {
+    let project = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::fs::write(
+        project.path().join("worker-compose.yaml"),
+        format!("engine:\n  url: ws://127.0.0.1:{port}\n  workers: {{}}\ncontainers: {{}}\n"),
+    )
+    .unwrap();
+
+    let output = iii_bin()
+        .current_dir(project.path())
+        .env("III_COMPOSE_STATE_DIR", state.path())
+        .args(["compose", "--namespace", "occupied-listener", "--up"])
+        .output()
+        .expect("run iii compose --up");
+    let terminal = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(!output.status.success(), "an occupied listener must fail");
+    assert!(
+        terminal.contains("MANAGED_ENGINE_LISTENER_UNAVAILABLE"),
+        "{terminal}"
+    );
+    assert!(!terminal.contains("engine started"), "{terminal}");
+}
+
 #[cfg(unix)]
 #[test]
 fn signal_during_managed_engine_startup_stops_the_engine() {

--- a/scripts/start-iii.sh
+++ b/scripts/start-iii.sh
@@ -55,23 +55,18 @@ if [[ -n "$COMPOSE_FILE" ]]; then
     config_name="$(basename "${CONFIG%.*}")"
     COMPOSE_NAMESPACE="sdk-${config_name//[^a-zA-Z0-9_-]/-}"
   fi
-  if grep -Eq '^engine:[[:space:]]*' "$COMPOSE_FILE"; then
-    if [[ -n "$ENGINE_URL" ]]; then
-      echo "Managed Compose file $COMPOSE_FILE cannot be combined with --engine/--iii-url" >&2
-      exit 1
-    fi
-    "$BINARY" compose \
-      --namespace "$COMPOSE_NAMESPACE" \
-      --up --file "$COMPOSE_FILE" > "$LOG_FILE" 2>&1 &
-  else
-    if [[ -z "$ENGINE_URL" ]]; then
-      echo "Compose file $COMPOSE_FILE has no engine section; pass --engine or --iii-url" >&2
-      exit 1
-    fi
+  if [[ -n "$ENGINE_URL" ]]; then
     "$BINARY" compose \
       --engine "$ENGINE_URL" \
       --namespace "$COMPOSE_NAMESPACE" \
       --up --file "$COMPOSE_FILE" > "$LOG_FILE" 2>&1 &
+  elif grep -Eq '^engine:[[:space:]]*' "$COMPOSE_FILE"; then
+    "$BINARY" compose \
+      --namespace "$COMPOSE_NAMESPACE" \
+      --up --file "$COMPOSE_FILE" > "$LOG_FILE" 2>&1 &
+  else
+    echo "Compose file $COMPOSE_FILE has no engine section; pass --engine or --iii-url" >&2
+    exit 1
   fi
 else
   "$BINARY" --config "$CONFIG" > "$LOG_FILE" 2>&1 &

--- a/scripts/start-iii.sh
+++ b/scripts/start-iii.sh
@@ -60,13 +60,10 @@ if [[ -n "$COMPOSE_FILE" ]]; then
       --engine "$ENGINE_URL" \
       --namespace "$COMPOSE_NAMESPACE" \
       --up --file "$COMPOSE_FILE" > "$LOG_FILE" 2>&1 &
-  elif grep -Eq '^engine:[[:space:]]*' "$COMPOSE_FILE"; then
+  else
     "$BINARY" compose \
       --namespace "$COMPOSE_NAMESPACE" \
       --up --file "$COMPOSE_FILE" > "$LOG_FILE" 2>&1 &
-  else
-    echo "Compose file $COMPOSE_FILE has no engine section; pass --engine or --iii-url" >&2
-    exit 1
   fi
 else
   "$BINARY" --config "$CONFIG" > "$LOG_FILE" 2>&1 &


### PR DESCRIPTION
## Summary

- resolve the engine URL consistently as `--engine` > compose file > `III_URL` > local default
- apply an explicit CLI namespace to the daemon and every loaded project
- load the default compose file for daemon configuration without requiring `--up`
- reject occupied managed-engine listeners before a child process can report false success
- align the CI launcher and Compose documentation with the same precedence rules

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p iii-compose`
- `SKIP_UI_BUILD=1 cargo test -p iii --test cli_args --test cli_integration --test compose_daemon_e2e --test compose_managed_engine_e2e`
- `cargo clippy -p iii-compose --all-targets --locked -- -D warnings`
- `SKIP_UI_BUILD=1 cargo build -p iii --bin iii`
- `bash -n scripts/start-iii.sh`
- `SKIP_UI_BUILD=1 ./scripts/generate-cli-docs.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compose automatically reads `worker-compose.yaml` for daemon defaults.
  * `--up` separately controls whether the initial project starts.
  * Explicit engine and namespace settings override compose-file and environment values.
  * External engines can be selected without starting a managed engine.
  * Engine selection falls back to the local default when no value is provided.

* **Bug Fixes**
  * Improved managed-engine listener validation and error reporting.
  * Added clearer handling for listener availability and endpoint mismatches.

* **Documentation**
  * Updated Compose CLI and migration guidance for the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->