### PR TITLE
fix(sdk): prefer compose-managed worker names

### DIFF
--- a/sdk/packages/go/iii/client.go
+++ b/sdk/packages/go/iii/client.go
@@ -164,7 +164,8 @@ func WithDescription(description string) Option {
 	return func(c *Client) { c.description = description }
 }
 
-// WithName sets the worker name reported to the engine (default: "hostname:pid").
+// WithName sets the worker name reported to the engine. A non-empty
+// III_WORKER_NAME takes precedence. The default is "hostname:pid".
 func WithName(name string) Option {
 	return func(cl *Client) { cl.name = name }
 }
@@ -209,6 +210,11 @@ func New(url string, opts ...Option) *Client {
 	}
 	for _, opt := range opts {
 		opt(c)
+	}
+	// The supervisor owns the managed identity. Apply it after options so a
+	// name embedded in worker code cannot hide the process from the supervisor.
+	if managedName := os.Getenv("III_WORKER_NAME"); managedName != "" {
+		c.name = managedName
 	}
 	if c.namespaceSet {
 		// Refused rather than read as absent, and refused here so nothing is

--- a/sdk/packages/go/iii/client_test.go
+++ b/sdk/packages/go/iii/client_test.go
@@ -845,6 +845,7 @@ func TestHandlerInvocationErrorPassthrough(t *testing.T) {
 
 // TestOptionsAndState covers the small accessors.
 func TestOptionsAndState(t *testing.T) {
+	t.Setenv("III_WORKER_NAME", "")
 	m := newMockEngine(t)
 	c := New(m.url, WithName("worker-x"))
 	if c.name != "worker-x" {
@@ -861,6 +862,26 @@ func TestOptionsAndState(t *testing.T) {
 	t.Cleanup(func() { _ = c.Close() })
 	if c.State() != StateConnected {
 		t.Errorf("State after Connect = %q, want connected", c.State())
+	}
+}
+
+func TestWorkerNameEnvOverridesExplicitName(t *testing.T) {
+	t.Setenv("III_WORKER_NAME", "managed-worker")
+
+	c := New("ws://127.0.0.1:0", WithName("explicit-worker"))
+
+	if c.name != "managed-worker" {
+		t.Errorf("worker name = %q, want managed-worker", c.name)
+	}
+}
+
+func TestWorkerNameUsesExplicitNameWhenEnvIsEmpty(t *testing.T) {
+	t.Setenv("III_WORKER_NAME", "")
+
+	c := New("ws://127.0.0.1:0", WithName("explicit-worker"))
+
+	if c.name != "explicit-worker" {
+		t.Errorf("worker name = %q, want explicit-worker", c.name)
 	}
 }
 

--- a/sdk/packages/node/iii/src/iii.ts
+++ b/sdk/packages/node/iii/src/iii.ts
@@ -84,15 +84,15 @@ function getOsInfo(): string {
   return `${os.platform()} ${os.release()} (${os.arch()})`
 }
 
-function getDefaultWorkerName(): string {
+function resolveWorkerName(explicitName?: string): string {
   // III_WORKER_NAME carries the orchestrator-assigned name (set by iii-worker
   // for engine-managed workers). The engine matches live registrations by
-  // name, so that identity must win over the hostname:pid fallback.
+  // name, so that identity must win over a name embedded in worker code.
   const managedName = process.env.III_WORKER_NAME
   if (managedName) {
     return managedName
   }
-  return `${os.hostname()}:${process.pid}`
+  return explicitName ?? `${os.hostname()}:${process.pid}`
 }
 
 /**
@@ -207,7 +207,7 @@ export type TelemetryOptions = {
  * ```
  */
 export type InitOptions = {
-  /** Display name for this worker. Defaults to `hostname:pid`. */
+  /** Display name for this worker. A non-empty `III_WORKER_NAME` overrides it. Defaults to `hostname:pid`. */
   workerName?: string
   /**
    * Namespace this worker belongs to. Resolution order:
@@ -278,7 +278,7 @@ class Sdk implements IIIClient {
     private readonly address: string,
     private readonly options?: InitOptions,
   ) {
-    this.workerName = options?.workerName ?? getDefaultWorkerName()
+    this.workerName = resolveWorkerName(options?.workerName)
     this.namespace = resolveNamespace(options?.namespace)
     this.workerDescription = options?.workerDescription
     this.metricsReportingEnabled = options?.enableMetricsReporting ?? true

--- a/sdk/packages/node/iii/tests/register-worker-metadata.test.ts
+++ b/sdk/packages/node/iii/tests/register-worker-metadata.test.ts
@@ -89,8 +89,20 @@ describe('registerWorkerMetadata — worker name', () => {
     expect(call.payload.name).toBe('managed-worker')
   })
 
-  it('explicit workerName option wins over III_WORKER_NAME', () => {
+  it('III_WORKER_NAME wins over an explicit workerName option', () => {
     process.env.III_WORKER_NAME = 'managed-worker'
+    const sdk = registerWorker('ws://127.0.0.1:0', {
+      workerName: 'explicit-name',
+    }) as unknown as InternalSdk
+    sdk.trigger = vi.fn()
+
+    sdk.registerWorkerMetadata()
+
+    const call = sdk.trigger.mock.calls[0][0]
+    expect(call.payload.name).toBe('managed-worker')
+  })
+
+  it('uses the explicit workerName when III_WORKER_NAME is unset', () => {
     const sdk = registerWorker('ws://127.0.0.1:0', {
       workerName: 'explicit-name',
     }) as unknown as InternalSdk

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -1554,11 +1554,11 @@ class III:
 
         # III_WORKER_NAME carries the orchestrator-assigned name (set by
         # iii-worker for engine-managed workers). The engine matches live
-        # registrations by name, so that identity must win over the
-        # hostname:pid fallback.
+        # registrations by name, so that identity must win over a name
+        # embedded in worker code.
         worker_name = (
-            self._options.worker_name
-            or os.environ.get("III_WORKER_NAME")
+            os.environ.get("III_WORKER_NAME")
+            or self._options.worker_name
             or f"{platform.node()}:{os.getpid()}"
         )
 

--- a/sdk/packages/python/iii/src/iii/iii_constants.py
+++ b/sdk/packages/python/iii/src/iii/iii_constants.py
@@ -56,7 +56,8 @@ class InitOptions:
     """Configuration options passed to ``register_worker``.
 
     Attributes:
-        worker_name: Display name for this worker. Defaults to ``hostname:pid``.
+        worker_name: Display name for this worker. A non-empty
+            ``III_WORKER_NAME`` overrides it. Defaults to ``hostname:pid``.
         worker_description: One-line, human/LLM-readable summary of what this
             worker does. Surfaces in ``engine::workers::list`` / ``engine::workers::info``.
         namespace: Namespace this worker belongs to. Falls back to the

--- a/sdk/packages/python/iii/tests/test_worker_metadata.py
+++ b/sdk/packages/python/iii/tests/test_worker_metadata.py
@@ -60,10 +60,20 @@ def test_get_worker_metadata_name_defaults_from_iii_worker_name_env(
     assert metadata["name"] == "managed-worker"
 
 
-def test_get_worker_metadata_explicit_worker_name_wins_over_env(
+def test_get_worker_metadata_iii_worker_name_env_wins_over_explicit_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("III_WORKER_NAME", "managed-worker")
+
+    metadata = _call_metadata_method(InitOptions(worker_name="explicit-name"))
+
+    assert metadata["name"] == "managed-worker"
+
+
+def test_get_worker_metadata_uses_explicit_name_when_env_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("III_WORKER_NAME", raising=False)
 
     metadata = _call_metadata_method(InitOptions(worker_name="explicit-name"))
 

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -2532,6 +2532,7 @@ pub(crate) async fn internal_create_channel(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::ffi::OsString;
 
     use serde_json::json;
 
@@ -2542,6 +2543,55 @@ mod tests {
     use crate::{InitOptions, protocol::RegisterTriggerInput, register_worker};
 
     use std::sync::atomic::AtomicUsize;
+
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<OsString>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl ScopedEnvVar {
+        fn new(key: &'static str) -> Self {
+            let lock = ENV_MUTEX.lock_or_recover();
+            let previous = std::env::var_os(key);
+            Self {
+                key,
+                previous,
+                _lock: lock,
+            }
+        }
+
+        fn set(&self, value: &str) {
+            // SAFETY: this guard holds the shared test mutex until the
+            // original environment value is restored.
+            unsafe {
+                std::env::set_var(self.key, value);
+            }
+        }
+
+        fn remove(&self) {
+            // SAFETY: this guard holds the shared test mutex until the
+            // original environment value is restored.
+            unsafe {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            // SAFETY: restoration happens while this guard still holds the
+            // shared test mutex, including when a test unwinds after a panic.
+            unsafe {
+                match self.previous.take() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
 
     /// Raw TCP listener that accepts and then holds sockets open without
     /// ever answering (or even reading) the WS handshake — the stalled /
@@ -3067,53 +3117,32 @@ mod tests {
         assert!(iii.inner.pending.lock().unwrap().is_empty());
     }
 
-    // Single test covers both branches so the env var mutation is serialized
-    // within one function (env vars are process-global and cargo runs tests in parallel).
     #[test]
     fn worker_metadata_default_reads_iii_isolation_env_var() {
-        let previous = std::env::var("III_ISOLATION").ok();
+        let env = ScopedEnvVar::new("III_ISOLATION");
 
-        // SAFETY: env mutations are serialized within this test and restored at the end.
-        unsafe {
-            std::env::remove_var("III_ISOLATION");
-        }
+        env.remove();
         assert!(WorkerMetadata::default().isolation.is_none());
 
-        unsafe {
-            std::env::set_var("III_ISOLATION", "docker");
-        }
+        env.set("docker");
         assert_eq!(
             WorkerMetadata::default().isolation.as_deref(),
             Some("docker")
         );
-
-        unsafe {
-            match previous {
-                Some(val) => std::env::set_var("III_ISOLATION", val),
-                None => std::env::remove_var("III_ISOLATION"),
-            }
-        }
     }
 
-    // Single test covers both branches so the env var mutation is serialized
-    // within one function (env vars are process-global and cargo runs tests in parallel).
     #[test]
     fn worker_name_resolution_prefers_iii_worker_name_env_var() {
-        let previous = std::env::var("III_WORKER_NAME").ok();
+        let env = ScopedEnvVar::new("III_WORKER_NAME");
 
-        // SAFETY: env mutations are serialized within this test and restored at the end.
-        unsafe {
-            std::env::remove_var("III_WORKER_NAME");
-        }
+        env.remove();
         let fallback = WorkerMetadata::default().name;
         assert!(
             fallback.ends_with(&format!(":{}", std::process::id())),
             "expected hostname:pid fallback, got {fallback}"
         );
 
-        unsafe {
-            std::env::set_var("III_WORKER_NAME", "");
-        }
+        env.set("");
         let metadata = WorkerMetadata {
             name: "explicit-worker".to_string(),
             ..WorkerMetadata::default()
@@ -3129,9 +3158,7 @@ mod tests {
             .clone();
         assert_eq!(explicit_name, "explicit-worker");
 
-        unsafe {
-            std::env::set_var("III_WORKER_NAME", "managed-worker");
-        }
+        env.set("managed-worker");
         assert_eq!(WorkerMetadata::default().name, "managed-worker");
 
         let metadata = WorkerMetadata {
@@ -3163,13 +3190,6 @@ mod tests {
             .name
             .clone();
         assert_eq!(replaced_name, "managed-worker");
-
-        unsafe {
-            match previous {
-                Some(val) => std::env::set_var("III_WORKER_NAME", val),
-                None => std::env::remove_var("III_WORKER_NAME"),
-            }
-        }
     }
 
     #[test]
@@ -3426,17 +3446,11 @@ mod tests {
         assert!(!logs_contain("Trigger registration failed"));
     }
 
-    // Single test covers every namespace-resolution branch so the env var
-    // mutation is serialized within one function (env vars are process-global
-    // and cargo runs tests in parallel).
     #[test]
     fn namespace_resolution_reads_env_and_prefers_explicit_option() {
-        let previous = std::env::var("III_NAMESPACE").ok();
+        let env = ScopedEnvVar::new("III_NAMESPACE");
 
-        // SAFETY: env mutations are serialized within this test and restored at the end.
-        unsafe {
-            std::env::remove_var("III_NAMESPACE");
-        }
+        env.remove();
         // Absent everywhere -> None (engine applies its default namespace).
         assert!(WorkerMetadata::default().namespace.is_none());
         assert!(resolve_namespace(None).is_none());
@@ -3446,9 +3460,7 @@ mod tests {
             Some("payments")
         );
 
-        unsafe {
-            std::env::set_var("III_NAMESPACE", "orders");
-        }
+        env.set("orders");
         // III_NAMESPACE flows into worker metadata, mirroring III_WORKER_NAME.
         assert_eq!(
             WorkerMetadata::default().namespace.as_deref(),
@@ -3461,13 +3473,6 @@ mod tests {
             resolve_namespace(Some("payments".into())).as_deref(),
             Some("payments")
         );
-
-        unsafe {
-            match previous {
-                Some(val) => std::env::set_var("III_NAMESPACE", val),
-                None => std::env::remove_var("III_NAMESPACE"),
-            }
-        }
     }
 
     #[tokio::test]

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -258,6 +258,8 @@ pub struct TelemetryOptions {
 pub struct WorkerMetadata {
     pub runtime: String,
     pub version: String,
+    /// Worker name reported to the engine. A non-empty `III_WORKER_NAME`
+    /// overrides this value when the client is created.
     pub name: String,
     pub os: String,
     /// One-line, human/LLM-readable summary of what this worker does.
@@ -306,10 +308,7 @@ impl Default for WorkerMetadata {
             // iii-worker for engine-managed workers). The engine matches live
             // registrations by name, so that identity must win over the
             // hostname:pid fallback.
-            name: std::env::var("III_WORKER_NAME")
-                .ok()
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| format!("{}:{}", hostname, pid)),
+            name: worker_name_from_env().unwrap_or_else(|| format!("{}:{}", hostname, pid)),
             os: os_info,
             description: None,
             pid: Some(pid),
@@ -332,9 +331,21 @@ impl Default for WorkerMetadata {
     }
 }
 
+fn worker_name_from_env() -> Option<String> {
+    std::env::var("III_WORKER_NAME")
+        .ok()
+        .filter(|name| !name.is_empty())
+}
+
+fn apply_worker_name_from_env(metadata: &mut WorkerMetadata) {
+    if let Some(managed_name) = worker_name_from_env() {
+        metadata.name = managed_name;
+    }
+}
+
 /// Resolve the effective worker namespace: an explicit `InitOptions.namespace`
 /// wins, then the `III_NAMESPACE` env var, then `None` (the engine applies its
-/// default namespace). Mirrors the `III_WORKER_NAME` precedence.
+/// default namespace).
 /// `namespace` option > `III_NAMESPACE` > `None` (the engine then applies its
 /// `default` namespace).
 ///
@@ -938,8 +949,12 @@ impl IIIClient {
         Self::with_metadata(address, WorkerMetadata::default())
     }
 
-    /// Create a new III with custom worker metadata
-    pub fn with_metadata(address: &str, metadata: WorkerMetadata) -> Self {
+    /// Create a new III with custom worker metadata.
+    ///
+    /// A non-empty `III_WORKER_NAME` overrides `metadata.name` so an
+    /// orchestrator can assign the worker identity.
+    pub fn with_metadata(address: &str, mut metadata: WorkerMetadata) -> Self {
+        apply_worker_name_from_env(&mut metadata);
         let (tx, rx) = mpsc::unbounded_channel();
         let inner = IIIInner {
             address: address.into(),
@@ -971,8 +986,11 @@ impl IIIClient {
         &self.inner.address
     }
 
-    /// Set custom worker metadata (call before connect)
-    pub fn set_metadata(&self, metadata: WorkerMetadata) {
+    /// Set custom worker metadata (call before connect).
+    ///
+    /// A non-empty `III_WORKER_NAME` overrides `metadata.name`.
+    pub fn set_metadata(&self, mut metadata: WorkerMetadata) {
+        apply_worker_name_from_env(&mut metadata);
         *self.inner.worker_metadata.lock_or_recover() = Some(metadata);
     }
 
@@ -3080,7 +3098,7 @@ mod tests {
     // Single test covers both branches so the env var mutation is serialized
     // within one function (env vars are process-global and cargo runs tests in parallel).
     #[test]
-    fn worker_metadata_default_reads_iii_worker_name_env_var() {
+    fn worker_name_resolution_prefers_iii_worker_name_env_var() {
         let previous = std::env::var("III_WORKER_NAME").ok();
 
         // SAFETY: env mutations are serialized within this test and restored at the end.
@@ -3094,9 +3112,57 @@ mod tests {
         );
 
         unsafe {
+            std::env::set_var("III_WORKER_NAME", "");
+        }
+        let metadata = WorkerMetadata {
+            name: "explicit-worker".to_string(),
+            ..WorkerMetadata::default()
+        };
+        let iii = IIIClient::with_metadata("ws://127.0.0.1:0", metadata);
+        let explicit_name = iii
+            .inner
+            .worker_metadata
+            .lock_or_recover()
+            .as_ref()
+            .unwrap()
+            .name
+            .clone();
+        assert_eq!(explicit_name, "explicit-worker");
+
+        unsafe {
             std::env::set_var("III_WORKER_NAME", "managed-worker");
         }
         assert_eq!(WorkerMetadata::default().name, "managed-worker");
+
+        let metadata = WorkerMetadata {
+            name: "explicit-worker".to_string(),
+            ..WorkerMetadata::default()
+        };
+        let iii = IIIClient::with_metadata("ws://127.0.0.1:0", metadata);
+        let resolved_name = iii
+            .inner
+            .worker_metadata
+            .lock_or_recover()
+            .as_ref()
+            .unwrap()
+            .name
+            .clone();
+        assert_eq!(resolved_name, "managed-worker");
+
+        let replacement = WorkerMetadata {
+            name: "replacement-worker".to_string(),
+            ..WorkerMetadata::default()
+        };
+        iii.set_metadata(replacement);
+        let replaced_name = iii
+            .inner
+            .worker_metadata
+            .lock_or_recover()
+            .as_ref()
+            .unwrap()
+            .name
+            .clone();
+        assert_eq!(replaced_name, "managed-worker");
 
         unsafe {
             match previous {

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -64,7 +64,8 @@ pub use types::{StreamRequest, StreamResponse};
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct InitOptions {
-    /// Custom worker metadata. Auto-detected if `None`.
+    /// Custom worker metadata. Auto-detected if `None`. A non-empty
+    /// `III_WORKER_NAME` overrides `metadata.name`.
     pub metadata: Option<iii::WorkerMetadata>,
     /// Custom HTTP headers sent during the WebSocket handshake.
     pub headers: Option<std::collections::HashMap<String, String>>,
@@ -72,7 +73,7 @@ pub struct InitOptions {
     pub otel: Option<iii_helpers::observability::OtelConfig>,
     /// Namespace this worker belongs to. Resolution order:
     /// `namespace` > env `III_NAMESPACE` > `None` (the engine then applies its
-    /// default namespace). Mirrors the `III_WORKER_NAME` precedence.
+    /// default namespace).
     ///
     /// It scopes more than the registration. The worker and its functions
     /// register here, and everything the worker does afterwards follows it: a


### PR DESCRIPTION
## Summary

- prefer a non-empty `III_WORKER_NAME` over worker names embedded in SDK options or metadata
- apply the same precedence in the Node.js, Python, Rust, and Go SDKs
- add regression coverage for managed names, explicit fallbacks, and empty environment values

## Why

Compose uses each container key as its runtime identity and passes it to the child as `III_WORKER_NAME`. SDK-level names currently override that value in several runtimes, so a container declared as `foo` can register as another name and never satisfy Compose readiness.

## Dependency

- stacked on #2074 because Compose provides the `III_WORKER_NAME` contract there

## Testing

- `cargo test -p iii-sdk --lib --locked`
- `cargo clippy -p iii-sdk --all-targets --all-features --locked -- -D warnings`
- `pnpm --filter iii-sdk build`
- `pnpm exec vitest run tests/register-worker-metadata.test.ts`
- `uv run --frozen pytest -q tests/test_worker_metadata.py`
- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker names can now be set consistently through the `III_WORKER_NAME` environment variable across Go, Node.js, Python, and Rust SDKs.
  * A non-empty environment value takes precedence over explicitly configured names; empty values preserve the configured name.
  * When no name is provided, the default remains `hostname:pid`.

* **Documentation**
  * Updated SDK guidance to describe worker-name precedence and defaults.

* **Tests**
  * Added coverage for environment overrides, explicit names, and fallback behavior across supported SDKs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->