### PR TITLE
feat(compose): expose worker logs

### DIFF
--- a/crates/iii-compose/src/cli.rs
+++ b/crates/iii-compose/src/cli.rs
@@ -23,9 +23,12 @@
 
 use std::path::PathBuf;
 
-use clap::Args;
+use clap::{Args, Subcommand};
 
-use crate::error::{ComposeError, Result};
+use crate::{
+    error::{ComposeError, Result},
+    logs::LogStream,
+};
 
 /// Compose file used when `--file` is not given: the one in the current
 /// directory. Running compose from inside a project should not require naming
@@ -33,6 +36,7 @@ use crate::error::{ComposeError, Result};
 pub const DEFAULT_COMPOSE_FILE: &str = "worker-compose.yaml";
 
 #[derive(Args, Debug, Clone)]
+#[command(args_conflicts_with_subcommands = true)]
 pub struct ComposeCli {
     /// Existing engine WebSocket address. Overrides the compose file and
     /// III_URL. The local default is used when none of them supplies a URL.
@@ -64,6 +68,61 @@ pub struct ComposeCli {
     /// call names no file.
     #[arg(short = 'f', long, value_name = "PATH", requires = "up")]
     pub file: Option<PathBuf>,
+
+    #[command(subcommand)]
+    pub command: Option<ComposeSubcommand>,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ComposeSubcommand {
+    /// Read retained worker stdout and stderr from a running Compose daemon.
+    Logs(ComposeLogsCli),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ComposeLogsCli {
+    /// Worker to read. Omit to read every worker in the project.
+    #[arg(value_name = "WORKER")]
+    pub worker: Option<String>,
+
+    /// Existing engine WebSocket address. The compose file and III_URL are
+    /// used when omitted.
+    #[arg(long, value_name = "URL")]
+    pub engine: Option<String>,
+
+    /// Namespace of the Compose daemon that owns the project.
+    #[arg(short = 'n', long = "namespace", value_name = "NS")]
+    pub namespace: Option<String>,
+
+    /// Compose file path on the daemon host. The daemon's default file is used
+    /// when omitted.
+    #[arg(short = 'f', long, value_name = "PATH")]
+    pub file: Option<PathBuf>,
+
+    /// Number of recent lines to show before following new output.
+    #[arg(long, default_value_t = crate::logs::DEFAULT_TAIL_LINES, value_parser = parse_tail)]
+    pub tail: usize,
+
+    /// Continue waiting for new output until interrupted.
+    #[arg(short = 'F', long)]
+    pub follow: bool,
+
+    /// Restrict output to one process stream.
+    #[arg(long, value_enum)]
+    pub stream: Option<LogStream>,
+}
+
+fn parse_tail(value: &str) -> std::result::Result<usize, String> {
+    let tail = value
+        .parse::<usize>()
+        .map_err(|_| "tail must be a non-negative integer".to_string())?;
+    if tail > crate::logs::MAX_TAIL_LINES {
+        return Err(format!(
+            "tail must not exceed {}",
+            crate::logs::MAX_TAIL_LINES
+        ));
+    }
+    Ok(tail)
 }
 
 /// What an invocation resolved to, after the flag combination is checked.
@@ -81,11 +140,33 @@ pub enum ComposeCommand {
         /// Whether to bring `file` up before the first call arrives.
         start: bool,
     },
+    /// Read process output through the already-running daemon.
+    Logs {
+        explicit_engine_url: Option<String>,
+        explicit_daemon_namespace: Option<String>,
+        file: Option<PathBuf>,
+        container: Option<String>,
+        tail: usize,
+        follow: bool,
+        stream: Option<LogStream>,
+    },
 }
 
 impl ComposeCli {
     /// Resolves the invocation, rejecting incomplete flag combinations.
     pub fn plan(&self) -> Result<ComposeCommand> {
+        if let Some(ComposeSubcommand::Logs(logs)) = &self.command {
+            return Ok(ComposeCommand::Logs {
+                explicit_engine_url: logs.engine.clone().filter(|url| !url.trim().is_empty()),
+                explicit_daemon_namespace: validated_namespace(logs.namespace.as_deref())?,
+                file: logs.file.clone(),
+                container: logs.worker.clone(),
+                tail: logs.tail.min(crate::logs::MAX_TAIL_LINES),
+                follow: logs.follow,
+                stream: logs.stream,
+            });
+        }
+
         if !self.up && self.file.is_some() {
             return Err(ComposeError::FileRequiresUp);
         }
@@ -125,28 +206,7 @@ impl ComposeCli {
     /// `--namespace` as given, checked. `None` when it was not given — the caller
     /// decides whether to inherit the compose file namespace or use `default`.
     pub fn validated_namespace(&self) -> Result<Option<String>> {
-        let Some(namespace) = &self.ns else {
-            return Ok(None);
-        };
-
-        let namespace = namespace.trim();
-        // The same rule `name:` is held to. It used to be looser here — a path
-        // separator was refused but a space was not — while `name:` was
-        // silently rewritten, so one string meant two different namespaces
-        // depending on which of the two the operator used to say it.
-        let reason = if namespace.is_empty() {
-            Some("it is empty")
-        } else {
-            crate::namespace::check(namespace).err()
-        };
-
-        match reason {
-            Some(reason) => Err(ComposeError::InvalidNamespace {
-                namespace: namespace.to_string(),
-                reason,
-            }),
-            None => Ok(Some(namespace.to_string())),
-        }
+        validated_namespace(self.ns.as_deref())
     }
 
     /// Returns the explicit process-level engine selection. File and default
@@ -156,5 +216,30 @@ impl ComposeCli {
             .clone()
             .filter(|url| !url.trim().is_empty())
             .or_else(|| std::env::var("III_URL").ok().filter(|url| !url.is_empty()))
+    }
+}
+
+fn validated_namespace(namespace: Option<&str>) -> Result<Option<String>> {
+    let Some(namespace) = namespace else {
+        return Ok(None);
+    };
+
+    let namespace = namespace.trim();
+    // The same rule `name:` is held to. It used to be looser here — a path
+    // separator was refused but a space was not — while `name:` was
+    // silently rewritten, so one string meant two different namespaces
+    // depending on which of the two the operator used to say it.
+    let reason = if namespace.is_empty() {
+        Some("it is empty")
+    } else {
+        crate::namespace::check(namespace).err()
+    };
+
+    match reason {
+        Some(reason) => Err(ComposeError::InvalidNamespace {
+            namespace: namespace.to_string(),
+            reason,
+        }),
+        None => Ok(Some(namespace.to_string())),
     }
 }

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -31,6 +31,7 @@ use crate::{
     engine::EngineClient,
     error::{ComposeError, Result},
     lifecycle::{OpResult, OpStatus},
+    logs::{LogCursor, LogStream, LogsOutcome},
     project::Project,
 };
 
@@ -820,6 +821,21 @@ impl Daemon {
         let path = self.resolve_file(file)?;
         self.validate_engine_policy_file(path)?;
         self.project(path).await
+    }
+
+    pub async fn logs(
+        &self,
+        file: Option<&Path>,
+        container: Option<&str>,
+        cursors: BTreeMap<String, LogCursor>,
+        tail: usize,
+        stream: Option<LogStream>,
+        wait_ms: u64,
+    ) -> Result<LogsOutcome> {
+        let project = self.status(file).await?;
+        project
+            .logs(container, cursors, tail, stream, wait_ms)
+            .await
     }
 
     fn validate_engine_policy_file(&self, path: &Path) -> Result<()> {

--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -29,6 +29,7 @@ pub mod error;
 pub mod hooks;
 pub mod interpolate;
 pub mod lifecycle;
+pub mod logs;
 mod managed_engine;
 pub mod manifest;
 pub mod namespace;
@@ -41,7 +42,7 @@ mod shutdown;
 pub mod spawn;
 pub mod state;
 
-pub use cli::{ComposeCli, ComposeCommand};
+pub use cli::{ComposeCli, ComposeCommand, ComposeLogsCli, ComposeSubcommand};
 pub use config::{ComposeFile, Container, EngineSpec, WorkerSource};
 pub use error::{ComposeError, Result};
 pub use manifest::{StartSpec, ValidationReport};
@@ -117,7 +118,216 @@ pub async fn run(cli: ComposeCli) -> i32 {
             Ok(()) => 0,
             Err(err) => report_error(&err),
         },
+        ComposeCommand::Logs {
+            explicit_engine_url,
+            explicit_daemon_namespace,
+            file,
+            container,
+            tail,
+            follow,
+            stream,
+        } => match follow_worker_logs(
+            explicit_engine_url,
+            explicit_daemon_namespace,
+            file,
+            container,
+            tail,
+            follow,
+            stream,
+        )
+        .await
+        {
+            Ok(()) => 0,
+            Err(err) => report_error(&err),
+        },
     }
+}
+
+async fn follow_worker_logs(
+    explicit_engine_url: Option<String>,
+    explicit_daemon_namespace: Option<String>,
+    file: Option<std::path::PathBuf>,
+    container: Option<String>,
+    tail: usize,
+    follow: bool,
+    stream: Option<logs::LogStream>,
+) -> Result<()> {
+    use iii_sdk::{InitOptions, protocol::TriggerRequest, register_worker};
+
+    let local_config_path = file
+        .as_deref()
+        .unwrap_or_else(|| std::path::Path::new(cli::DEFAULT_COMPOSE_FILE));
+    let local_file = load_invocation_file(local_config_path, false)?;
+    let daemon_namespace = resolve_daemon_namespace(explicit_daemon_namespace, local_file.as_ref());
+    let environment_engine_url = std::env::var("III_URL")
+        .ok()
+        .filter(|url| !url.trim().is_empty());
+    let engine_url = match resolve_engine_mode(
+        local_file.as_ref(),
+        false,
+        explicit_engine_url.as_deref(),
+        environment_engine_url.as_deref(),
+    ) {
+        EngineMode::Managed { url } | EngineMode::External { url } => url,
+    };
+
+    let client = register_worker(
+        &engine_url,
+        InitOptions {
+            metadata: Some(iii_sdk::iii::WorkerMetadata {
+                name: format!(
+                    "compose-logs:{}:{}",
+                    std::process::id(),
+                    uuid::Uuid::new_v4()
+                ),
+                description: Some("Read retained Compose worker output".to_string()),
+                ..Default::default()
+            }),
+            // Environment namespace belongs to managed workers, not to this
+            // short-lived operator client. Every call below routes explicitly.
+            namespace: Some(namespace::DEFAULT_NAMESPACE.to_string()),
+            ..Default::default()
+        },
+    );
+    let mut cursors = std::collections::BTreeMap::new();
+    let mut first = true;
+
+    loop {
+        let mut payload = serde_json::Map::new();
+        if let Some(file) = &file {
+            payload.insert(
+                "file".to_string(),
+                serde_json::Value::String(file.to_string_lossy().into_owned()),
+            );
+        }
+        if let Some(container) = &container {
+            payload.insert(
+                "container".to_string(),
+                serde_json::Value::String(container.clone()),
+            );
+        }
+        if let Some(stream) = stream {
+            payload.insert(
+                "stream".to_string(),
+                serde_json::Value::String(match stream {
+                    logs::LogStream::Stdout => "stdout".to_string(),
+                    logs::LogStream::Stderr => "stderr".to_string(),
+                }),
+            );
+        }
+        payload.insert("tail".to_string(), serde_json::json!(tail));
+        if !cursors.is_empty() {
+            let values = cursors
+                .iter()
+                .map(|(container, cursor): (&String, &logs::LogCursor)| {
+                    (
+                        container.clone(),
+                        serde_json::json!({
+                            "generation": cursor.generation,
+                            "offset": cursor.offset,
+                        }),
+                    )
+                })
+                .collect();
+            payload.insert("cursors".to_string(), serde_json::Value::Object(values));
+        }
+        if follow {
+            payload.insert("wait_ms".to_string(), serde_json::json!(logs::MAX_WAIT_MS));
+        }
+
+        let request = TriggerRequest {
+            function_id: "compose::logs".to_string(),
+            payload: serde_json::Value::Object(payload),
+            action: None,
+            timeout_ms: Some(10_000),
+        }
+        .namespace(&daemon_namespace);
+
+        let result = tokio::select! {
+            result = client.trigger(request) => Some(result),
+            _ = tokio::signal::ctrl_c(), if follow => None,
+        };
+        let Some(result) = result else {
+            client.shutdown_async().await;
+            return Ok(());
+        };
+        let value = match result {
+            Ok(value) => value,
+            Err(error) => {
+                client.shutdown_async().await;
+                return Err(ComposeError::EngineCallFailed {
+                    function: "compose::logs".to_string(),
+                    message: error.to_string(),
+                });
+            }
+        };
+        let outcome: logs::LogsOutcome = match serde_json::from_value(value) {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                client.shutdown_async().await;
+                return Err(ComposeError::EngineCallFailed {
+                    function: "compose::logs".to_string(),
+                    message: format!("daemon returned an invalid log response: {error}"),
+                });
+            }
+        };
+
+        if let Err(source) = print_worker_logs(outcome, &mut cursors) {
+            client.shutdown_async().await;
+            if source.kind() == std::io::ErrorKind::BrokenPipe {
+                return Ok(());
+            }
+            return Err(ComposeError::Io {
+                path: std::path::PathBuf::from("<stdout>"),
+                source,
+            });
+        }
+
+        if !follow {
+            client.shutdown_async().await;
+            return Ok(());
+        }
+        if first && cursors.is_empty() {
+            // A project can be declared before any worker has produced output.
+            // Avoid a hot loop until the daemon has a file it can long-poll.
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        }
+        first = false;
+    }
+}
+
+fn print_worker_logs(
+    outcome: logs::LogsOutcome,
+    cursors: &mut std::collections::BTreeMap<String, logs::LogCursor>,
+) -> std::io::Result<()> {
+    use colored::Colorize;
+    use std::io::Write;
+
+    let mut stdout = std::io::stdout().lock();
+    for batch in outcome.containers {
+        let color = report::container_color(&batch.container);
+        for entry in batch.entries {
+            let tag = match entry.stream {
+                logs::LogStream::Stdout => format!("[{}]", batch.container).color(color),
+                logs::LogStream::Stderr => format!("[{}]", batch.container).color(color).bold(),
+            };
+            writeln!(stdout, "{tag} {}", entry.message)?;
+        }
+        if batch.truncated {
+            eprintln!(
+                "{}",
+                format!(
+                    "[{}] older output is no longer retained; showing the most recent retained lines",
+                    batch.container
+                )
+                .yellow()
+            );
+        }
+        if let Some(cursor) = batch.cursor {
+            cursors.insert(batch.container, cursor);
+        }
+    }
+    stdout.flush()
 }
 
 /// Serves `compose::*` until asked to stop.

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -34,6 +34,7 @@ use crate::{
     engine::EngineClient,
     error::{ComposeError, Result},
     hooks,
+    logs::LogStore,
     manifest::{StartSpec, resolve_start},
     process::{Outcome, Supervised, spawn_supervised_piped},
     report,
@@ -99,10 +100,8 @@ pub struct LifecycleCtx<'a> {
     pub config_dir: &'a std::path::Path,
     /// Where installed packages live, shared across projects on this machine.
     pub package_cache: &'a std::path::Path,
-    /// Where a child's own output is written. Compose neither prints nor
-    /// serves it — this is the record for a worker that dies before it can
-    /// tell the engine anything.
-    pub log_dir: &'a std::path::Path,
+    /// Persistent, bounded stdout and stderr for every project worker.
+    pub logs: &'a LogStore,
     /// Root of the per-container VM state for bundle containers.
     pub vm_dir: &'a std::path::Path,
 }
@@ -747,7 +746,7 @@ async fn start_one_until_shutdown(
         })?;
     // Capture before waiting on readiness: whatever the child prints while
     // starting is exactly what an operator needs when it does not.
-    let capture = report::capture_output(key, output.stdout, output.stderr, ctx.log_dir);
+    ctx.logs.capture(key, output.stdout, output.stderr);
 
     let readiness = if let Some(signal) = shutdown.as_mut() {
         tokio::select! {
@@ -763,7 +762,7 @@ async fn start_one_until_shutdown(
                 &child,
                 container.startup_timeout,
                 &baseline,
-                ctx.log_dir,
+                ctx.logs.dir(),
             ) => readiness,
         }
     } else {
@@ -774,7 +773,7 @@ async fn start_one_until_shutdown(
                 &child,
                 container.startup_timeout,
                 &baseline,
-                ctx.log_dir,
+                ctx.logs.dir(),
             )
             .await
     };
@@ -786,11 +785,6 @@ async fn start_one_until_shutdown(
         fire_post_run(ctx, &spawn_ctx, container).await;
         return Err(StartFailure::Failed(error));
     }
-
-    // Registered: the engine can hear it now, so its own logging is the record
-    // and compose stops keeping a second one. What stays on disk is the boot,
-    // which is the part the engine never saw.
-    capture.stop();
 
     let record = ChildRecord::from_supervised(&child, ChildStatus::Ready);
     Ok((record, child))

--- a/crates/iii-compose/src/logs.rs
+++ b/crates/iii-compose/src/logs.rs
@@ -1,0 +1,837 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Bounded process-output storage for Compose workers.
+//!
+//! Every project owns one writer. Worker pipes only read and enqueue records;
+//! the writer serializes stdout and stderr into one rotating file per worker.
+//! This keeps rotation race-free across streams and worker restarts.
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs::File,
+    io::{BufRead, BufReader, Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use crate::managed_engine::TerminalSanitizer;
+
+pub const WORKER_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
+pub const WORKER_LOG_ARCHIVES: usize = 3;
+pub const DEFAULT_TAIL_LINES: usize = 100;
+pub const MAX_TAIL_LINES: usize = 1_000;
+pub const MAX_WAIT_MS: u64 = 5_000;
+
+const LOG_HEADER_PREFIX: &str = "# iii-compose-worker-log-v1 ";
+const MAX_LINE_BYTES: usize = 64 * 1024;
+const MAX_BATCH_BYTES: usize = 512 * 1024;
+const MAX_TAIL_SCAN_BYTES: u64 = WORKER_LOG_MAX_BYTES + MAX_LINE_BYTES as u64;
+const MAX_WRITE_BATCH_RECORDS: usize = 128;
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, clap::ValueEnum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum LogStream {
+    Stdout,
+    Stderr,
+}
+
+impl LogStream {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct LogCursor {
+    /// Opaque identity of the active or archived log segment.
+    pub generation: String,
+    /// Byte offset after the last record returned from that segment.
+    pub offset: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct LogEntry {
+    pub stream: LogStream,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ContainerLogs {
+    pub container: String,
+    pub entries: Vec<LogEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<LogCursor>,
+    /// True when the requested cursor was older than the retained archives.
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct LogsOutcome {
+    pub containers: Vec<ContainerLogs>,
+}
+
+impl LogsOutcome {
+    pub fn is_empty(&self) -> bool {
+        self.containers
+            .iter()
+            .all(|container| container.entries.is_empty())
+    }
+
+    fn has_cursor_progress(&self, cursors: &BTreeMap<String, LogCursor>) -> bool {
+        self.containers.iter().any(|container| {
+            container.cursor.as_ref() != cursors.get(&container.container)
+                && container.cursor.is_some()
+        })
+    }
+}
+
+struct LogMessage {
+    container: String,
+    stream: LogStream,
+    message: Vec<u8>,
+}
+
+/// One project-wide log writer and query surface.
+pub struct LogStore {
+    dir: PathBuf,
+    sender: tokio::sync::mpsc::Sender<LogMessage>,
+    changed: tokio::sync::watch::Sender<u64>,
+    io_lock: Arc<Mutex<()>>,
+    archives: usize,
+}
+
+impl LogStore {
+    pub fn open(dir: PathBuf) -> std::io::Result<Self> {
+        Self::open_with_limits(dir, WORKER_LOG_MAX_BYTES, WORKER_LOG_ARCHIVES)
+    }
+
+    fn open_with_limits(dir: PathBuf, max_bytes: u64, archives: usize) -> std::io::Result<Self> {
+        std::fs::create_dir_all(&dir)?;
+        owner_only(&dir)?;
+
+        let (sender, mut receiver) = tokio::sync::mpsc::channel::<LogMessage>(1_024);
+        let (changed, _) = tokio::sync::watch::channel(0_u64);
+        let writer_changed = changed.clone();
+        let writer_dir = dir.clone();
+        let io_lock = Arc::new(Mutex::new(()));
+        let writer_io_lock = Arc::clone(&io_lock);
+        tokio::spawn(async move {
+            let mut files: HashMap<String, WorkerLogFile> = HashMap::new();
+            while let Some(first) = receiver.recv().await {
+                let mut records = Vec::with_capacity(MAX_WRITE_BATCH_RECORDS);
+                records.push(first);
+                while records.len() < MAX_WRITE_BATCH_RECORDS {
+                    let Ok(record) = receiver.try_recv() else {
+                        break;
+                    };
+                    records.push(record);
+                }
+
+                let io_lock = Arc::clone(&writer_io_lock);
+                let dir = writer_dir.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    let Ok(_guard) = io_lock.lock() else {
+                        return None;
+                    };
+                    let mut wrote = false;
+                    for record in records {
+                        let file = match files.entry(record.container.clone()) {
+                            std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                            std::collections::hash_map::Entry::Vacant(entry) => {
+                                let path = log_path(&dir, &record.container);
+                                let Ok(file) = WorkerLogFile::open(path, max_bytes, archives)
+                                else {
+                                    continue;
+                                };
+                                entry.insert(file)
+                            }
+                        };
+
+                        if file.write_entry(record.stream, &record.message).is_ok() {
+                            wrote = true;
+                        } else {
+                            files.remove(&record.container);
+                        }
+                    }
+                    Some((files, wrote))
+                })
+                .await;
+                let Ok(Some((next_files, wrote))) = result else {
+                    break;
+                };
+                files = next_files;
+                if wrote {
+                    writer_changed.send_modify(|generation| {
+                        *generation = generation.wrapping_add(1);
+                    });
+                }
+            }
+        });
+
+        Ok(Self {
+            dir,
+            sender,
+            changed,
+            io_lock,
+            archives,
+        })
+    }
+
+    pub fn path(&self, container: &str) -> PathBuf {
+        log_path(&self.dir, container)
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    /// Drains both child streams until EOF and keeps every record after the
+    /// worker becomes ready. The bounded channel applies backpressure instead
+    /// of growing memory without limit when disk is slower than the worker.
+    pub fn capture(
+        &self,
+        container: &str,
+        stdout: Option<tokio::process::ChildStdout>,
+        stderr: Option<tokio::process::ChildStderr>,
+    ) {
+        for (stream, reader) in [
+            stdout.map(|reader| {
+                (
+                    LogStream::Stdout,
+                    Box::new(reader) as Box<dyn AsyncRead + Unpin + Send>,
+                )
+            }),
+            stderr.map(|reader| {
+                (
+                    LogStream::Stderr,
+                    Box::new(reader) as Box<dyn AsyncRead + Unpin + Send>,
+                )
+            }),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            let sender = self.sender.clone();
+            let container = container.to_string();
+            tokio::spawn(async move {
+                pump_stream(reader, container, stream, sender).await;
+            });
+        }
+    }
+
+    pub async fn query(
+        &self,
+        containers: Vec<String>,
+        cursors: BTreeMap<String, LogCursor>,
+        tail: usize,
+        stream: Option<LogStream>,
+        wait: Duration,
+    ) -> std::io::Result<LogsOutcome> {
+        let mut changed = self.changed.subscribe();
+        changed.borrow_and_update();
+        let first = self
+            .query_once(containers.clone(), cursors.clone(), tail, stream)
+            .await?;
+        if !first.is_empty() || first.has_cursor_progress(&cursors) || wait.is_zero() {
+            return Ok(first);
+        }
+
+        let _ = tokio::time::timeout(wait, changed.changed()).await;
+        self.query_once(containers, cursors, tail, stream).await
+    }
+
+    async fn query_once(
+        &self,
+        containers: Vec<String>,
+        cursors: BTreeMap<String, LogCursor>,
+        tail: usize,
+        stream: Option<LogStream>,
+    ) -> std::io::Result<LogsOutcome> {
+        let dir = self.dir.clone();
+        let io_lock = Arc::clone(&self.io_lock);
+        let archives = self.archives;
+        let tail = tail.min(MAX_TAIL_LINES);
+        tokio::task::spawn_blocking(move || {
+            let _guard = io_lock
+                .lock()
+                .map_err(|_| std::io::Error::other("worker log lock is poisoned"))?;
+            let mut batches = Vec::with_capacity(containers.len());
+            for container in containers {
+                batches.push(read_container_logs(
+                    &dir,
+                    &container,
+                    cursors.get(&container),
+                    tail,
+                    stream,
+                    archives,
+                )?);
+            }
+            Ok(LogsOutcome {
+                containers: batches,
+            })
+        })
+        .await
+        .map_err(std::io::Error::other)?
+    }
+}
+
+async fn pump_stream(
+    mut reader: Box<dyn AsyncRead + Unpin + Send>,
+    container: String,
+    stream: LogStream,
+    sender: tokio::sync::mpsc::Sender<LogMessage>,
+) {
+    let mut sanitizer = TerminalSanitizer::default();
+    let mut read_buffer = vec![0_u8; 8 * 1024];
+    let mut line = Vec::new();
+
+    while let Ok(count) = reader.read(&mut read_buffer).await {
+        if count == 0 {
+            break;
+        }
+
+        let clean = sanitizer.sanitize(&read_buffer[..count]);
+        let mut remaining = clean.as_slice();
+        while !remaining.is_empty() {
+            let newline = remaining.iter().position(|byte| *byte == b'\n');
+            let end = newline.map_or(remaining.len(), |index| index + 1);
+            line.extend_from_slice(&remaining[..end]);
+            remaining = &remaining[end..];
+
+            while line.len() >= MAX_LINE_BYTES {
+                let rest = line.split_off(MAX_LINE_BYTES);
+                let chunk = std::mem::replace(&mut line, rest);
+                if send_line(&sender, &container, stream, chunk).await.is_err() {
+                    return;
+                }
+            }
+
+            if newline.is_some() {
+                let complete = std::mem::take(&mut line);
+                if send_line(&sender, &container, stream, complete)
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        }
+    }
+
+    if !line.is_empty() {
+        let _ = send_line(&sender, &container, stream, line).await;
+    }
+}
+
+async fn send_line(
+    sender: &tokio::sync::mpsc::Sender<LogMessage>,
+    container: &str,
+    stream: LogStream,
+    mut message: Vec<u8>,
+) -> Result<(), tokio::sync::mpsc::error::SendError<LogMessage>> {
+    while matches!(message.last(), Some(b'\n' | b'\r')) {
+        message.pop();
+    }
+    sender
+        .send(LogMessage {
+            container: container.to_string(),
+            stream,
+            message,
+        })
+        .await
+}
+
+struct WorkerLogFile {
+    path: PathBuf,
+    file: Option<File>,
+    size: u64,
+    max_bytes: u64,
+    archives: usize,
+}
+
+impl WorkerLogFile {
+    fn open(path: PathBuf, max_bytes: u64, archives: usize) -> std::io::Result<Self> {
+        let max_bytes = max_bytes.max(1);
+        if path.exists() && read_generation(&path)?.is_none() {
+            rotate_path(&path, archives)?;
+        }
+
+        let mut log = Self {
+            path,
+            file: None,
+            size: 0,
+            max_bytes,
+            archives,
+        };
+        log.open_active()?;
+        if log.size >= log.max_bytes {
+            log.rotate()?;
+        }
+        Ok(log)
+    }
+
+    fn open_active(&mut self) -> std::io::Result<()> {
+        let new_file = !self.path.exists() || self.path.metadata()?.len() == 0;
+        let mut options = std::fs::OpenOptions::new();
+        options.create(true).append(true).read(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&self.path)?;
+        owner_only(&self.path)?;
+        if new_file {
+            writeln!(file, "{LOG_HEADER_PREFIX}{}", uuid::Uuid::new_v4())?;
+            file.flush()?;
+        }
+        self.size = file.metadata()?.len();
+        self.file = Some(file);
+        Ok(())
+    }
+
+    fn write_entry(&mut self, stream: LogStream, message: &[u8]) -> std::io::Result<()> {
+        let mut record = Vec::with_capacity(stream.as_str().len() + message.len() + 2);
+        record.extend_from_slice(stream.as_str().as_bytes());
+        record.push(b'\t');
+        record.extend_from_slice(message);
+        record.push(b'\n');
+
+        if self.size + record.len() as u64 > self.max_bytes {
+            self.rotate()?;
+        }
+        let file = self
+            .file
+            .as_mut()
+            .ok_or_else(|| std::io::Error::other("worker log file is not open"))?;
+        file.write_all(&record)?;
+        file.flush()?;
+        self.size += record.len() as u64;
+        Ok(())
+    }
+
+    fn rotate(&mut self) -> std::io::Result<()> {
+        if let Some(mut file) = self.file.take() {
+            file.flush()?;
+        }
+        rotate_path(&self.path, self.archives)?;
+        self.open_active()
+    }
+}
+
+fn rotate_path(path: &Path, archives: usize) -> std::io::Result<()> {
+    if archives == 0 {
+        if path.exists() {
+            std::fs::remove_file(path)?;
+        }
+        return Ok(());
+    }
+
+    let oldest = archive_path(path, archives);
+    if oldest.exists() {
+        std::fs::remove_file(oldest)?;
+    }
+    for index in (1..archives).rev() {
+        let source = archive_path(path, index);
+        if source.exists() {
+            std::fs::rename(source, archive_path(path, index + 1))?;
+        }
+    }
+    if path.exists() {
+        std::fs::rename(path, archive_path(path, 1))?;
+    }
+    Ok(())
+}
+
+fn read_container_logs(
+    dir: &Path,
+    container: &str,
+    cursor: Option<&LogCursor>,
+    tail: usize,
+    stream: Option<LogStream>,
+    archives: usize,
+) -> std::io::Result<ContainerLogs> {
+    let active = log_path(dir, container);
+    let segments = segment_paths(&active, archives);
+    let available: Vec<(PathBuf, String)> = segments
+        .into_iter()
+        .filter_map(|path| match read_generation(&path) {
+            Ok(Some(generation)) => Some(Ok((path, generation))),
+            Ok(None) => None,
+            Err(error) => Some(Err(error)),
+        })
+        .collect::<std::io::Result<_>>()?;
+
+    if available.is_empty() {
+        return Ok(ContainerLogs {
+            container: container.to_string(),
+            entries: Vec::new(),
+            cursor: None,
+            truncated: false,
+        });
+    }
+
+    match cursor {
+        Some(cursor) => read_after_cursor(container, &available, cursor, tail, stream),
+        None => read_tail(container, &available, tail, stream, false),
+    }
+}
+
+fn read_after_cursor(
+    container: &str,
+    segments: &[(PathBuf, String)],
+    cursor: &LogCursor,
+    limit: usize,
+    stream: Option<LogStream>,
+) -> std::io::Result<ContainerLogs> {
+    let Some(start) = segments
+        .iter()
+        .position(|(_, generation)| generation == &cursor.generation)
+    else {
+        return read_tail(container, segments, limit, stream, true);
+    };
+
+    let mut entries = Vec::new();
+    let mut bytes = 0;
+    let mut next = cursor.clone();
+    for (index, (path, generation)) in segments.iter().enumerate().skip(start) {
+        let offset = if index == start {
+            cursor.offset
+        } else {
+            header_end(path)?.unwrap_or_default()
+        };
+        let (more, position) =
+            read_entries(path, offset, limit - entries.len(), stream, &mut bytes)?;
+        entries.extend(more);
+        next = LogCursor {
+            generation: generation.clone(),
+            offset: position,
+        };
+        if entries.len() >= limit || bytes >= MAX_BATCH_BYTES {
+            break;
+        }
+    }
+
+    Ok(ContainerLogs {
+        container: container.to_string(),
+        entries,
+        cursor: Some(next),
+        truncated: false,
+    })
+}
+
+fn read_tail(
+    container: &str,
+    segments: &[(PathBuf, String)],
+    limit: usize,
+    stream: Option<LogStream>,
+    truncated: bool,
+) -> std::io::Result<ContainerLogs> {
+    let mut entries = Vec::new();
+    for (path, _) in segments.iter().rev() {
+        let mut from_segment = tail_entries(path, limit.saturating_sub(entries.len()), stream)?;
+        from_segment.append(&mut entries);
+        entries = from_segment;
+        if entries.len() >= limit {
+            break;
+        }
+    }
+    if entries.len() > limit {
+        entries.drain(..entries.len() - limit);
+    }
+
+    let (active, generation) = segments
+        .last()
+        .ok_or_else(|| std::io::Error::other("worker log has no readable segment"))?;
+    let offset = active.metadata()?.len();
+    Ok(ContainerLogs {
+        container: container.to_string(),
+        entries,
+        cursor: Some(LogCursor {
+            generation: generation.clone(),
+            offset,
+        }),
+        truncated,
+    })
+}
+
+fn read_entries(
+    path: &Path,
+    offset: u64,
+    limit: usize,
+    stream: Option<LogStream>,
+    bytes: &mut usize,
+) -> std::io::Result<(Vec<LogEntry>, u64)> {
+    let mut file = BufReader::new(File::open(path)?);
+    let length = file.get_ref().metadata()?.len();
+    file.seek(SeekFrom::Start(offset.min(length)))?;
+    let mut entries = Vec::new();
+    let mut record = Vec::new();
+    while entries.len() < limit && *bytes < MAX_BATCH_BYTES {
+        record.clear();
+        let count = file.read_until(b'\n', &mut record)?;
+        if count == 0 {
+            break;
+        }
+        *bytes += count;
+        if let Some(entry) = parse_entry(&record, stream) {
+            entries.push(entry);
+        }
+    }
+    Ok((entries, file.stream_position()?))
+}
+
+fn tail_entries(
+    path: &Path,
+    limit: usize,
+    stream: Option<LogStream>,
+) -> std::io::Result<Vec<LogEntry>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    let mut file = File::open(path)?;
+    let length = file.metadata()?.len();
+    let start = length.saturating_sub(MAX_TAIL_SCAN_BYTES);
+    file.seek(SeekFrom::Start(start))?;
+    let mut bytes = Vec::with_capacity((length - start) as usize);
+    file.take(MAX_TAIL_SCAN_BYTES).read_to_end(&mut bytes)?;
+    let text = if start > 0 {
+        bytes
+            .splitn(2, |byte| *byte == b'\n')
+            .nth(1)
+            .unwrap_or_default()
+    } else {
+        bytes.as_slice()
+    };
+    let mut entries: Vec<LogEntry> = text
+        .split_inclusive(|byte| *byte == b'\n')
+        .filter_map(|record| parse_entry(record, stream))
+        .collect();
+    if entries.len() > limit {
+        entries.drain(..entries.len() - limit);
+    }
+    Ok(entries)
+}
+
+fn parse_entry(record: &[u8], filter: Option<LogStream>) -> Option<LogEntry> {
+    let record = record.strip_suffix(b"\n").unwrap_or(record);
+    let separator = record.iter().position(|byte| *byte == b'\t')?;
+    let stream = &record[..separator];
+    let message = &record[separator + 1..];
+    let stream = match stream {
+        b"stdout" => LogStream::Stdout,
+        b"stderr" => LogStream::Stderr,
+        _ => return None,
+    };
+    if filter.is_some_and(|filter| filter != stream) {
+        return None;
+    }
+    Some(LogEntry {
+        stream,
+        message: String::from_utf8_lossy(message).into_owned(),
+    })
+}
+
+fn read_generation(path: &Path) -> std::io::Result<Option<String>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let mut header = String::new();
+    BufReader::new(File::open(path)?).read_line(&mut header)?;
+    Ok(header
+        .trim_end()
+        .strip_prefix(LOG_HEADER_PREFIX)
+        .map(str::to_string))
+}
+
+fn header_end(path: &Path) -> std::io::Result<Option<u64>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let mut reader = BufReader::new(File::open(path)?);
+    let mut header = Vec::new();
+    reader.read_until(b'\n', &mut header)?;
+    Ok(Some(reader.stream_position()?))
+}
+
+fn segment_paths(path: &Path, archives: usize) -> Vec<PathBuf> {
+    let mut paths = (1..=archives)
+        .rev()
+        .map(|index| archive_path(path, index))
+        .collect::<Vec<_>>();
+    paths.push(path.to_path_buf());
+    paths
+}
+
+fn archive_path(path: &Path, index: usize) -> PathBuf {
+    let mut archive = path.as_os_str().to_os_string();
+    archive.push(format!(".{index}"));
+    PathBuf::from(archive)
+}
+
+fn log_path(dir: &Path, container: &str) -> PathBuf {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+    let mut name = String::with_capacity(container.len() + 4);
+    for byte in container.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.') {
+            name.push(char::from(byte));
+        } else {
+            name.push('%');
+            name.push(char::from(HEX[(byte >> 4) as usize]));
+            name.push(char::from(HEX[(byte & 0x0f) as usize]));
+        }
+    }
+    name.push_str(".log");
+    dir.join(name)
+}
+
+#[cfg(unix)]
+fn owner_only(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(
+        path,
+        std::fs::Permissions::from_mode(if path.is_dir() { 0o700 } else { 0o600 }),
+    )
+}
+
+#[cfg(not(unix))]
+fn owner_only(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    fn write(file: &mut WorkerLogFile, stream: LogStream, message: &str) {
+        file.write_entry(stream, message.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn worker_log_rotates_without_losing_a_cursor_in_retained_archives() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("queue.log");
+        let mut file = WorkerLogFile::open(path, 130, 2).unwrap();
+        write(&mut file, LogStream::Stdout, "before rotation");
+        let first = read_container_logs(dir.path(), "queue", None, 10, None, 2).unwrap();
+        let cursor = first.cursor.unwrap();
+
+        for index in 0..3 {
+            write(&mut file, LogStream::Stdout, &format!("line-{index:02}"));
+        }
+        let after = read_container_logs(dir.path(), "queue", Some(&cursor), 20, None, 2).unwrap();
+
+        assert!(
+            after.entries.iter().any(|entry| entry.message == "line-00"),
+            "cursor did not continue into the retained archive: {after:?}"
+        );
+    }
+
+    #[test]
+    fn worker_log_reports_a_cursor_older_than_retention_as_truncated() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("queue.log");
+        let mut file = WorkerLogFile::open(path, 80, 1).unwrap();
+        write(&mut file, LogStream::Stdout, "old");
+        let old = read_container_logs(dir.path(), "queue", None, 10, None, 1)
+            .unwrap()
+            .cursor
+            .unwrap();
+
+        for index in 0..30 {
+            write(&mut file, LogStream::Stdout, &format!("new-{index:02}"));
+        }
+        let result = read_container_logs(dir.path(), "queue", Some(&old), 10, None, 1).unwrap();
+
+        assert!(result.truncated);
+    }
+
+    #[test]
+    fn worker_log_filters_stderr_without_restyling_the_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("queue.log");
+        let mut file = WorkerLogFile::open(path, 1_024, 1).unwrap();
+        write(&mut file, LogStream::Stdout, "ordinary output");
+        write(&mut file, LogStream::Stderr, "failure output");
+
+        let result =
+            read_container_logs(dir.path(), "queue", None, 10, Some(LogStream::Stderr), 1).unwrap();
+
+        assert_eq!(
+            result.entries,
+            vec![LogEntry {
+                stream: LogStream::Stderr,
+                message: "failure output".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn worker_name_cannot_escape_the_log_directory() {
+        let dir = Path::new("logs");
+        let path = log_path(dir, "../../outside");
+
+        assert_eq!(path, dir.join("..%2F..%2Foutside.log"));
+    }
+
+    #[tokio::test]
+    async fn capture_keeps_output_written_after_the_initial_cursor() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LogStore::open_with_limits(dir.path().to_path_buf(), 1_024, 1).unwrap();
+        let (mut writer, reader) = tokio::io::duplex(1_024);
+        let sender = store.sender.clone();
+        tokio::spawn(async move {
+            pump_stream(
+                Box::new(reader),
+                "queue".to_string(),
+                LogStream::Stdout,
+                sender,
+            )
+            .await;
+        });
+
+        writer.write_all(b"boot output\n").await.unwrap();
+        let first = store
+            .query(
+                vec!["queue".to_string()],
+                BTreeMap::new(),
+                10,
+                None,
+                Duration::from_secs(1),
+            )
+            .await
+            .unwrap();
+        let cursor = first.containers[0].cursor.clone().unwrap();
+
+        writer.write_all(b"output after ready\n").await.unwrap();
+        let after = store
+            .query(
+                vec!["queue".to_string()],
+                BTreeMap::from([("queue".to_string(), cursor)]),
+                10,
+                None,
+                Duration::from_secs(1),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(after.containers[0].entries[0].message, "output after ready");
+    }
+}

--- a/crates/iii-compose/src/managed_engine.rs
+++ b/crates/iii-compose/src/managed_engine.rs
@@ -538,14 +538,14 @@ enum TerminalState {
 /// suppressed, which fails closed instead of letting their payload reach a
 /// terminal through `tail -f` or an error summary.
 #[derive(Debug, Default)]
-struct TerminalSanitizer {
+pub(crate) struct TerminalSanitizer {
     state: TerminalState,
     utf8: Vec<u8>,
     utf8_expected: usize,
 }
 
 impl TerminalSanitizer {
-    fn sanitize(&mut self, bytes: &[u8]) -> Vec<u8> {
+    pub(crate) fn sanitize(&mut self, bytes: &[u8]) -> Vec<u8> {
         let mut clean = Vec::with_capacity(bytes.len());
 
         for &input in bytes {

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -30,8 +30,9 @@ use tokio::sync::{Mutex, RwLock};
 use crate::{
     config::ComposeFile,
     engine::EngineClient,
-    error::Result,
+    error::{ComposeError, Result},
     lifecycle::{self, Children, LifecycleCtx, OpResult},
+    logs::{LogCursor, LogStore, LogStream, LogsOutcome},
     process::Supervised,
     state::{ChildStatus, DaemonState, Reconciliation, StateStore, reconcile},
 };
@@ -52,6 +53,7 @@ pub struct Project {
     /// projects.
     engine: Arc<EngineClient>,
     post_runs: crate::hooks::PostRunSupervisor,
+    logs: LogStore,
     store: StateStore,
     inner: Mutex<Inner>,
 }
@@ -94,6 +96,11 @@ impl Project {
         let mut state =
             recovered.unwrap_or_else(|| DaemonState::new(&file.path, &project_namespace));
         state.namespace = project_namespace.clone();
+        let log_dir = store.dir().join("logs");
+        let logs = LogStore::open(log_dir.clone()).map_err(|source| ComposeError::Io {
+            path: log_dir,
+            source,
+        })?;
 
         let project = Arc::new(Self {
             file: RwLock::new(file),
@@ -103,6 +110,7 @@ impl Project {
             engine_url,
             engine,
             post_runs: crate::hooks::PostRunSupervisor::default(),
+            logs,
             store,
             inner: Mutex::new(Inner {
                 children: BTreeMap::new(),
@@ -360,12 +368,6 @@ impl Project {
         self.store.dir().join("config")
     }
 
-    /// Where each container's own output is written. Beside the project's
-    /// state, so a project that is removed takes its logs with it.
-    fn log_dir(&self) -> PathBuf {
-        self.store.dir().join("logs")
-    }
-
     /// Per-container VM state for bundle containers: rootfs, boot script, pid
     /// file. Keyed by project rather than by worker name, so two projects
     /// running the same bundle under the same container key stay apart.
@@ -385,7 +387,6 @@ impl Project {
 
     pub async fn up(&self, target: Option<&str>, operation_id: String) -> OpResult {
         let config_dir = self.config_dir();
-        let log_dir = self.log_dir();
         let package_cache = self.package_cache();
         let vm_dir = self.vm_dir();
         let mut inner = self.inner.lock().await;
@@ -400,7 +401,7 @@ impl Project {
             project_namespace: &self.project_namespace,
             engine_url: &self.engine_url,
             config_dir: &config_dir,
-            log_dir: &log_dir,
+            logs: &self.logs,
             package_cache: &package_cache,
             vm_dir: &vm_dir,
         };
@@ -421,7 +422,6 @@ impl Project {
         shutdown: crate::shutdown::ShutdownSignal,
     ) -> Option<OpResult> {
         let config_dir = self.config_dir();
-        let log_dir = self.log_dir();
         let package_cache = self.package_cache();
         let vm_dir = self.vm_dir();
         let mut inner = self.inner.lock().await;
@@ -436,7 +436,7 @@ impl Project {
             project_namespace: &self.project_namespace,
             engine_url: &self.engine_url,
             config_dir: &config_dir,
-            log_dir: &log_dir,
+            logs: &self.logs,
             package_cache: &package_cache,
             vm_dir: &vm_dir,
         };
@@ -468,7 +468,6 @@ impl Project {
         operation_id: String,
     ) -> (Vec<OpResult>, OpResult) {
         let config_dir = self.config_dir();
-        let log_dir = self.log_dir();
         let package_cache = self.package_cache();
         let vm_dir = self.vm_dir();
         let mut inner = self.inner.lock().await;
@@ -487,7 +486,7 @@ impl Project {
             project_namespace: &self.project_namespace,
             engine_url: &self.engine_url,
             config_dir: &config_dir,
-            log_dir: &log_dir,
+            logs: &self.logs,
             package_cache: &package_cache,
             vm_dir: &vm_dir,
         };
@@ -534,7 +533,6 @@ impl Project {
         operation_id: String,
     ) -> (OpResult, OpResult) {
         let config_dir = self.config_dir();
-        let log_dir = self.log_dir();
         let package_cache = self.package_cache();
         let vm_dir = self.vm_dir();
         let mut inner = self.inner.lock().await;
@@ -550,7 +548,7 @@ impl Project {
                 project_namespace: &self.project_namespace,
                 engine_url: &self.engine_url,
                 config_dir: &config_dir,
-                log_dir: &log_dir,
+                logs: &self.logs,
                 package_cache: &package_cache,
                 vm_dir: &vm_dir,
             };
@@ -577,7 +575,7 @@ impl Project {
             project_namespace: &self.project_namespace,
             engine_url: &self.engine_url,
             config_dir: &config_dir,
-            log_dir: &log_dir,
+            logs: &self.logs,
             package_cache: &package_cache,
             vm_dir: &vm_dir,
         };
@@ -601,7 +599,6 @@ impl Project {
     /// not take the container's graph with it.
     pub async fn restart_one(&self, key: &str, operation_id: String) -> OpResult {
         let config_dir = self.config_dir();
-        let log_dir = self.log_dir();
         let package_cache = self.package_cache();
         let vm_dir = self.vm_dir();
         let mut inner = self.inner.lock().await;
@@ -616,7 +613,7 @@ impl Project {
             project_namespace: &self.project_namespace,
             engine_url: &self.engine_url,
             config_dir: &config_dir,
-            log_dir: &log_dir,
+            logs: &self.logs,
             package_cache: &package_cache,
             vm_dir: &vm_dir,
         };
@@ -632,7 +629,6 @@ impl Project {
 
     pub async fn down(&self, target: Option<&str>, operation_id: String) -> OpResult {
         let config_dir = self.config_dir();
-        let log_dir = self.log_dir();
         let package_cache = self.package_cache();
         let vm_dir = self.vm_dir();
         let mut inner = self.inner.lock().await;
@@ -647,7 +643,7 @@ impl Project {
             project_namespace: &self.project_namespace,
             engine_url: &self.engine_url,
             config_dir: &config_dir,
-            log_dir: &log_dir,
+            logs: &self.logs,
             package_cache: &package_cache,
             vm_dir: &vm_dir,
         };
@@ -682,10 +678,49 @@ impl Project {
                     },
                     pid: record.map(|r| r.pid),
                     owned: inner.children.contains_key(key),
+                    log_path: self.logs.path(key),
                     last_error: record.and_then(|r| r.last_error.clone()),
                 }
             })
             .collect()
+    }
+
+    /// Reads retained stdout and stderr without exposing arbitrary host paths.
+    pub async fn logs(
+        &self,
+        container: Option<&str>,
+        cursors: BTreeMap<String, LogCursor>,
+        tail: usize,
+        stream: Option<LogStream>,
+        wait_ms: u64,
+    ) -> Result<LogsOutcome> {
+        let file = self.file.read().await;
+        let containers = match container {
+            Some(container) if file.containers.contains_key(container) => {
+                vec![container.to_string()]
+            }
+            Some(container) => {
+                return Err(ComposeError::UnknownContainer {
+                    container: container.to_string(),
+                });
+            }
+            None => file.containers.keys().cloned().collect(),
+        };
+        drop(file);
+
+        self.logs
+            .query(
+                containers,
+                cursors,
+                tail,
+                stream,
+                Duration::from_millis(wait_ms.min(crate::logs::MAX_WAIT_MS)),
+            )
+            .await
+            .map_err(|source| ComposeError::Io {
+                path: self.logs.dir().to_path_buf(),
+                source,
+            })
     }
 
     /// Leaves without touching what was not started here.
@@ -739,6 +774,8 @@ pub struct ContainerStatus {
     pub pid: Option<u32>,
     /// Whether this daemon owns the process (started it and can stop it).
     pub owned: bool,
+    /// Rotating stdout and stderr file on the daemon host.
+    pub log_path: PathBuf,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_error: Option<String>,
 }

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -21,7 +21,7 @@
 //! fall back to `worker-compose.yaml` in the daemon's own directory, and say
 //! so when there is none.
 
-use std::{path::PathBuf, sync::Arc};
+use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 
 use iii_sdk::{Error, RegisterFunction};
 use schemars::{JsonSchema, schema_for};
@@ -32,6 +32,7 @@ use crate::{
     daemon::Daemon,
     error::ComposeError,
     lifecycle::{OpResult, OpStatus},
+    logs::{LogCursor, LogStream, LogsOutcome},
     project::ContainerStatus,
 };
 
@@ -66,6 +67,14 @@ pub struct ComposeRequest {
     /// This is the canonical `compose::add` JSON field. The singular `worker`
     /// field remains accepted for clients that used the old contract.
     pub workers: Option<Vec<String>>,
+    /// Last cursor returned for each selected worker.
+    pub cursors: Option<BTreeMap<String, LogCursor>>,
+    /// Number of recent lines returned when no cursor is supplied.
+    pub tail: Option<usize>,
+    /// Restrict logs to stdout or stderr.
+    pub stream: Option<LogStream>,
+    /// Long-poll budget. Bounded by the daemon.
+    pub wait_ms: Option<u64>,
     /// Function or file contract requested by `compose::schema`.
     pub function_id: Option<String>,
 }
@@ -146,6 +155,29 @@ struct RestartOptions {
     container: Option<String>,
     /// Alias for `container`.
     worker: Option<String>,
+}
+
+/// Request fields used by `compose::logs`.
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+struct LogsOptions {
+    /// Optional daemon guard. Use the trigger `--namespace` flag to route.
+    namespace: Option<String>,
+    /// Compose file on the daemon host. Defaults to `worker-compose.yaml` in
+    /// the daemon working directory.
+    file: Option<String>,
+    /// Container whose process output should be read. Omit for every worker.
+    container: Option<String>,
+    /// Alias for `container`.
+    worker: Option<String>,
+    /// Last cursor returned for each selected worker.
+    cursors: Option<BTreeMap<String, LogCursor>>,
+    /// Recent line count for the first request. Default 100, maximum 1000.
+    tail: Option<usize>,
+    /// Restrict output to stdout or stderr.
+    stream: Option<LogStream>,
+    /// Wait this many milliseconds for new output. Maximum 5000.
+    wait_ms: Option<u64>,
 }
 
 /// `compose::schema` request. Omit `function_id` to return every contract.
@@ -297,6 +329,7 @@ enum Operation {
     Down,
     List,
     Status,
+    Logs,
     Stop,
     Validate,
     Add,
@@ -312,6 +345,7 @@ const REGISTERED_OPERATIONS: &[(&str, Operation)] = &[
     ("down", Operation::Down),
     ("list", Operation::List),
     ("status", Operation::Status),
+    ("logs", Operation::Logs),
     ("stop", Operation::Stop),
     ("validate", Operation::Validate),
     ("add", Operation::Add),
@@ -438,6 +472,20 @@ async fn dispatch(
             })),
             Err(err) => Err(compose_error(&err)),
         },
+        Operation::Logs => match daemon
+            .logs(
+                file.as_deref(),
+                request.container.as_deref().or(request.worker.as_deref()),
+                request.cursors.unwrap_or_default(),
+                request.tail.unwrap_or(crate::logs::DEFAULT_TAIL_LINES),
+                request.stream,
+                request.wait_ms.unwrap_or_default(),
+            )
+            .await
+        {
+            Ok(logs) => Ok(to_value(&logs)),
+            Err(err) => Err(compose_error(&err)),
+        },
         // Answers first, exits after: the serve loop picks the request up and
         // runs the same teardown a signal would.
         Operation::Stop => Ok(daemon.request_stop().await),
@@ -513,6 +561,10 @@ fn op_description(function_id: &str) -> &'static str {
             "Report the project namespace, state directory, daemon pid, and \
              current state of every declared container."
         }
+        "compose::logs" => {
+            "Read bounded worker stdout and stderr. A cursor continues from the last response; \
+             callers may long-poll for new output."
+        }
         "compose::stop" => {
             "Ask this compose daemon to stop every project and exit after it \
              answers the caller."
@@ -557,6 +609,7 @@ fn op_metadata(function_id: &str) -> (u64, bool) {
         "compose::down" => (60_000, true),
         "compose::list" => (10_000, true),
         "compose::status" => (10_000, true),
+        "compose::logs" => (10_000, true),
         "compose::stop" => (30_000, false),
         "compose::validate" => (10_000, true),
         "compose::add" => (600_000, false),
@@ -594,6 +647,11 @@ fn schema_table() -> &'static [SchemaTriple] {
                 "compose::status",
                 schema_for_value::<ProjectOptions>(),
                 schema_for_value::<StatusOutcome>(),
+            ),
+            (
+                "compose::logs",
+                schema_for_value::<LogsOptions>(),
+                schema_for_value::<LogsOutcome>(),
             ),
             (
                 "compose::stop",
@@ -806,6 +864,22 @@ mod tests {
         let (_, list, _) = schema_entry("compose::list");
         let list = list.as_ref().unwrap()["properties"].as_object().unwrap();
         assert_eq!(list.keys().collect::<Vec<_>>(), vec!["namespace"]);
+
+        let (_, logs, _) = schema_entry("compose::logs");
+        let logs = logs.as_ref().unwrap()["properties"].as_object().unwrap();
+        for field in [
+            "namespace",
+            "file",
+            "container",
+            "worker",
+            "cursors",
+            "tail",
+            "stream",
+            "wait_ms",
+        ] {
+            assert!(logs.contains_key(field), "compose::logs is missing {field}");
+        }
+        assert!(!logs.contains_key("workers"));
     }
 
     #[test]

--- a/crates/iii-compose/src/report.rs
+++ b/crates/iii-compose/src/report.rs
@@ -11,9 +11,9 @@
 //! nothing else is being printed.
 //!
 //! Everything the daemon writes goes through [`line`] or [`finish`], and both
-//! take the console lock. That is not tidiness — the children are writing to the
-//! same terminal at the same time, and a spinner that does not clear its own
-//! line before someone else writes leaves the two shredded together.
+//! take the console lock. Worker output is retained by the log store instead
+//! of writing into this terminal, but concurrent lifecycle operations can
+//! still update the same progress block.
 //!
 //! The spinner only exists when stderr is a terminal. Redirected to a file or a
 //! pipe it is replaced by a plain line, because a log full of `⠹⠸⠼` frames is
@@ -36,7 +36,6 @@ use std::{
 };
 
 use colored::{Color, Colorize};
-use tokio::io::{AsyncBufReadExt, BufReader};
 
 /// Marks left of a container name.
 const OK: &str = "✓";
@@ -442,94 +441,6 @@ fn pick_color(taken: &[Color], last: Option<Color>) -> Color {
         })
         .copied()
         .unwrap_or(CONTAINER_COLORS[0])
-}
-
-/// Re-emits a child's output with a `[container]` tag in that container's
-/// colour.
-///
-/// The line itself is never restyled: it belongs to the worker, and a worker
-/// that colours its own logs must keep them. Only the tag is ours.
-///
-/// stderr is tagged the same way but the tag is bold, so a project's error
-/// output is findable in a wall of five workers logging at once. Both streams
-/// go out through [`line`], which is what keeps them from colliding with a
-/// spinner that is turning at the same time.
-/// Keeps a child's startup output in a file beside its project's state, until
-/// the child can speak for itself.
-///
-/// Compose neither prints nor serves a worker's log: that belongs to the
-/// engine, which is where it is read from. The one case the engine cannot
-/// cover is a worker that dies before it ever connects, whose only account of
-/// itself is on its own stderr. That window is what this covers, and
-/// [`Capture::stop`] closes it the moment readiness makes the engine the
-/// better source.
-///
-/// Draining never stops, only writing does. A pipe nobody reads fills at
-/// 64 KiB and the child then blocks forever on its next `println!`, so a
-/// capture that ended by dropping the reader would hang exactly the workers
-/// that log the most.
-pub fn capture_output(
-    key: &str,
-    stdout: Option<tokio::process::ChildStdout>,
-    stderr: Option<tokio::process::ChildStderr>,
-    log_dir: &std::path::Path,
-) -> Capture {
-    let path = log_dir.join(format!("{key}.log"));
-    let stopped = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-    if std::fs::create_dir_all(log_dir).is_err() {
-        return Capture(stopped);
-    }
-
-    for stream in [
-        stdout.map(|out| Box::new(out) as Box<dyn tokio::io::AsyncRead + Unpin + Send>),
-        stderr.map(|err| Box::new(err) as Box<dyn tokio::io::AsyncRead + Unpin + Send>),
-    ]
-    .into_iter()
-    .flatten()
-    {
-        let path = path.clone();
-        let stopped = std::sync::Arc::clone(&stopped);
-        tokio::spawn(async move {
-            // Appended, never truncated: a container that restarts extends its
-            // account rather than erasing the run that explains why.
-            let Ok(file) = std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&path)
-            else {
-                return;
-            };
-            let mut lines = BufReader::new(stream).lines();
-            let mut sink = Some(file);
-            while let Ok(Some(text)) = lines.next_line().await {
-                if stopped.load(std::sync::atomic::Ordering::Relaxed) {
-                    // Releases the descriptor and keeps reading: the worker is
-                    // registered, so from here its own logging is the record.
-                    sink = None;
-                    continue;
-                }
-                if let Some(file) = sink.as_mut() {
-                    use std::io::Write;
-                    let _ = writeln!(file, "{text}");
-                }
-            }
-        });
-    }
-    Capture(stopped)
-}
-
-/// Ends a capture without ending the drain.
-///
-/// Dropping it does nothing: the tasks own their own copy of the flag, and a
-/// container whose start failed keeps its output to the end so the error can
-/// carry the last of it.
-pub struct Capture(std::sync::Arc<std::sync::atomic::AtomicBool>);
-
-impl Capture {
-    /// Stop writing the child's output down.
-    pub fn stop(&self) {
-        self.0.store(true, std::sync::atomic::Ordering::Relaxed);
-    }
 }
 
 #[cfg(test)]

--- a/crates/iii-compose/tests/cli.rs
+++ b/crates/iii-compose/tests/cli.rs
@@ -27,7 +27,9 @@ fn bare_compose_serves_in_the_foreground() {
     // The address is asserted in the III_URL test and nowhere else: it reads
     // process-wide state, and two tests reading it while one writes it is a
     // flake waiting for a loaded machine.
-    let ComposeCommand::Serve { .. } = parse(&["iii", "compose"]).plan().unwrap();
+    let ComposeCommand::Serve { .. } = parse(&["iii", "compose"]).plan().unwrap() else {
+        panic!("expected serve command");
+    };
 }
 
 #[test]
@@ -48,7 +50,10 @@ fn the_namespace_is_how_one_daemon_is_told_from_another() {
         ..
     } = parse(&["iii", "compose", "--namespace", "pc-da-xuxa"])
         .plan()
-        .unwrap();
+        .unwrap()
+    else {
+        panic!("expected serve command");
+    };
     assert_eq!(explicit_daemon_namespace.as_deref(), Some("pc-da-xuxa"));
 }
 
@@ -102,7 +107,6 @@ fn the_project_flags_are_gone_rather_than_ignored() {
         &["iii", "compose", "--file", "c.yaml"][..],
         &["iii", "compose", "--id", "a"][..],
         &["iii", "compose", "down"][..],
-        &["iii", "compose", "logs"][..],
         &["iii", "compose", "stop"][..],
         // Backgrounding is the supervisor's job, not compose's: it never
         // daemonises itself, so there is nothing to attach back to.
@@ -126,11 +130,53 @@ fn a_programmatic_file_without_up_is_refused() {
         ns: None,
         up: false,
         file: Some("other.yaml".into()),
+        command: None,
     }
     .plan()
     .expect_err("a public ComposeCli must enforce the same rule as clap");
 
     assert_eq!(err.code(), "FILE_REQUIRES_UP");
+}
+
+#[test]
+fn logs_resolves_to_a_remote_read_without_starting_a_daemon() {
+    let ComposeCommand::Logs {
+        container,
+        tail,
+        follow,
+        stream,
+        ..
+    } = parse(&[
+        "iii",
+        "compose",
+        "logs",
+        "queue",
+        "--namespace",
+        "dev",
+        "--tail",
+        "50",
+        "--follow",
+        "--stream",
+        "stderr",
+    ])
+    .plan()
+    .unwrap()
+    else {
+        panic!("expected logs command");
+    };
+
+    assert_eq!(container.as_deref(), Some("queue"));
+    assert_eq!(tail, 50);
+    assert!(follow);
+    assert_eq!(stream, Some(iii_compose::logs::LogStream::Stderr));
+}
+
+#[test]
+fn logs_rejects_an_unbounded_initial_tail() {
+    let error = Wrapper::try_parse_from(["iii", "compose", "logs", "--tail", "1001"])
+        .expect_err("the CLI should bound one log response");
+
+    assert!(error.to_string().contains("tail must not exceed 1000"));
 }
 
 #[test]
@@ -167,7 +213,10 @@ fn bare_compose_starts_holding_nothing() {
     let ComposeCommand::Serve { file, start, .. } =
         parse(&["iii", "compose", "--engine", "ws://shared:49134"])
             .plan()
-            .unwrap();
+            .unwrap()
+    else {
+        panic!("expected serve command");
+    };
     assert_eq!(file, std::path::Path::new("worker-compose.yaml"));
     assert!(!start, "a bare daemon must not start the default file");
 }
@@ -176,7 +225,10 @@ fn bare_compose_starts_holding_nothing() {
 fn up_names_the_file_in_the_current_directory() {
     // The point of the flag: in a project directory, one option starts it.
     let ComposeCommand::Serve { file, start, .. } =
-        parse(&["iii", "compose", "--up"]).plan().unwrap();
+        parse(&["iii", "compose", "--up"]).plan().unwrap()
+    else {
+        panic!("expected serve command");
+    };
     assert_eq!(file, std::path::Path::new("worker-compose.yaml"));
     assert!(start);
 }
@@ -201,7 +253,10 @@ fn production_docker_compose_command_matches_the_cli() {
         file,
         start,
         ..
-    } = cli.plan().unwrap();
+    } = cli.plan().unwrap()
+    else {
+        panic!("expected serve command");
+    };
 
     assert_eq!(explicit_daemon_namespace.as_deref(), Some("production"));
     assert_eq!(file, std::path::Path::new("/app/worker-compose.yaml"));
@@ -214,7 +269,10 @@ fn up_without_a_cli_namespace_defers_to_the_compose_file() {
         explicit_daemon_namespace,
         start,
         ..
-    } = parse(&["iii", "compose", "--up"]).plan().unwrap();
+    } = parse(&["iii", "compose", "--up"]).plan().unwrap()
+    else {
+        panic!("expected serve command");
+    };
 
     assert_eq!(explicit_daemon_namespace, None);
     assert!(start);
@@ -316,7 +374,10 @@ fn up_takes_a_file_of_its_own() {
     let ComposeCommand::Serve { file, start, .. } =
         parse(&["iii", "compose", "--up", "-f", "./other.yaml"])
             .plan()
-            .unwrap();
+            .unwrap()
+    else {
+        panic!("expected serve command");
+    };
     assert_eq!(file, std::path::Path::new("./other.yaml"));
     assert!(start);
 }
@@ -335,7 +396,10 @@ fn the_namespace_reads_the_same_on_either_side_of_the_up_flag() {
             explicit_daemon_namespace,
             start,
             ..
-        } = cli.plan().unwrap();
+        } = cli.plan().unwrap()
+        else {
+            panic!("expected serve command");
+        };
         assert_eq!(explicit_daemon_namespace.as_deref(), Some("orders"));
         assert!(start, "{args:?} should still enable --up");
     }

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -73,6 +73,10 @@ iii compose logs [OPTIONS] [WORKER]
 | `-F, --follow` | Continue waiting for new output until interrupted |
 | `--stream <STREAM>` | Restrict output to one process stream [possible values: stdout, stderr] |
 
+<Note>
+  Without `--follow`, this command prints a recent snapshot and exits. With `--follow`, it long-polls and continues from per-worker cursors. Each worker has a 10 MiB active file and three archives; older output is deleted after rotation, and a cursor older than the retained history resumes from the most recent retained lines with a warning. See [The `compose::*` functions](../using-iii/compose#the-compose-functions) for the remote `compose::logs` fields: `cursors`, `tail`, `stream`, and `wait_ms`.
+</Note>
+
 ### `iii project`
 
 Manage iii projects (init, generate-docker)

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -42,6 +42,7 @@ Without `--up`, worker-compose.yaml supplies daemon defaults but no project star
 
 ```text
 iii compose [OPTIONS]
+iii compose <COMMAND>
 ```
 
 | Option | Description |
@@ -50,6 +51,27 @@ iii compose [OPTIONS]
 | `-n, --namespace <NS>` | Namespace this daemon answers `compose::*` in and applies to every project it loads. Several daemons attach to one engine; this is what tells them apart |
 | `--up` | Serve with one project brought up first, starting its declared engine unless `--engine` selects an existing one |
 | `-f, --file <PATH>` | The compose file. Only valid with `--up`. Defaults to `./worker-compose.yaml`, the same fallback `compose::up` uses when a call names no file |
+
+#### `iii compose logs`
+
+Read retained worker stdout and stderr from a running Compose daemon
+
+```text
+iii compose logs [OPTIONS] [WORKER]
+```
+
+| Argument | Description |
+| -------- | ----------- |
+| `[WORKER]` | Worker to read. Omit to read every worker in the project |
+
+| Option | Description |
+| ------ | ----------- |
+| `--engine <URL>` | Existing engine WebSocket address. The compose file and III_URL are used when omitted |
+| `-n, --namespace <NS>` | Namespace of the Compose daemon that owns the project |
+| `-f, --file <PATH>` | Compose file path on the daemon host. The daemon's default file is used when omitted |
+| `--tail <TAIL>` | Number of recent lines to show before following new output [default: 100] |
+| `-F, --follow` | Continue waiting for new output until interrupted |
+| `--stream <STREAM>` | Restrict output to one process stream [possible values: stdout, stderr] |
 
 ### `iii project`
 

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -40,6 +40,7 @@ Without `--up`, worker-compose.yaml supplies daemon defaults but no project star
 
 ```text
 iii compose [OPTIONS]
+iii compose <COMMAND>
 ```
 
 | Option | Description |
@@ -48,6 +49,27 @@ iii compose [OPTIONS]
 | `-n, --namespace <NS>` | Namespace this daemon answers `compose::*` in and applies to every project it loads. Several daemons attach to one engine; this is what tells them apart |
 | `--up` | Serve with one project brought up first, starting its declared engine unless `--engine` selects an existing one |
 | `-f, --file <PATH>` | The compose file. Only valid with `--up`. Defaults to `./worker-compose.yaml`, the same fallback `compose::up` uses when a call names no file |
+
+#### `iii compose logs`
+
+Read retained worker stdout and stderr from a running Compose daemon
+
+```text
+iii compose logs [OPTIONS] [WORKER]
+```
+
+| Argument | Description |
+| -------- | ----------- |
+| `[WORKER]` | Worker to read. Omit to read every worker in the project |
+
+| Option | Description |
+| ------ | ----------- |
+| `--engine <URL>` | Existing engine WebSocket address. The compose file and III_URL are used when omitted |
+| `-n, --namespace <NS>` | Namespace of the Compose daemon that owns the project |
+| `-f, --file <PATH>` | Compose file path on the daemon host. The daemon's default file is used when omitted |
+| `--tail <TAIL>` | Number of recent lines to show before following new output [default: 100] |
+| `-F, --follow` | Continue waiting for new output until interrupted |
+| `--stream <STREAM>` | Restrict output to one process stream [possible values: stdout, stderr] |
 
 ### `iii project`
 

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -71,6 +71,10 @@ iii compose logs [OPTIONS] [WORKER]
 | `-F, --follow` | Continue waiting for new output until interrupted |
 | `--stream <STREAM>` | Restrict output to one process stream [possible values: stdout, stderr] |
 
+<Note>
+  Without `--follow`, this command prints a recent snapshot and exits. With `--follow`, it long-polls and continues from per-worker cursors. Each worker has a 10 MiB active file and three archives; older output is deleted after rotation, and a cursor older than the retained history resumes from the most recent retained lines with a warning. See [The `compose::*` functions](../using-iii/compose#the-compose-functions) for the remote `compose::logs` fields: `cursors`, `tail`, `stream`, and `wait_ms`.
+</Note>
+
 ### `iii project`
 
 Manage iii projects (init, generate-docker)

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -15,9 +15,10 @@ The daemon is itself a worker. It registers under the name `compose` in a namesp
 exposes the `compose::*` functions there, so every project operation is a normal
 [trigger](./triggers), addressed to one daemon with `--namespace`.
 
-`iii compose` is intentionally a verbless top-level daemon command, analogous to `iii console`.
-It reads `worker-compose.yaml` when the file exists so the namespace and engine URL can configure
-the daemon. The `--up` flag also loads the file as a project and starts its containers.
+Bare `iii compose` is the daemon command. It reads `worker-compose.yaml` when the file exists so
+the namespace and engine URL can configure the daemon. The `--up` flag also loads the file as a
+project and starts its containers. `iii compose logs` is a read-only client for a daemon that is
+already running.
 
 ## The daemon
 
@@ -101,6 +102,26 @@ namespace uses at most about 40 MiB for engine logs. The printed follow command 
 active `engine.log` across rotations. Compose strips terminal control sequences before persisting
 the engine output.
 
+### Reading worker output
+
+Compose keeps each worker's complete stdout and stderr, including output written after the worker
+becomes ready. The active file rotates at 10 MiB and keeps three archives, so one worker uses at
+most about 40 MiB. Terminal control sequences are removed before output is stored or returned.
+
+Use the logs client for a recent snapshot or a live view:
+
+```bash
+iii compose logs                         # last 100 lines from every worker
+iii compose logs queue --tail 200        # one worker
+iii compose logs queue --follow          # keep waiting for new output
+iii compose logs queue --stream stderr   # only stderr
+iii compose logs queue --namespace dev --engine ws://127.0.0.1:49134
+```
+
+Options for the logs client come after `logs`. `--file` names a compose file on the daemon host;
+when it is omitted, the daemon uses `worker-compose.yaml` in its own working directory. Each line
+is prefixed with the worker name, and stderr uses a bold prefix on a terminal.
+
 A project that does not start ends the command with `PROJECT_DID_NOT_START`. Rollback has already
 stopped whatever came up, so there is nothing left to supervise.
 
@@ -158,6 +179,10 @@ All functions accept the same payload.
 | `worker`    | string | A repeatable CLI argument for `add`; one worker for `remove`, `restart`, and `update`. |
 | `workers`   | string[] | The canonical JSON list used by `add`.                                          |
 | `function_id` | string | The function or file contract requested by `compose::schema`.                  |
+| `cursors`   | object | Last cursor returned for each worker by `compose::logs`.                          |
+| `tail`      | number | Recent lines returned by the first `compose::logs` call. Maximum 1000.             |
+| `stream`    | string | Optional `stdout` or `stderr` filter for `compose::logs`.                          |
+| `wait_ms`   | number | Long-poll budget for `compose::logs`. Maximum 5000 milliseconds.                   |
 
 A project is its compose file, and nothing else names one. The same file reached twice is the same
 project however it was spelled, so there is no second identity to keep in sync and no way to point
@@ -175,6 +200,7 @@ one at the wrong file.
 | `compose::up`       | `file`    | An operation result.                                                           |
 | `compose::down`     | `file`    | An operation result.                                                           |
 | `compose::status`   | `file`    | The project's namespace, file, state directory, daemon pid, container states.  |
+| `compose::logs`     | `file`, `worker` | Bounded stdout/stderr entries and one cursor per worker.                  |
 | `compose::list`     | nothing   | The daemon name, its namespace, its pid, and every project it holds.           |
 | `compose::validate` | `file`    | A validation report.                                                           |
 | `compose::add`      | `file`, `workers` | What the edit did, changed workers restarted, and new workers started.  |
@@ -241,6 +267,7 @@ answer.
 iii trigger compose::up     --namespace dev file=./worker-compose.yaml
 iii trigger compose::up     --namespace dev file=./worker-compose.yaml container=api
 iii trigger compose::status --namespace dev file=./worker-compose.yaml
+iii trigger compose::logs   --namespace dev file=./worker-compose.yaml worker=api tail=100
 iii trigger compose::down   --namespace dev file=./worker-compose.yaml
 iii trigger compose::list   --namespace dev
 iii trigger compose::add    --namespace dev file=./worker-compose.yaml worker=database worker=web
@@ -342,9 +369,9 @@ operation are left alone.
 | `failed`   | Exited without being asked to, or one of its hooks failed. |
 | `stopped`  | Stopped by this daemon.                                    |
 
-`compose::status` reports each declared container with its `state`, its `pid`, an `owned` flag, and
-`last_error` when there is one. `owned` is `false` for a container this daemon can see but did not
-start.
+`compose::status` reports each declared container with its `state`, its `pid`, an `owned` flag, its
+rotating `log_path`, and `last_error` when there is one. `owned` is `false` for a container this
+daemon can see but did not start.
 
 ### Validation reports
 
@@ -614,14 +641,14 @@ Everything sits under `~/.iii/compose`, or under `$III_COMPOSE_STATE_DIR` when t
 | --------------------------- | ---------------------------------------------------- |
 | `<ns>/<project>/state.json` | One project's child records. Owner-only.             |
 | `<ns>/<project>/config/`    | Resolved configuration files.                        |
-| `<ns>/<project>/logs/`      | What each container printed while starting.          |
+| `<ns>/<project>/logs/`      | Rotating stdout and stderr for every project worker.  |
 | `<ns>/<project>/vm/`        | VM state for bundle containers, one directory each, plus the config each one publishes into its guest. |
 | `packages/`                 | Installed `package://` artefacts, shared by projects. |
 
 `<ns>` is the daemon's namespace. `<project>` is derived from the compose file's canonical path:
 readable enough to recognise, hashed enough that two projects in directories of the same name stay
-apart. Because it is derived, it cannot be guessed. `compose::status` reports it as `state_dir`,
-which is how a container's startup output is located:
+apart. Because it is derived, it cannot be guessed. `compose::status` reports it as `state_dir`
+and reports the exact `log_path` for each worker:
 
 ```bash
 iii trigger compose::status --namespace dev file=./worker-compose.yaml
@@ -634,11 +661,10 @@ ls /home/you/.iii/compose/dev/shop-3f2a1b9c/logs/
   [Understanding iii / Compose](../understanding-iii/compose).
 </Note>
 
-Capture stops when a container becomes ready. Up to that point a worker has no connection and its
-own output is the only account of itself, which is what the file keeps; once the engine can hear it,
-the worker's logging is the record and compose keeps no second copy. So a container that fails at
-boot leaves its reason on disk, and one that runs for a month does not leave a file that grew all
-month.
+Capture continues until the worker exits. Rotation bounds disk use while keeping raw `print`,
+`console.log`, `println!`, stdout, and stderr output available even when the worker does not use the
+structured logger. Use `engine::logs::list` when structured OpenTelemetry fields and trace
+correlation are required.
 
 A clean shutdown clears the state file. After an unclean exit, the daemon compares each record
 against the live process: a match is adopted, a dead process is recorded `failed`, and a live pid it

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -104,9 +104,10 @@ the engine output.
 
 ### Reading worker output
 
-Compose keeps each worker's complete stdout and stderr, including output written after the worker
-becomes ready. The active file rotates at 10 MiB and keeps three archives, so one worker uses at
-most about 40 MiB. Terminal control sequences are removed before output is stored or returned.
+Compose captures each worker's stdout and stderr until the worker exits, including output written
+after it becomes ready. Retained history is bounded: the active file rotates at 10 MiB and keeps
+three archives, so one worker uses at most about 40 MiB. Older output can be truncated or deleted
+after rotation. Terminal control sequences are removed before output is stored or returned.
 
 Use the logs client for a recent snapshot or a live view:
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -98,9 +98,10 @@ the engine output.
 
 ### Reading worker output
 
-Compose keeps each worker's complete stdout and stderr, including output written after the worker
-becomes ready. The active file rotates at 10 MiB and keeps three archives, so one worker uses at
-most about 40 MiB. Terminal control sequences are removed before output is stored or returned.
+Compose captures each worker's stdout and stderr until the worker exits, including output written
+after it becomes ready. Retained history is bounded: the active file rotates at 10 MiB and keeps
+three archives, so one worker uses at most about 40 MiB. Older output can be truncated or deleted
+after rotation. Terminal control sequences are removed before output is stored or returned.
 
 Use the logs client for a recent snapshot or a live view:
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -9,9 +9,10 @@ The daemon is itself a worker. It registers under the name `compose` in a namesp
 exposes the `compose::*` functions there, so every project operation is a normal
 [trigger](./triggers), addressed to one daemon with `--namespace`.
 
-`iii compose` is intentionally a verbless top-level daemon command, analogous to `iii console`.
-It reads `worker-compose.yaml` when the file exists so the namespace and engine URL can configure
-the daemon. The `--up` flag also loads the file as a project and starts its containers.
+Bare `iii compose` is the daemon command. It reads `worker-compose.yaml` when the file exists so
+the namespace and engine URL can configure the daemon. The `--up` flag also loads the file as a
+project and starts its containers. `iii compose logs` is a read-only client for a daemon that is
+already running.
 
 ## The daemon
 
@@ -95,6 +96,26 @@ namespace uses at most about 40 MiB for engine logs. The printed follow command 
 active `engine.log` across rotations. Compose strips terminal control sequences before persisting
 the engine output.
 
+### Reading worker output
+
+Compose keeps each worker's complete stdout and stderr, including output written after the worker
+becomes ready. The active file rotates at 10 MiB and keeps three archives, so one worker uses at
+most about 40 MiB. Terminal control sequences are removed before output is stored or returned.
+
+Use the logs client for a recent snapshot or a live view:
+
+```bash
+iii compose logs                         # last 100 lines from every worker
+iii compose logs queue --tail 200        # one worker
+iii compose logs queue --follow          # keep waiting for new output
+iii compose logs queue --stream stderr   # only stderr
+iii compose logs queue --namespace dev --engine ws://127.0.0.1:49134
+```
+
+Options for the logs client come after `logs`. `--file` names a compose file on the daemon host;
+when it is omitted, the daemon uses `worker-compose.yaml` in its own working directory. Each line
+is prefixed with the worker name, and stderr uses a bold prefix on a terminal.
+
 A project that does not start ends the command with `PROJECT_DID_NOT_START`. Rollback has already
 stopped whatever came up, so there is nothing left to supervise.
 
@@ -152,6 +173,10 @@ All functions accept the same payload.
 | `worker`    | string | A repeatable CLI argument for `add`; one worker for `remove`, `restart`, and `update`. |
 | `workers`   | string[] | The canonical JSON list used by `add`.                                          |
 | `function_id` | string | The function or file contract requested by `compose::schema`.                  |
+| `cursors`   | object | Last cursor returned for each worker by `compose::logs`.                          |
+| `tail`      | number | Recent lines returned by the first `compose::logs` call. Maximum 1000.             |
+| `stream`    | string | Optional `stdout` or `stderr` filter for `compose::logs`.                          |
+| `wait_ms`   | number | Long-poll budget for `compose::logs`. Maximum 5000 milliseconds.                   |
 
 A project is its compose file, and nothing else names one. The same file reached twice is the same
 project however it was spelled, so there is no second identity to keep in sync and no way to point
@@ -169,6 +194,7 @@ one at the wrong file.
 | `compose::up`       | `file`    | An operation result.                                                           |
 | `compose::down`     | `file`    | An operation result.                                                           |
 | `compose::status`   | `file`    | The project's namespace, file, state directory, daemon pid, container states.  |
+| `compose::logs`     | `file`, `worker` | Bounded stdout/stderr entries and one cursor per worker.                  |
 | `compose::list`     | nothing   | The daemon name, its namespace, its pid, and every project it holds.           |
 | `compose::validate` | `file`    | A validation report.                                                           |
 | `compose::add`      | `file`, `workers` | What the edit did, changed workers restarted, and new workers started.  |
@@ -235,6 +261,7 @@ answer.
 iii trigger compose::up     --namespace dev file=./worker-compose.yaml
 iii trigger compose::up     --namespace dev file=./worker-compose.yaml container=api
 iii trigger compose::status --namespace dev file=./worker-compose.yaml
+iii trigger compose::logs   --namespace dev file=./worker-compose.yaml worker=api tail=100
 iii trigger compose::down   --namespace dev file=./worker-compose.yaml
 iii trigger compose::list   --namespace dev
 iii trigger compose::add    --namespace dev file=./worker-compose.yaml worker=database worker=web
@@ -336,9 +363,9 @@ operation are left alone.
 | `failed`   | Exited without being asked to, or one of its hooks failed. |
 | `stopped`  | Stopped by this daemon.                                    |
 
-`compose::status` reports each declared container with its `state`, its `pid`, an `owned` flag, and
-`last_error` when there is one. `owned` is `false` for a container this daemon can see but did not
-start.
+`compose::status` reports each declared container with its `state`, its `pid`, an `owned` flag, its
+rotating `log_path`, and `last_error` when there is one. `owned` is `false` for a container this
+daemon can see but did not start.
 
 ### Validation reports
 
@@ -608,14 +635,14 @@ Everything sits under `~/.iii/compose`, or under `$III_COMPOSE_STATE_DIR` when t
 | --------------------------- | ---------------------------------------------------- |
 | `<ns>/<project>/state.json` | One project's child records. Owner-only.             |
 | `<ns>/<project>/config/`    | Resolved configuration files.                        |
-| `<ns>/<project>/logs/`      | What each container printed while starting.          |
+| `<ns>/<project>/logs/`      | Rotating stdout and stderr for every project worker.  |
 | `<ns>/<project>/vm/`        | VM state for bundle containers, one directory each, plus the config each one publishes into its guest. |
 | `packages/`                 | Installed `package://` artefacts, shared by projects. |
 
 `<ns>` is the daemon's namespace. `<project>` is derived from the compose file's canonical path:
 readable enough to recognise, hashed enough that two projects in directories of the same name stay
-apart. Because it is derived, it cannot be guessed. `compose::status` reports it as `state_dir`,
-which is how a container's startup output is located:
+apart. Because it is derived, it cannot be guessed. `compose::status` reports it as `state_dir`
+and reports the exact `log_path` for each worker:
 
 ```bash
 iii trigger compose::status --namespace dev file=./worker-compose.yaml
@@ -628,11 +655,10 @@ ls /home/you/.iii/compose/dev/shop-3f2a1b9c/logs/
   [Understanding iii / Compose](../understanding-iii/compose).
 </Note>
 
-Capture stops when a container becomes ready. Up to that point a worker has no connection and its
-own output is the only account of itself, which is what the file keeps; once the engine can hear it,
-the worker's logging is the record and compose keeps no second copy. So a container that fails at
-boot leaves its reason on disk, and one that runs for a month does not leave a file that grew all
-month.
+Capture continues until the worker exits. Rotation bounds disk use while keeping raw `print`,
+`console.log`, `println!`, stdout, and stderr output available even when the worker does not use the
+structured logger. Use `engine::logs::list` when structured OpenTelemetry fields and trace
+correlation are required.
 
 A clean shutdown clears the state file. After an unclean exit, the daemon compares each record
 against the live process: a match is adopted, a dead process is recorded `failed`, and a live pid it

--- a/docs/next/using-iii/workers.mdx
+++ b/docs/next/using-iii/workers.mdx
@@ -71,6 +71,7 @@ before adding it.
 
 ```bash
 iii trigger -n dev compose::status file=worker-compose.yaml
+iii compose logs state --follow --namespace dev
 iii trigger -n dev compose::restart file=worker-compose.yaml worker=state
 iii trigger -n dev compose::update file=worker-compose.yaml worker=state
 iii trigger -n dev compose::down file=worker-compose.yaml
@@ -81,6 +82,7 @@ and restarts the project. `compose::down` stops containers in reverse dependency
 
 Use `engine::workers::list` and `engine::workers::info` for the engine's live connection view. Use
 `compose::status` for process ownership, PID, and the last supervisor error.
+Use `iii compose logs <worker> --follow --namespace <daemon>` for live raw stdout and stderr.
 
 ## Configuration
 

--- a/docs/next/using-iii/workers.mdx.skill.md
+++ b/docs/next/using-iii/workers.mdx.skill.md
@@ -67,6 +67,7 @@ before adding it.
 
 ```bash
 iii trigger -n dev compose::status file=worker-compose.yaml
+iii compose logs state --follow --namespace dev
 iii trigger -n dev compose::restart file=worker-compose.yaml worker=state
 iii trigger -n dev compose::update file=worker-compose.yaml worker=state
 iii trigger -n dev compose::down file=worker-compose.yaml
@@ -77,6 +78,7 @@ and restarts the project. `compose::down` stops containers in reverse dependency
 
 Use `engine::workers::list` and `engine::workers::info` for the engine's live connection view. Use
 `compose::status` for process ownership, PID, and the last supervisor error.
+Use `iii compose logs <worker> --follow --namespace <daemon>` for live raw stdout and stderr.
 
 ## Configuration
 

--- a/engine/src/cli/gen_docs.rs
+++ b/engine/src/cli/gen_docs.rs
@@ -47,6 +47,16 @@ fn delegated() -> BTreeMap<String, Delegated> {
 fn mdx_only_notes() -> BTreeMap<String, String> {
     let mut map = BTreeMap::new();
     map.insert(
+        "iii compose logs".to_string(),
+        "<Note>\n  Without `--follow`, this command prints a recent snapshot and exits. With \
+         `--follow`, it long-polls and continues from per-worker cursors. Each worker has a 10 MiB \
+         active file and three archives; older output is deleted after rotation, and a cursor older \
+         than the retained history resumes from the most recent retained lines with a warning. See \
+         [The `compose::*` functions](../using-iii/compose#the-compose-functions) for the remote \
+         `compose::logs` fields: `cursors`, `tail`, `stream`, and `wait_ms`.\n</Note>"
+            .to_string(),
+    );
+    map.insert(
         "iii trigger".to_string(),
         "<Note>\n  `iii trigger <function> --help` additionally queries a running engine for \
          the function's description and request schema. That output depends on which workers \

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -215,8 +215,10 @@ fn cli_usage_command_path(cli: &Cli) -> String {
             cli::project::ProjectAction::Init(_) => "project init".to_string(),
             cli::project::ProjectAction::GenerateDocker(_) => "project generate-docker".to_string(),
         },
-        // One command now: what used to be subcommands are `compose::*` calls.
-        Some(Commands::Compose(_)) => "compose".to_string(),
+        Some(Commands::Compose(args)) => match &args.command {
+            Some(iii_compose::ComposeSubcommand::Logs(_)) => "compose logs".to_string(),
+            None => "compose".to_string(),
+        },
         Some(Commands::GenDocs { .. }) => "gen-cli-docs".to_string(),
         Some(Commands::Update {
             list_targets: true, ..
@@ -796,7 +798,6 @@ mod tests {
         for removed in [
             ["iii", "compose", "up"],
             ["iii", "compose", "down"],
-            ["iii", "compose", "logs"],
             ["iii", "compose", "validate"],
         ] {
             assert!(

--- a/engine/src/workers/engine_fn/README.md
+++ b/engine/src/workers/engine_fn/README.md
@@ -71,13 +71,15 @@ that daemon with its namespace:
 ```bash
 iii trigger -n dev compose::add worker=state
 iii trigger -n dev compose::status file=worker-compose.yaml
+iii trigger -n dev compose::logs file=worker-compose.yaml worker=state tail=100
 iii trigger -n dev compose::restart file=worker-compose.yaml worker=state
 iii trigger -n dev compose::update file=worker-compose.yaml worker=state
 iii trigger -n dev compose::down file=worker-compose.yaml
 ```
 
 `iii worker` and `worker::*` no longer exist. Use `engine::workers::list` for live registrations and
-`compose::status` for process ownership and supervisor state.
+`compose::status` for process ownership and supervisor state. Use `compose::logs` for bounded raw
+stdout and stderr, or `iii compose logs state --follow --namespace dev` for a live view.
 
 ## Trigger types
 

--- a/engine/src/workers/engine_fn/skills/SKILL.md
+++ b/engine/src/workers/engine_fn/skills/SKILL.md
@@ -224,13 +224,15 @@ restart, update, and shutdown lifecycle:
 ```bash
 iii trigger -n dev compose::add worker=state
 iii trigger -n dev compose::status file=worker-compose.yaml
+iii trigger -n dev compose::logs file=worker-compose.yaml worker=state tail=100
 iii trigger -n dev compose::restart file=worker-compose.yaml worker=state
 iii trigger -n dev compose::update file=worker-compose.yaml worker=state
 iii trigger -n dev compose::down file=worker-compose.yaml
 ```
 
 `iii worker` and `worker::*` were removed. Use `engine::workers::list` for live registrations and
-`compose::status` for the supervisor's process state.
+`compose::status` for the supervisor's process state. Use `compose::logs` for raw worker stdout and
+stderr.
 
 ## Discovery surface
 
@@ -243,6 +245,7 @@ iii trigger -n dev compose::down file=worker-compose.yaml
 | `engine::triggers::info { id }` | One trigger type's config / return schema + provider. |
 | `engine::registered-triggers::list` | Every trigger INSTANCE bound. Filter `function_id` / `worker`. |
 | `compose::status` | Declared containers, process state, PID, ownership, and last error. |
+| `compose::logs` | Bounded worker stdout/stderr entries and continuation cursors. |
 | `compose::list` | Projects held by one Compose daemon. |
 | `directory::registry::workers::list` | Workers published in the public registry. Filter `search`. |
 | `directory::registry::workers::info { name }` | A registry worker's README, config, API reference, and skills. |

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -774,6 +774,110 @@ async fn a_child_that_never_registers_times_out_and_rolls_back() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn logs_continue_from_a_cursor_after_the_worker_is_ready() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let started = tmp.path().join("workers/queue/started");
+    let emit = tmp.path().join("workers/queue/emit-after-ready");
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: worker-logs
+startup_timeout: 3s
+stop_timeout: 100ms
+containers:
+  queue:
+    worker: path://./workers/queue
+    scripts:
+      run: |
+        touch started
+        printf '%s\n' 'output before ready'
+        while [ ! -f emit-after-ready ]; do sleep 0.02; done
+        printf '%s\n' 'output after ready'
+        printf '%s\n' 'error after ready' >&2
+        sleep 30
+"#,
+        &["queue"],
+    );
+
+    let up = call(
+        port,
+        "compose::up",
+        json!({ "file": file.to_str().unwrap() }),
+    );
+    let ready = async {
+        wait_for_start_markers(&[started.as_path()]).await;
+        let worker = register_test_worker(port, "worker-logs", "queue");
+        wait_for_worker_state(&daemon, "worker-logs", "queue", true).await;
+        worker
+    };
+    let (up, worker) = tokio::join!(up, ready);
+    let up = up.expect("compose::up should answer");
+    assert_eq!(up["status"], "ok", "project did not start: {up}");
+
+    let before = call(
+        port,
+        "compose::logs",
+        json!({
+            "file": file.to_str().unwrap(),
+            "container": "queue",
+            "tail": 10,
+            "wait_ms": 1_000,
+        }),
+    )
+    .await
+    .expect("compose::logs should return startup output");
+    assert_eq!(
+        before["containers"][0]["entries"][0]["message"], "output before ready",
+        "startup output was not retained: {before}"
+    );
+    let cursor = before["containers"][0]["cursor"].clone();
+
+    std::fs::write(&emit, "now").expect("release worker output");
+    let after = call(
+        port,
+        "compose::logs",
+        json!({
+            "file": file.to_str().unwrap(),
+            "container": "queue",
+            "cursors": { "queue": cursor },
+            "tail": 10,
+            "wait_ms": 2_000,
+        }),
+    )
+    .await
+    .expect("compose::logs should continue after its cursor");
+    let entries = after["containers"][0]["entries"]
+        .as_array()
+        .expect("log entries");
+    assert!(
+        entries.iter().any(|entry| {
+            entry["stream"] == "stdout" && entry["message"] == "output after ready"
+        }),
+        "stdout after readiness was not returned: {after}"
+    );
+    assert!(
+        entries.iter().any(|entry| {
+            entry["stream"] == "stderr" && entry["message"] == "error after ready"
+        }),
+        "stderr after readiness was not returned: {after}"
+    );
+
+    worker.shutdown_async().await;
+    call(
+        port,
+        "compose::down",
+        json!({ "file": file.to_str().unwrap() }),
+    )
+    .await
+    .expect("compose::down should stop the fixture");
+    daemon.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn a_second_daemon_on_one_engine_is_refused() {
     isolate_state();
     let port = spawn_engine().await;


### PR DESCRIPTION
## Summary

- retain worker stdout and stderr for the full process lifetime
- add bounded rotating storage with stream metadata and continuation cursors
- expose compose::logs with tail, stream filtering, and long polling
- add iii compose logs with snapshot and follow modes
- document the CLI and remote function contract

## Test plan

- [x] cargo fmt --all -- --check
- [x] cargo build -p iii
- [x] cargo test -p iii-compose
- [x] cargo test -p iii --test compose_daemon_e2e
- [x] cargo test -p iii --bin iii compose
- [x] cargo clippy -p iii-compose --all-targets -- -D warnings
- [x] cargo check -p iii

## Notes

- This PR is stacked on #2074 so its diff contains only worker log support.
- The repository-wide pnpm fmt:check currently stops on pre-existing nested Biome root configuration errors in sdk and console; the changed Rust targets pass formatting and lint checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added `iii compose logs` to view retained worker output.
- Supports worker selection, tail limits, stdout/stderr filtering, and live following.
- Added continuation support for incremental log reading.
- Worker logs remain available throughout the worker lifecycle and are stored in rotating files.
- Log file locations are included in status information.

## Documentation
- Added CLI reference, Compose API guidance, and worker-operation examples for viewing logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->