### PR TITLE
feat(compose): add package build command

### DIFF
--- a/crates/iii-compose/src/build.rs
+++ b/crates/iii-compose/src/build.rs
@@ -1,0 +1,219 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Prepare every registry package in a compose file without starting anything.
+
+use std::{future::Future, path::Path, time::Instant};
+
+use futures::StreamExt;
+
+use crate::{
+    ComposeFile,
+    config::WorkerSource,
+    error::Result,
+    registry::{self, InstallStatus, InstalledPackage},
+    report,
+    state::StateStore,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildReport {
+    pub packages: usize,
+    pub downloaded: usize,
+    pub cached: usize,
+}
+
+#[derive(Debug, Clone)]
+struct PackageRequest {
+    index: usize,
+    container: String,
+    reference: String,
+    version: String,
+}
+
+/// Download every `package://` container declared by `file` into the cache
+/// shared with `compose::up`.
+pub async fn build(file: &Path) -> Result<BuildReport> {
+    let file = ComposeFile::load(file)?;
+    let cache = StateStore::package_cache()?;
+    build_file_with(&file, &cache, |request, cache| async move {
+        registry::install(
+            &request.container,
+            &request.reference,
+            &request.version,
+            &cache,
+        )
+        .await
+    })
+    .await
+}
+
+async fn build_file_with<F, Fut>(
+    file: &ComposeFile,
+    cache: &Path,
+    installer: F,
+) -> Result<BuildReport>
+where
+    F: Fn(PackageRequest, std::path::PathBuf) -> Fut + Sync,
+    Fut: Future<Output = Result<InstalledPackage>>,
+{
+    let began = Instant::now();
+    let requests: Vec<_> = file
+        .containers
+        .iter()
+        .enumerate()
+        .filter_map(|(index, (container, spec))| match &spec.worker {
+            WorkerSource::Package { reference } => Some(PackageRequest {
+                index,
+                container: container.clone(),
+                reference: reference.clone(),
+                version: spec.version.as_deref().unwrap_or("*").to_string(),
+            }),
+            WorkerSource::Path { .. } => None,
+        })
+        .collect();
+
+    report::plan(
+        &requests
+            .iter()
+            .map(|request| (request.container.clone(), 0))
+            .collect::<Vec<_>>(),
+    );
+
+    let installer = &installer;
+    let mut work = futures::stream::iter(requests.into_iter().map(|request| {
+        let cache = cache.to_path_buf();
+        async move {
+            let index = request.index;
+            let container = request.container.clone();
+            let reference = request.reference.clone();
+            let version = request.version.clone();
+            let began = Instant::now();
+            report::starting(&container, &format!("preparing {reference}@{version}"));
+            let result = installer(request, cache).await;
+            (index, container, began.elapsed(), result)
+        }
+    }))
+    .buffer_unordered(crate::parallelism::max_parallel_workers());
+
+    let mut downloaded = 0;
+    let mut cached = 0;
+    let mut failures = Vec::new();
+    while let Some((index, container, elapsed, result)) = work.next().await {
+        match result {
+            Ok(package) => match package.status {
+                InstallStatus::Downloaded => {
+                    downloaded += 1;
+                    report::completed(&container, "downloaded", elapsed);
+                }
+                InstallStatus::Cached => {
+                    cached += 1;
+                    report::unchanged(&container, "already cached");
+                }
+            },
+            Err(error) => {
+                let message = error.to_string();
+                let prefix = format!("container '{container}': ");
+                let message = message.strip_prefix(&prefix).unwrap_or(&message);
+                report::failed(&container, error.code(), message);
+                failures.push((index, error));
+            }
+        }
+    }
+    report::plan_done();
+
+    if !failures.is_empty() {
+        failures.sort_by_key(|(index, _)| *index);
+        let error = failures.remove(0).1;
+        report::summary_failed("build", error.code(), began.elapsed());
+        return Err(error);
+    }
+
+    let packages = downloaded + cached;
+    report::summary_ok("build", downloaded, packages, began.elapsed());
+    Ok(BuildReport {
+        packages,
+        downloaded,
+        cached,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use crate::error::ComposeError;
+    use crate::registry::Payload;
+
+    fn package(status: InstallStatus) -> InstalledPackage {
+        InstalledPackage {
+            name: "worker".to_string(),
+            version: "1.0.0".to_string(),
+            payload: Payload::Binary("/tmp/worker".into()),
+            default_config: None,
+            status,
+        }
+    }
+
+    #[tokio::test]
+    async fn build_installs_only_registry_packages() {
+        let file = ComposeFile::parse(
+            "containers:\n  local:\n    worker: path://./local\n    scripts: { run: ./start }\n  state:\n    worker: package://state\n    version: 1.0.0\n  queue:\n    worker: package://queue\n    version: 2.0.0\n",
+            "/srv/app/worker-compose.yaml",
+        )
+        .unwrap();
+        let installed = Arc::new(Mutex::new(Vec::new()));
+        let seen = Arc::clone(&installed);
+
+        let report = build_file_with(&file, Path::new("/cache"), move |request, _| {
+            let seen = Arc::clone(&seen);
+            async move {
+                seen.lock().unwrap().push(request.container.clone());
+                Ok(if request.container == "state" {
+                    package(InstallStatus::Downloaded)
+                } else {
+                    package(InstallStatus::Cached)
+                })
+            }
+        })
+        .await
+        .unwrap();
+
+        let mut installed = installed.lock().unwrap().clone();
+        installed.sort();
+        assert_eq!(installed, ["queue", "state"]);
+        assert_eq!(
+            report,
+            BuildReport {
+                packages: 2,
+                downloaded: 1,
+                cached: 1,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn build_reports_the_first_declared_failure() {
+        let file = ComposeFile::parse(
+            "containers:\n  first:\n    worker: package://first\n    version: 1.0.0\n  second:\n    worker: package://second\n    version: 1.0.0\n",
+            "/srv/app/worker-compose.yaml",
+        )
+        .unwrap();
+
+        let error = build_file_with(&file, Path::new("/cache"), |request, _| async move {
+            Err(ComposeError::PackageDownloadFailed {
+                container: request.container.clone(),
+                url: format!("https://example.test/{}", request.container),
+                message: "failed".to_string(),
+            })
+        })
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("container 'first'"));
+    }
+}

--- a/crates/iii-compose/src/build.rs
+++ b/crates/iii-compose/src/build.rs
@@ -1,8 +1,5 @@
-// Copyright Motia LLC and/or licensed to Motia LLC under one or more
-// contributor license agreements. Licensed under the Elastic License 2.0;
-// you may not use this file except in compliance with the Elastic License 2.0.
-// This software is patent protected. We welcome discussions - reach out at team@iii.dev
-// See LICENSE and PATENTS files for details.
+// Copyright 2025 Motia LLC. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 //! Prepare every registry package in a compose file without starting anything.
 

--- a/crates/iii-compose/src/cli.rs
+++ b/crates/iii-compose/src/cli.rs
@@ -20,6 +20,9 @@
 //! Argument parsing stays separated from execution
 //! ([`ComposeCli::plan`]) so the resolved invocation is testable without
 //! touching a socket.
+//!
+//! `iii compose build` is the one local action. It reads a compose file and
+//! prepares its registry packages without connecting to or starting an engine.
 
 use std::path::PathBuf;
 
@@ -75,8 +78,22 @@ pub struct ComposeCli {
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum ComposeSubcommand {
+    /// Download every registry package declared by the compose file.
+    Build(BuildCli),
     /// Read retained worker stdout and stderr from a running Compose daemon.
     Logs(ComposeLogsCli),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct BuildCli {
+    /// Compose file whose registry packages should be downloaded.
+    #[arg(
+        short = 'f',
+        long,
+        value_name = "PATH",
+        default_value = DEFAULT_COMPOSE_FILE
+    )]
+    pub file: PathBuf,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -128,6 +145,8 @@ fn parse_tail(value: &str) -> std::result::Result<usize, String> {
 /// What an invocation resolved to, after the flag combination is checked.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ComposeCommand {
+    /// Download registry packages without starting an engine or a worker.
+    Build { file: PathBuf },
     /// Serve `compose::*` in the foreground.
     Serve {
         explicit_engine_url: Option<String>,
@@ -155,16 +174,27 @@ pub enum ComposeCommand {
 impl ComposeCli {
     /// Resolves the invocation, rejecting incomplete flag combinations.
     pub fn plan(&self) -> Result<ComposeCommand> {
-        if let Some(ComposeSubcommand::Logs(logs)) = &self.command {
-            return Ok(ComposeCommand::Logs {
-                explicit_engine_url: logs.engine.clone().filter(|url| !url.trim().is_empty()),
-                explicit_daemon_namespace: validated_namespace(logs.namespace.as_deref())?,
-                file: logs.file.clone(),
-                container: logs.worker.clone(),
-                tail: logs.tail.min(crate::logs::MAX_TAIL_LINES),
-                follow: logs.follow,
-                stream: logs.stream,
-            });
+        if let Some(command) = &self.command {
+            return match command {
+                ComposeSubcommand::Build(args) => {
+                    if self.engine.is_some() || self.ns.is_some() || self.up || self.file.is_some()
+                    {
+                        return Err(ComposeError::BuildConflictsWithServeOptions);
+                    }
+                    Ok(ComposeCommand::Build {
+                        file: args.file.clone(),
+                    })
+                }
+                ComposeSubcommand::Logs(logs) => Ok(ComposeCommand::Logs {
+                    explicit_engine_url: logs.engine.clone().filter(|url| !url.trim().is_empty()),
+                    explicit_daemon_namespace: validated_namespace(logs.namespace.as_deref())?,
+                    file: logs.file.clone(),
+                    container: logs.worker.clone(),
+                    tail: logs.tail.min(crate::logs::MAX_TAIL_LINES),
+                    follow: logs.follow,
+                    stream: logs.stream,
+                }),
+            };
         }
 
         if !self.up && self.file.is_some() {

--- a/crates/iii-compose/src/error.rs
+++ b/crates/iii-compose/src/error.rs
@@ -49,6 +49,9 @@ pub enum ComposeError {
     #[error("--file requires --up")]
     FileRequiresUp,
 
+    #[error("`iii compose build` cannot be combined with daemon options")]
+    BuildConflictsWithServeOptions,
+
     #[error(
         "{path} declares engine:, but this Compose daemon is connected to an external engine. \
          Start the file in a separate `iii compose --up` invocation without --engine"
@@ -497,6 +500,7 @@ impl ComposeError {
             Self::InvalidEngineWorkerConfig { .. } => "INVALID_ENGINE_WORKER_CONFIG",
             Self::InvalidManagedEngineUrl => "INVALID_MANAGED_ENGINE_URL",
             Self::FileRequiresUp => "FILE_REQUIRES_UP",
+            Self::BuildConflictsWithServeOptions => "BUILD_CONFLICTS_WITH_SERVE_OPTIONS",
             Self::EngineSectionRequiresManagedStart { .. } => {
                 "ENGINE_SECTION_REQUIRES_MANAGED_START"
             }

--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -18,6 +18,7 @@
 //! `package://` workers from the registry, keeps watching its children after
 //! they are ready, and adopts whatever survived a restart.
 
+pub mod build;
 pub mod cli;
 pub mod config;
 pub mod configuration;
@@ -33,6 +34,7 @@ pub mod logs;
 mod managed_engine;
 pub mod manifest;
 pub mod namespace;
+mod parallelism;
 pub mod process;
 pub mod project;
 pub mod registry;
@@ -42,7 +44,7 @@ mod shutdown;
 pub mod spawn;
 pub mod state;
 
-pub use cli::{ComposeCli, ComposeCommand, ComposeLogsCli, ComposeSubcommand};
+pub use cli::{BuildCli, ComposeCli, ComposeCommand, ComposeLogsCli, ComposeSubcommand};
 pub use config::{ComposeFile, Container, EngineSpec, WorkerSource};
 pub use error::{ComposeError, Result};
 pub use manifest::{StartSpec, ValidationReport};
@@ -109,6 +111,10 @@ pub async fn run(cli: ComposeCli) -> i32 {
     };
 
     match command {
+        ComposeCommand::Build { file } => match build::build(&file).await {
+            Ok(_) => 0,
+            Err(err) => report_error(&err),
+        },
         ComposeCommand::Serve {
             explicit_engine_url,
             explicit_daemon_namespace,

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -127,27 +127,6 @@ impl From<ComposeError> for StartFailure {
     }
 }
 
-/// Environment variable that overrides how many containers may start at once.
-const MAX_PARALLEL_WORKERS_ENV: &str = "III_COMPOSE_MAX_PARALLEL_WORKERS";
-
-/// Default number of containers that may start at once inside one wave.
-///
-/// Not unbounded: a wave can be the whole file, and each start may download an
-/// artefact, spawn a process, or boot a VM.
-const DEFAULT_MAX_PARALLEL_WORKERS: usize = 8;
-
-fn max_parallel_workers() -> usize {
-    let value = std::env::var(MAX_PARALLEL_WORKERS_ENV).ok();
-    parse_max_parallel_workers(value.as_deref())
-}
-
-fn parse_max_parallel_workers(value: Option<&str>) -> usize {
-    value
-        .and_then(|value| value.trim().parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(DEFAULT_MAX_PARALLEL_WORKERS)
-}
-
 /// Containers currently supervised by this daemon, keyed by container id.
 pub type Children = BTreeMap<String, Supervised>;
 
@@ -200,7 +179,7 @@ async fn up_inner(
     let mut results: Vec<ContainerResult> = Vec::new();
     // Only what *this* operation started may be rolled back.
     let mut started: Vec<String> = Vec::new();
-    let max_parallel_workers = max_parallel_workers();
+    let max_parallel_workers = crate::parallelism::max_parallel_workers();
 
     // Everything this operation will touch, drawn before any of it moves, so an
     // operator sees the shape rather than a line at a time.
@@ -1218,28 +1197,6 @@ containers:
     fn an_unknown_target_is_rejected_before_anything_starts() {
         let err = plan_targets(&file(), Some("ghost")).unwrap_err();
         assert_eq!(err.code(), "UNKNOWN_CONTAINER");
-    }
-
-    #[test]
-    fn parallel_worker_limit_defaults_to_eight() {
-        assert_eq!(parse_max_parallel_workers(None), 8);
-    }
-
-    #[test]
-    fn parallel_worker_limit_accepts_a_positive_environment_value() {
-        assert_eq!(parse_max_parallel_workers(Some("16")), 16);
-        assert_eq!(parse_max_parallel_workers(Some(" 4 ")), 4);
-    }
-
-    #[test]
-    fn parallel_worker_limit_uses_the_default_for_invalid_values() {
-        for value in ["", "0", "many", "-1"] {
-            assert_eq!(
-                parse_max_parallel_workers(Some(value)),
-                DEFAULT_MAX_PARALLEL_WORKERS,
-                "{value:?} must not disable container startup"
-            );
-        }
     }
 
     #[test]

--- a/crates/iii-compose/src/parallelism.rs
+++ b/crates/iii-compose/src/parallelism.rs
@@ -1,0 +1,51 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+/// Environment variable that limits concurrent package work and container starts.
+const MAX_PARALLEL_WORKERS_ENV: &str = "III_COMPOSE_MAX_PARALLEL_WORKERS";
+
+/// Keep large compose files from opening an unbounded number of downloads or
+/// processes at once.
+const DEFAULT_MAX_PARALLEL_WORKERS: usize = 8;
+
+pub(crate) fn max_parallel_workers() -> usize {
+    let value = std::env::var(MAX_PARALLEL_WORKERS_ENV).ok();
+    parse_max_parallel_workers(value.as_deref())
+}
+
+fn parse_max_parallel_workers(value: Option<&str>) -> usize {
+    value
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_MAX_PARALLEL_WORKERS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parallel_worker_limit_defaults_to_eight() {
+        assert_eq!(parse_max_parallel_workers(None), 8);
+    }
+
+    #[test]
+    fn parallel_worker_limit_accepts_a_positive_environment_value() {
+        assert_eq!(parse_max_parallel_workers(Some("16")), 16);
+        assert_eq!(parse_max_parallel_workers(Some(" 4 ")), 4);
+    }
+
+    #[test]
+    fn parallel_worker_limit_uses_the_default_for_invalid_values() {
+        for value in ["", "0", "many", "-1"] {
+            assert_eq!(
+                parse_max_parallel_workers(Some(value)),
+                DEFAULT_MAX_PARALLEL_WORKERS,
+                "{value:?} must not disable concurrent work"
+            );
+        }
+    }
+}

--- a/crates/iii-compose/src/parallelism.rs
+++ b/crates/iii-compose/src/parallelism.rs
@@ -1,8 +1,5 @@
-// Copyright Motia LLC and/or licensed to Motia LLC under one or more
-// contributor license agreements. Licensed under the Elastic License 2.0;
-// you may not use this file except in compliance with the Elastic License 2.0.
-// This software is patent protected. We welcome discussions - reach out at team@iii.dev
-// See LICENSE and PATENTS files for details.
+// Copyright 2025 Motia LLC. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 /// Environment variable that limits concurrent package work and container starts.
 const MAX_PARALLEL_WORKERS_ENV: &str = "III_COMPOSE_MAX_PARALLEL_WORKERS";

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -380,9 +380,7 @@ impl Project {
     /// deriving this by walking up from the state directory would silently
     /// re-scope it the next time that layout gains a level.
     fn package_cache(&self) -> PathBuf {
-        StateStore::root()
-            .unwrap_or_else(|_| self.store.dir().to_path_buf())
-            .join("packages")
+        StateStore::package_cache().unwrap_or_else(|_| self.store.dir().join("packages"))
     }
 
     pub async fn up(&self, target: Option<&str>, operation_id: String) -> OpResult {

--- a/crates/iii-compose/src/registry.rs
+++ b/crates/iii-compose/src/registry.rs
@@ -15,9 +15,9 @@
 //!    process will run it. A download that does not match its digest is not a
 //!    slow download or a corrupt one — it is a different artefact than the
 //!    registry promised, and it never reaches disk.
-//! 3. **Cache.** Installs are keyed by `(name, version, target)`, which is the
-//!    artefact's whole identity, so a second `up` reuses the first one's work
-//!    and two projects on one machine share it.
+//! 3. **Cache.** Installs are keyed by package metadata, target, and SHA-256,
+//!    so only the exact verified artefact is reused across registries and
+//!    projects.
 
 use std::{
     path::{Path, PathBuf},
@@ -307,10 +307,15 @@ async fn install_binary(
                 },
             })?;
 
-    let install_dir = cache_root.join(format!("{}-{}-{}", resolved.name, resolved.version, target));
+    let digest = validated_cache_digest(container, resolved, &artifact.sha256)?;
+    let install_dir = cache_root.join(format!(
+        "{}-{}-{}-{digest}",
+        resolved.name, resolved.version, target
+    ));
     if let Some(existing) = installed_binary(&install_dir) {
         return Ok((existing, InstallStatus::Cached));
     }
+    remove_invalid_install(&install_dir)?;
     download_and_extract(container, artifact, &install_dir).await?;
     let program =
         installed_binary(&install_dir).ok_or_else(|| ComposeError::PackageArtifactEmpty {
@@ -351,13 +356,18 @@ async fn install_bundle(
         }
     };
 
-    let install_dir = cache_root.join(format!("{}-{}-bundle", resolved.name, resolved.version));
+    let digest = validated_cache_digest(container, resolved, sha256)?;
+    let install_dir = cache_root.join(format!(
+        "{}-{}-bundle-{digest}",
+        resolved.name, resolved.version
+    ));
     // The manifest is the bundle's entry point, so its presence is what makes
     // an install dir a cache hit — not the first executable, which a bundle
     // need not have at all.
     if install_dir.join(BUNDLE_MANIFEST).is_file() {
         return Ok((install_dir, InstallStatus::Cached));
     }
+    remove_invalid_install(&install_dir)?;
 
     let artifact = Artifact {
         sha256: sha256.clone(),
@@ -373,6 +383,48 @@ async fn install_bundle(
         });
     }
     Ok((install_dir, InstallStatus::Downloaded))
+}
+
+/// Returns the normalized digest used as the immutable part of a cache key.
+fn validated_cache_digest(
+    container: &str,
+    resolved: &ResolvedWorker,
+    sha256: &str,
+) -> Result<String> {
+    if sha256.len() == 64 && sha256.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Ok(sha256.to_ascii_lowercase());
+    }
+
+    Err(ComposeError::PackageNotResolved {
+        container: container.to_string(),
+        name: resolved.name.clone(),
+        range: resolved.version.clone(),
+        message: "the registry returned an invalid SHA-256 digest".to_string(),
+    })
+}
+
+/// Removes a stale cache entry that cannot be used as an installed package.
+fn remove_invalid_install(path: &Path) -> Result<()> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(source) => {
+            return Err(ComposeError::Io {
+                path: path.to_path_buf(),
+                source,
+            });
+        }
+    };
+
+    let result = if metadata.is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    };
+    result.map_err(|source| ComposeError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
 }
 
 /// The raw `/resolve` answer: the worker and everything it depends on.
@@ -736,16 +788,15 @@ mod tests {
     use super::*;
     use wiremock::{Mock, MockServer, ResponseTemplate, matchers};
 
-    fn executable_archive() -> Vec<u8> {
+    fn executable_archive(body: &[u8]) -> Vec<u8> {
         let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
         let mut archive = tar::Builder::new(encoder);
-        let body = b"#!/bin/sh\nexit 0\n";
         let mut header = tar::Header::new_gnu();
         header.set_size(body.len() as u64);
         header.set_mode(0o755);
         header.set_cksum();
         let name = format!("worker{}", std::env::consts::EXE_SUFFIX);
-        archive.append_data(&mut header, name, &body[..]).unwrap();
+        archive.append_data(&mut header, name, body).unwrap();
         let encoder = archive.into_inner().unwrap();
         encoder.finish().unwrap()
     }
@@ -823,7 +874,7 @@ mod tests {
     #[tokio::test]
     async fn a_second_install_reuses_the_downloaded_artefact() {
         let server = MockServer::start().await;
-        let archive = executable_archive();
+        let archive = executable_archive(b"#!/bin/sh\nexit 0\n");
         let digest = hex::encode(Sha256::digest(&archive));
         let target = host_target();
         let artifact_url = format!("{}/artifact", server.uri());
@@ -865,6 +916,71 @@ mod tests {
         assert_eq!(first.status, InstallStatus::Downloaded);
         assert_eq!(second.status, InstallStatus::Cached);
         assert_eq!(first.default_config, second.default_config);
+    }
+
+    #[tokio::test]
+    async fn same_name_and_version_with_a_different_digest_is_downloaded_again() {
+        let server = MockServer::start().await;
+        let first_archive = executable_archive(b"#!/bin/sh\nexit 0\n");
+        let second_archive = executable_archive(b"#!/bin/sh\nexit 1\n");
+        let first_digest = hex::encode(Sha256::digest(&first_archive));
+        let second_digest = hex::encode(Sha256::digest(&second_archive));
+        let first_url = format!("{}/artifact-first", server.uri());
+        let second_url = format!("{}/artifact-second", server.uri());
+        let target = host_target();
+        let resolutions = Arc::new(AtomicUsize::new(0));
+        let responder_resolutions = Arc::clone(&resolutions);
+
+        Mock::given(matchers::method("POST"))
+            .and(matchers::path("/resolve"))
+            .respond_with(move |_: &wiremock::Request| {
+                let (digest, url) = if responder_resolutions.fetch_add(1, Ordering::SeqCst) == 0 {
+                    (&first_digest, &first_url)
+                } else {
+                    (&second_digest, &second_url)
+                };
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "graph": [{
+                        "name": "state",
+                        "version": "1.0.0",
+                        "type": "binary",
+                        "binaries": {
+                            (target): {
+                                "sha256": digest,
+                                "url": url,
+                            }
+                        }
+                    }]
+                }))
+            })
+            .expect(2)
+            .mount(&server)
+            .await;
+        Mock::given(matchers::method("GET"))
+            .and(matchers::path("/artifact-first"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(first_archive))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(matchers::method("GET"))
+            .and(matchers::path("/artifact-second"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(second_archive))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let cache = tempfile::tempdir().unwrap();
+        let first = install_from_registry("state", &server.uri(), "state", "1.0.0", cache.path())
+            .await
+            .unwrap();
+        let second = install_from_registry("state", &server.uri(), "state", "1.0.0", cache.path())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            [first.status, second.status],
+            [InstallStatus::Downloaded, InstallStatus::Downloaded]
+        );
     }
 
     #[test]

--- a/crates/iii-compose/src/registry.rs
+++ b/crates/iii-compose/src/registry.rs
@@ -101,6 +101,14 @@ pub enum Payload {
     Bundle(PathBuf),
 }
 
+/// Whether this invocation downloaded an artefact or reused one already on
+/// disk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallStatus {
+    Downloaded,
+    Cached,
+}
+
 /// A package resolved and installed locally.
 #[derive(Debug, Clone)]
 pub struct InstalledPackage {
@@ -110,6 +118,7 @@ pub struct InstalledPackage {
     /// Configuration the worker ships with, to be merged under anything the
     /// compose file overrides.
     pub default_config: Option<serde_yaml::Value>,
+    pub status: InstallStatus,
 }
 
 /// The rust target triple this daemon is running on, which is the one its
@@ -160,13 +169,25 @@ pub async fn install(
     cache_root: &Path,
 ) -> Result<InstalledPackage> {
     let (registry, name) = split_reference(reference);
+    install_from_registry(container, &registry, &name, version_range, cache_root).await
+}
+
+async fn install_from_registry(
+    container: &str,
+    registry: &str,
+    name: &str,
+    version_range: &str,
+    cache_root: &Path,
+) -> Result<InstalledPackage> {
     let target = host_target();
 
-    let resolved = resolve(container, &registry, &name, version_range, target).await?;
+    let resolved = resolve(container, registry, name, version_range, target).await?;
 
-    let payload = match resolved.kind.as_str() {
+    let (payload, status) = match resolved.kind.as_str() {
         "binary" => {
-            Payload::Binary(install_binary(container, &resolved, target, cache_root).await?)
+            let (program, status) =
+                install_binary(container, &resolved, target, cache_root).await?;
+            (Payload::Binary(program), status)
         }
         // Refused before the download on a platform that could not start it:
         // the archive is megabytes, and an operator learns nothing from having
@@ -179,7 +200,10 @@ pub async fn install(
             });
         }
         #[cfg(unix)]
-        "bundle" => Payload::Bundle(install_bundle(container, &resolved, cache_root).await?),
+        "bundle" => {
+            let (install_dir, status) = install_bundle(container, &resolved, cache_root).await?;
+            (Payload::Bundle(install_dir), status)
+        }
         // `engine` workers are compiled into the engine itself: there is no
         // artefact to install and nothing for compose to start. `image` workers
         // have one, but running it needs the OCI runtime.
@@ -202,6 +226,7 @@ pub async fn install(
         version: resolved.version,
         payload,
         default_config,
+        status,
     })
 }
 
@@ -265,7 +290,7 @@ async fn install_binary(
     resolved: &ResolvedWorker,
     target: &str,
     cache_root: &Path,
-) -> Result<PathBuf> {
+) -> Result<(PathBuf, InstallStatus)> {
     let artifact =
         resolved
             .binaries
@@ -284,14 +309,16 @@ async fn install_binary(
 
     let install_dir = cache_root.join(format!("{}-{}-{}", resolved.name, resolved.version, target));
     if let Some(existing) = installed_binary(&install_dir) {
-        return Ok(existing);
+        return Ok((existing, InstallStatus::Cached));
     }
     download_and_extract(container, artifact, &install_dir).await?;
-    installed_binary(&install_dir).ok_or_else(|| ComposeError::PackageArtifactEmpty {
-        container: container.to_string(),
-        name: resolved.name.clone(),
-        path: install_dir.clone(),
-    })
+    let program =
+        installed_binary(&install_dir).ok_or_else(|| ComposeError::PackageArtifactEmpty {
+            container: container.to_string(),
+            name: resolved.name.clone(),
+            path: install_dir.clone(),
+        })?;
+    Ok((program, InstallStatus::Downloaded))
 }
 
 /// Installs a bundle: one archive, no target in its identity.
@@ -307,7 +334,7 @@ async fn install_bundle(
     container: &str,
     resolved: &ResolvedWorker,
     cache_root: &Path,
-) -> Result<PathBuf> {
+) -> Result<(PathBuf, InstallStatus)> {
     // The registry sends both or neither. Without the digest the archive cannot
     // be verified, and an unverifiable artefact is not installed.
     let (url, sha256) = match (&resolved.archive_url, &resolved.sha256) {
@@ -329,7 +356,7 @@ async fn install_bundle(
     // an install dir a cache hit — not the first executable, which a bundle
     // need not have at all.
     if install_dir.join(BUNDLE_MANIFEST).is_file() {
-        return Ok(install_dir);
+        return Ok((install_dir, InstallStatus::Cached));
     }
 
     let artifact = Artifact {
@@ -345,7 +372,7 @@ async fn install_bundle(
             path: install_dir.clone(),
         });
     }
-    Ok(install_dir)
+    Ok((install_dir, InstallStatus::Downloaded))
 }
 
 /// The raw `/resolve` answer: the worker and everything it depends on.
@@ -561,28 +588,42 @@ async fn download_and_extract(
     // Extract beside the destination and rename: a crash mid-extraction must
     // not leave a half-unpacked directory that the next run treats as a cache
     // hit.
-    let staging = install_dir.with_extension("unpacking");
-    let _ = std::fs::remove_dir_all(&staging);
-    std::fs::create_dir_all(&staging).map_err(|source| ComposeError::Io {
-        path: staging.clone(),
-        source,
-    })?;
+    // Each writer needs its own staging directory. Two containers can resolve
+    // to the same artefact and download it at the same time; sharing one
+    // `.unpacking` path would let either writer remove files under the other.
+    let staging = install_dir.with_extension(format!("unpacking-{}", uuid::Uuid::new_v4()));
+    if let Err(source) = std::fs::create_dir_all(&staging) {
+        return Err(ComposeError::Io {
+            path: staging,
+            source,
+        });
+    }
 
     let decoder = flate2::read::GzDecoder::new(std::io::Cursor::new(bytes));
-    tar::Archive::new(decoder)
-        .unpack(&staging)
-        .map_err(|source| ComposeError::Io {
+    if let Err(source) = tar::Archive::new(decoder).unpack(&staging) {
+        let error = ComposeError::Io {
             path: staging.clone(),
             source,
-        })?;
+        };
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(error);
+    }
 
-    if let Some(parent) = install_dir.parent() {
-        std::fs::create_dir_all(parent).map_err(|source| ComposeError::Io {
+    if let Some(parent) = install_dir.parent()
+        && let Err(source) = std::fs::create_dir_all(parent)
+    {
+        let error = ComposeError::Io {
             path: parent.to_path_buf(),
             source,
-        })?;
+        };
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(error);
     }
-    publish(&staging, install_dir)
+    let result = publish(&staging, install_dir);
+    if result.is_err() {
+        let _ = std::fs::remove_dir_all(&staging);
+    }
+    result
 }
 
 /// Moves a verified install into place without ever unmaking one.
@@ -695,6 +736,20 @@ mod tests {
     use super::*;
     use wiremock::{Mock, MockServer, ResponseTemplate, matchers};
 
+    fn executable_archive() -> Vec<u8> {
+        let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut archive = tar::Builder::new(encoder);
+        let body = b"#!/bin/sh\nexit 0\n";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        let name = format!("worker{}", std::env::consts::EXE_SUFFIX);
+        archive.append_data(&mut header, name, &body[..]).unwrap();
+        let encoder = archive.into_inner().unwrap();
+        encoder.finish().unwrap()
+    }
+
     #[test]
     fn a_reference_without_a_host_uses_the_default_registry() {
         let (registry, name) = split_reference("state");
@@ -763,6 +818,53 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error.code(), "PACKAGE_NOT_RESOLVED");
+    }
+
+    #[tokio::test]
+    async fn a_second_install_reuses_the_downloaded_artefact() {
+        let server = MockServer::start().await;
+        let archive = executable_archive();
+        let digest = hex::encode(Sha256::digest(&archive));
+        let target = host_target();
+        let artifact_url = format!("{}/artifact", server.uri());
+
+        Mock::given(matchers::method("POST"))
+            .and(matchers::path("/resolve"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "graph": [{
+                    "name": "state",
+                    "version": "1.0.0",
+                    "type": "binary",
+                    "binaries": {
+                        (target): {
+                            "sha256": digest,
+                            "url": artifact_url,
+                        }
+                    },
+                    "config": {"prefix": "state"}
+                }]
+            })))
+            .expect(2)
+            .mount(&server)
+            .await;
+        Mock::given(matchers::method("GET"))
+            .and(matchers::path("/artifact"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(archive))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let cache = tempfile::tempdir().unwrap();
+        let first = install_from_registry("state", &server.uri(), "state", "1.0.0", cache.path())
+            .await
+            .unwrap();
+        let second = install_from_registry("state", &server.uri(), "state", "1.0.0", cache.path())
+            .await
+            .unwrap();
+
+        assert_eq!(first.status, InstallStatus::Downloaded);
+        assert_eq!(second.status, InstallStatus::Cached);
+        assert_eq!(first.default_config, second.default_config);
     }
 
     #[test]

--- a/crates/iii-compose/src/report.rs
+++ b/crates/iii-compose/src/report.rs
@@ -80,7 +80,10 @@ enum RowState {
     /// Declared, and waiting on something earlier in the graph.
     Waiting,
     Starting,
-    Ready(Duration),
+    Ready {
+        what: String,
+        elapsed: Duration,
+    },
     Failed,
     /// Already running, or otherwise not this operation's to start.
     Skipped(String),
@@ -175,10 +178,11 @@ fn render_row(row: &Row, frame: usize) -> String {
             FRAMES[frame % FRAMES.len()].cyan(),
             row.key.bold()
         ),
-        RowState::Ready(elapsed) => format!(
-            "{indent}{} {} {}",
+        RowState::Ready { what, elapsed } => format!(
+            "{indent}{} {} {} {}",
             OK.green(),
             row.key.bold(),
+            what.green(),
             format!("({})", format_elapsed(*elapsed)).dimmed()
         ),
         RowState::Failed => format!("{indent}{} {}", FAILED.red(), row.key.bold().red()),
@@ -281,14 +285,24 @@ pub fn starting(key: &str, what: &str) {
 }
 
 pub fn ready(key: &str, elapsed: Duration) {
-    if set(key, RowState::Ready(elapsed)) {
+    completed(key, "ready", elapsed);
+}
+
+pub fn completed(key: &str, what: &str, elapsed: Duration) {
+    if set(
+        key,
+        RowState::Ready {
+            what: what.to_string(),
+            elapsed,
+        },
+    ) {
         return;
     }
     line(&format!(
         "{} {} {} {}",
         OK.green(),
         key.bold(),
-        "ready".green(),
+        what.green(),
         format!("({})", format_elapsed(elapsed)).dimmed()
     ));
 }
@@ -531,12 +545,18 @@ mod tests {
         let parent = Row {
             key: "harness".to_string(),
             depth: 0,
-            state: RowState::Ready(Duration::from_millis(10)),
+            state: RowState::Ready {
+                what: "ready".to_string(),
+                elapsed: Duration::from_millis(10),
+            },
         };
         let child = Row {
             key: "queue".to_string(),
             depth: 1,
-            state: RowState::Ready(Duration::from_millis(10)),
+            state: RowState::Ready {
+                what: "ready".to_string(),
+                elapsed: Duration::from_millis(10),
+            },
         };
         let drawn_parent = render_row(&parent, 0);
         let drawn_child = render_row(&child, 0);

--- a/crates/iii-compose/src/state.rs
+++ b/crates/iii-compose/src/state.rs
@@ -184,6 +184,12 @@ impl StateStore {
         }
     }
 
+    /// Registry packages are shared by every Compose daemon and project on
+    /// this machine.
+    pub fn package_cache() -> Result<PathBuf> {
+        Ok(Self::root()?.join("packages"))
+    }
+
     /// Where one project's state lives:
     /// `~/.iii/compose/<daemon-namespace>/<project-slug>`, or under
     /// `$III_COMPOSE_STATE_DIR` when the operator relocates it (a read-only

--- a/crates/iii-compose/tests/cli.rs
+++ b/crates/iii-compose/tests/cli.rs
@@ -5,7 +5,10 @@
 //! starts holding a project or holding nothing.
 
 use clap::Parser;
-use iii_compose::{ComposeCli, ComposeCommand, ComposeFile, EngineMode, resolve_engine_mode};
+use iii_compose::{
+    BuildCli, ComposeCli, ComposeCommand, ComposeFile, ComposeSubcommand, EngineMode,
+    resolve_engine_mode,
+};
 
 /// Mirrors how the engine mounts the subcommand, so parsing is exercised
 /// through the same shape the real binary uses.
@@ -177,6 +180,50 @@ fn logs_rejects_an_unbounded_initial_tail() {
         .expect_err("the CLI should bound one log response");
 
     assert!(error.to_string().contains("tail must not exceed 1000"));
+}
+
+#[test]
+fn build_uses_the_default_compose_file() {
+    let ComposeCommand::Build { file } = parse(&["iii", "compose", "build"]).plan().unwrap() else {
+        panic!("expected build command");
+    };
+    assert_eq!(file, std::path::Path::new("worker-compose.yaml"));
+}
+
+#[test]
+fn build_accepts_its_own_file() {
+    let ComposeCommand::Build { file } =
+        parse(&["iii", "compose", "build", "--file", "other.yaml"])
+            .plan()
+            .unwrap()
+    else {
+        panic!("expected build command");
+    };
+    assert_eq!(file, std::path::Path::new("other.yaml"));
+}
+
+#[test]
+fn build_conflicts_with_daemon_options() {
+    for args in [
+        &["iii", "compose", "--up", "build"][..],
+        &["iii", "compose", "--engine", "ws://host:1", "build"][..],
+        &["iii", "compose", "--namespace", "dev", "build"][..],
+    ] {
+        assert!(Wrapper::try_parse_from(args).is_err(), "{args:?} must fail");
+    }
+
+    let error = ComposeCli {
+        engine: None,
+        ns: None,
+        up: true,
+        file: None,
+        command: Some(ComposeSubcommand::Build(BuildCli {
+            file: "worker-compose.yaml".into(),
+        })),
+    }
+    .plan()
+    .unwrap_err();
+    assert_eq!(error.code(), "BUILD_CONFLICTS_WITH_SERVE_OPTIONS");
 }
 
 #[test]

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -28,7 +28,7 @@ iii [OPTIONS] [COMMAND]
 | Command | Description |
 | ------- | ----------- |
 | `cloud` | Manage iii Cloud deployments. Dispatches to the external `iii-cloud` binary, which is temporarily maintained outside this repository; run `iii cloud --help` for its current surface. |
-| [`compose`](#iii-compose) | Serve worker-compose projects: supervise each one's workers as a graph |
+| [`compose`](#iii-compose) | Serve worker-compose projects or prepare their registry packages |
 | [`console`](#iii-console) | Launch the iii web console. |
 | [`project`](#iii-project) | Manage iii projects (init, generate-docker) |
 | [`trigger`](#iii-trigger) | Invoke a function on a running iii engine |
@@ -36,9 +36,9 @@ iii [OPTIONS] [COMMAND]
 
 ### `iii compose`
 
-Serve worker-compose projects: supervise each one's workers as a graph.
+Serve worker-compose projects or prepare their registry packages.
 
-Without `--up`, worker-compose.yaml supplies daemon defaults but no project starts. Projects are then managed through `compose::*` calls. With `--up`, the initial project also starts, together with its declared engine unless `--engine` selects an existing one.
+Without `--up`, worker-compose.yaml supplies daemon defaults but no project starts. Projects are then managed through `compose::*` calls. With `--up`, the initial project also starts, together with its declared engine unless `--engine` selects an existing one. `build` downloads packages without starting an engine or worker.
 
 ```text
 iii compose [OPTIONS]
@@ -51,6 +51,18 @@ iii compose <COMMAND>
 | `-n, --namespace <NS>` | Namespace this daemon answers `compose::*` in and applies to every project it loads. Several daemons attach to one engine; this is what tells them apart |
 | `--up` | Serve with one project brought up first, starting its declared engine unless `--engine` selects an existing one |
 | `-f, --file <PATH>` | The compose file. Only valid with `--up`. Defaults to `./worker-compose.yaml`, the same fallback `compose::up` uses when a call names no file |
+
+#### `iii compose build`
+
+Download every registry package declared by the compose file
+
+```text
+iii compose build [OPTIONS]
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-f, --file <PATH>` | Compose file whose registry packages should be downloaded [default: worker-compose.yaml] |
 
 #### `iii compose logs`
 

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -26,7 +26,7 @@ iii [OPTIONS] [COMMAND]
 | Command | Description |
 | ------- | ----------- |
 | `cloud` | Manage iii Cloud deployments. Dispatches to the external `iii-cloud` binary, which is temporarily maintained outside this repository; run `iii cloud --help` for its current surface. |
-| [`compose`](#iii-compose) | Serve worker-compose projects: supervise each one's workers as a graph |
+| [`compose`](#iii-compose) | Serve worker-compose projects or prepare their registry packages |
 | [`console`](#iii-console) | Launch the iii web console. |
 | [`project`](#iii-project) | Manage iii projects (init, generate-docker) |
 | [`trigger`](#iii-trigger) | Invoke a function on a running iii engine |
@@ -34,9 +34,9 @@ iii [OPTIONS] [COMMAND]
 
 ### `iii compose`
 
-Serve worker-compose projects: supervise each one's workers as a graph.
+Serve worker-compose projects or prepare their registry packages.
 
-Without `--up`, worker-compose.yaml supplies daemon defaults but no project starts. Projects are then managed through `compose::*` calls. With `--up`, the initial project also starts, together with its declared engine unless `--engine` selects an existing one.
+Without `--up`, worker-compose.yaml supplies daemon defaults but no project starts. Projects are then managed through `compose::*` calls. With `--up`, the initial project also starts, together with its declared engine unless `--engine` selects an existing one. `build` downloads packages without starting an engine or worker.
 
 ```text
 iii compose [OPTIONS]
@@ -49,6 +49,18 @@ iii compose <COMMAND>
 | `-n, --namespace <NS>` | Namespace this daemon answers `compose::*` in and applies to every project it loads. Several daemons attach to one engine; this is what tells them apart |
 | `--up` | Serve with one project brought up first, starting its declared engine unless `--engine` selects an existing one |
 | `-f, --file <PATH>` | The compose file. Only valid with `--up`. Defaults to `./worker-compose.yaml`, the same fallback `compose::up` uses when a call names no file |
+
+#### `iii compose build`
+
+Download every registry package declared by the compose file
+
+```text
+iii compose build [OPTIONS]
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-f, --file <PATH>` | Compose file whose registry packages should be downloaded [default: worker-compose.yaml] |
 
 #### `iii compose logs`
 

--- a/docs/next/using-iii/cli.mdx
+++ b/docs/next/using-iii/cli.mdx
@@ -18,7 +18,7 @@ The generated [CLI reference](../cli-reference/index) publishes the same surface
 
 | Subcommand | What it does |
 | --- | --- |
-| `iii compose` | Run the Compose daemon; `iii compose --up` supervises a declared engine and project workers. |
+| `iii compose` | Run the Compose daemon, prepare registry packages with `build`, or supervise a project with `--up`. |
 | `iii trigger` | Invoke a registered function on a running engine. |
 | `iii project` | Scaffold projects and generate Docker assets. |
 | `iii console` | Launch the iii web console. |
@@ -32,6 +32,7 @@ Running `iii` with no subcommand starts only the engine from `./config.yaml` or 
 `iii compose --up` for the normal project lifecycle:
 
 ```bash
+iii compose build --file worker-compose.yaml
 iii compose --namespace dev --up --file worker-compose.yaml
 ```
 

--- a/docs/next/using-iii/cli.mdx.skill.md
+++ b/docs/next/using-iii/cli.mdx.skill.md
@@ -16,7 +16,7 @@ The generated [CLI reference](../cli-reference/index) publishes the same surface
 
 | Subcommand | What it does |
 | --- | --- |
-| `iii compose` | Run the Compose daemon; `iii compose --up` supervises a declared engine and project workers. |
+| `iii compose` | Run the Compose daemon, prepare registry packages with `build`, or supervise a project with `--up`. |
 | `iii trigger` | Invoke a registered function on a running engine. |
 | `iii project` | Scaffold projects and generate Docker assets. |
 | `iii console` | Launch the iii web console. |
@@ -30,6 +30,7 @@ Running `iii` with no subcommand starts only the engine from `./config.yaml` or 
 `iii compose --up` for the normal project lifecycle:
 
 ```bash
+iii compose build --file worker-compose.yaml
 iii compose --namespace dev --up --file worker-compose.yaml
 ```
 

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -18,7 +18,29 @@ exposes the `compose::*` functions there, so every project operation is a normal
 Bare `iii compose` is the daemon command. It reads `worker-compose.yaml` when the file exists so
 the namespace and engine URL can configure the daemon. The `--up` flag also loads the file as a
 project and starts its containers. `iii compose logs` is a read-only client for a daemon that is
-already running.
+already running. `iii compose build` is a local action that prepares registry packages without
+starting the daemon.
+
+## Build registry packages
+
+```text
+iii compose build [-f, --file <PATH>]
+```
+
+`build` reads and validates the compose file, then downloads every `package://` container into the
+same cache used by `compose::up`. The file defaults to `./worker-compose.yaml`. The command does not
+connect to an engine, start a worker, or run lifecycle hooks. Local `path://` workers and built-in
+engine workers need no registry download and are skipped.
+
+```bash
+iii compose build --file worker-compose.yaml
+iii compose --up --file worker-compose.yaml
+```
+
+The cache is shared under `~/.iii/compose/packages`, or under `III_COMPOSE_STATE_DIR` when that
+variable is set. A later `compose::up` still resolves package metadata, but it reuses a valid cached
+artefact and does not download its bytes again. If the cache is missing, `up` keeps its existing
+download fallback.
 
 ## The daemon
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -12,7 +12,29 @@ exposes the `compose::*` functions there, so every project operation is a normal
 Bare `iii compose` is the daemon command. It reads `worker-compose.yaml` when the file exists so
 the namespace and engine URL can configure the daemon. The `--up` flag also loads the file as a
 project and starts its containers. `iii compose logs` is a read-only client for a daemon that is
-already running.
+already running. `iii compose build` is a local action that prepares registry packages without
+starting the daemon.
+
+## Build registry packages
+
+```text
+iii compose build [-f, --file <PATH>]
+```
+
+`build` reads and validates the compose file, then downloads every `package://` container into the
+same cache used by `compose::up`. The file defaults to `./worker-compose.yaml`. The command does not
+connect to an engine, start a worker, or run lifecycle hooks. Local `path://` workers and built-in
+engine workers need no registry download and are skipped.
+
+```bash
+iii compose build --file worker-compose.yaml
+iii compose --up --file worker-compose.yaml
+```
+
+The cache is shared under `~/.iii/compose/packages`, or under `III_COMPOSE_STATE_DIR` when that
+variable is set. A later `compose::up` still resolves package metadata, but it reuses a valid cached
+artefact and does not download its bytes again. If the cache is missing, `up` keeps its existing
+download fallback.
 
 ## The daemon
 

--- a/docs/next/using-iii/workers.mdx
+++ b/docs/next/using-iii/workers.mdx
@@ -44,8 +44,12 @@ file or `scripts.start` from their `iii.worker.yaml` manifest.
 Start a project and keep its daemon in the foreground:
 
 ```bash
+iii compose build --file worker-compose.yaml
 iii compose --namespace dev --up --file worker-compose.yaml
 ```
+
+`build` downloads all declared `package://` workers before startup. `--up` then reuses the shared
+package cache. The command skips local `path://` workers.
 
 The presence of `engine:` makes the daemon own and stop the engine. Without it, pass `--engine` or
 set `III_URL` to connect to an engine managed elsewhere.

--- a/docs/next/using-iii/workers.mdx.skill.md
+++ b/docs/next/using-iii/workers.mdx.skill.md
@@ -40,8 +40,12 @@ file or `scripts.start` from their `iii.worker.yaml` manifest.
 Start a project and keep its daemon in the foreground:
 
 ```bash
+iii compose build --file worker-compose.yaml
 iii compose --namespace dev --up --file worker-compose.yaml
 ```
+
+`build` downloads all declared `package://` workers before startup. `--up` then reuses the shared
+package cache. The command skips local `path://` workers.
 
 The presence of `engine:` makes the daemon own and stop the engine. Without it, pass `--engine` or
 set `III_URL` to connect to an engine managed elsewhere.

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -157,12 +157,13 @@ enum Commands {
     /// Manage iii projects (init, generate-docker)
     Project(crate::cli::project::ProjectArgs),
 
-    /// Serve worker-compose projects: supervise each one's workers as a graph.
+    /// Serve worker-compose projects or prepare their registry packages.
     ///
     /// Without `--up`, worker-compose.yaml supplies daemon defaults but no
     /// project starts. Projects are then managed through `compose::*` calls.
     /// With `--up`, the initial project also starts, together with its declared
     /// engine unless `--engine` selects an existing one.
+    /// `build` downloads packages without starting an engine or worker.
     Compose(iii_compose::ComposeCli),
 
     /// Generate the committed MDX CLI reference page from this binary's
@@ -216,6 +217,7 @@ fn cli_usage_command_path(cli: &Cli) -> String {
             cli::project::ProjectAction::GenerateDocker(_) => "project generate-docker".to_string(),
         },
         Some(Commands::Compose(args)) => match &args.command {
+            Some(iii_compose::ComposeSubcommand::Build(_)) => "compose build".to_string(),
             Some(iii_compose::ComposeSubcommand::Logs(_)) => "compose logs".to_string(),
             None => "compose".to_string(),
         },
@@ -756,9 +758,8 @@ mod tests {
         );
     }
 
-    /// Bare `iii compose` is the whole command. What a project is and what
-    /// happens to it are `compose::*` call arguments now, so nothing here
-    /// names one.
+    /// Bare `iii compose` stays the daemon command. Project lifecycle actions
+    /// remain `compose::*` calls; `build` only prepares local packages.
     #[test]
     fn compose_mounts_as_a_single_command() {
         let cli = Cli::try_parse_from(["iii", "compose"]).expect("should parse compose");
@@ -767,6 +768,23 @@ mod tests {
             Some(Commands::Compose(args)) => {
                 assert!(args.engine.is_none());
                 assert!(args.ns.is_none());
+                assert!(args.command.is_none());
+            }
+            _ => panic!("expected Compose subcommand"),
+        }
+    }
+
+    #[test]
+    fn compose_build_has_its_own_telemetry_path() {
+        let cli =
+            Cli::try_parse_from(["iii", "compose", "build"]).expect("should parse compose build");
+        assert_eq!(cli_usage_command_path(&cli), "compose build");
+        match cli.command {
+            Some(Commands::Compose(args)) => {
+                assert!(matches!(
+                    args.command,
+                    Some(iii_compose::ComposeSubcommand::Build(_))
+                ));
             }
             _ => panic!("expected Compose subcommand"),
         }


### PR DESCRIPTION
## Summary

- add `iii compose build` to prefetch all `package://` workers without starting an engine, daemon, hooks, or workers
- reuse the shared Compose package cache and report downloaded versus cached packages
- preserve `compose::up` as a backward-compatible fallback and make concurrent package preparation safe
- document the command and cover CLI parsing, cache reuse, deterministic errors, and package filtering

## Testing

- `cargo fmt --all --check`
- `cargo test -p iii-compose`
- `SKIP_UI_BUILD=1 cargo test -p iii --bin iii`
- `cargo clippy -p iii-compose --all-targets -- -D warnings`
- `SKIP_UI_BUILD=1 cargo clippy --workspace --all-targets`
- `SKIP_UI_BUILD=1 cargo build -p iii`
- `SKIP_UI_BUILD=1 bash scripts/generate-cli-docs.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `iii compose build` to download registry packages without starting workers or an engine.
  * Supports custom compose files with `--file`; defaults to `worker-compose.yaml`.
  * Reports downloaded and cached package counts.
  * Reuses cached packages during subsequent project startup.

* **Bug Fixes**
  * Improved concurrent package preparation and temporary-file cleanup.
  * Added clear validation when build options conflict with daemon options.

* **Documentation**
  * Added CLI reference and usage guidance for preparing registry packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->