### PR TITLE
fix(ci): request actions:write for downstream validation dispatch

### DIFF
--- a/.github/workflows/release-iii.yml
+++ b/.github/workflows/release-iii.yml
@@ -723,6 +723,7 @@ jobs:
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
           owner: iii-hq
           repositories: templates,quickstart-validator
+          permission-actions: write
 
       - name: Dispatch validation workflows
         env:


### PR DESCRIPTION
## What

Adds `permission-actions: write` to the `III_CI_APP` token generated by the `trigger-validations` job in `release-iii.yml`.

## Why

The `iii/v0.23.0-rc.5` release run ([33108100062](https://github.com/iii-hq/iii/actions/runs/33108100062)) failed at its last job: `gh workflow run` against `iii-hq/templates` returned `HTTP 403: Resource not accessible by integration`. The token step requested no explicit permissions, so it inherited the app installation's grants — which include `actions: read` (listing workflows worked) but not `actions: write` (the dispatch POST was rejected). Every publish job had already succeeded, so the release itself went out, but the run was marked failed and no downstream validation ran for rc.5.

Requesting the permission explicitly matches `_homebrew.yml` (`permission-contents: write`) and turns a missing grant into an immediate, clear failure at token generation instead of a late opaque 403.

## Notes

This PR alone is not sufficient: an org admin must grant the **III_CI_APP** GitHub App **Actions: Read and write** and approve the permission update on the `iii-hq` installation (WORKFLOWS.md already documents this requirement). Until then the job fails at `Generate token` with an explicit permission error.

To cover rc.5 retroactively once the grant is in place:
```
gh workflow run init-smoke.yml --repo iii-hq/templates --ref main -f channel=rc
gh workflow run quickstart-validate.yml --repo iii-hq/quickstart-validator --ref main -f channel=rc
```

https://claude.ai/code/session_015zcMX7misXc7NGcTv8dvEH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated release validation by enabling downstream workflow dispatches.
  * Ensured validation workflows can successfully trigger required checks across related repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->