### PR TITLE
fix(compose): support empty container declarations

### DIFF
--- a/crates/iii-compose/src/config.rs
+++ b/crates/iii-compose/src/config.rs
@@ -203,7 +203,8 @@ impl ComposeFile {
                 message: err.to_string(),
             })?;
 
-        if raw.containers.is_empty() && raw.engine.is_none() {
+        let raw_containers = raw.containers.unwrap_or_default();
+        if raw_containers.is_empty() && raw.engine.is_none() {
             return Err(ComposeError::EmptyContainers);
         }
 
@@ -231,8 +232,8 @@ impl ComposeFile {
         let stop_timeout = file_duration("stop_timeout", &raw.stop_timeout, DEFAULT_STOP_TIMEOUT)?;
         let engine = raw.engine.map(validate_engine).transpose()?;
 
-        let mut containers = IndexMap::with_capacity(raw.containers.len());
-        for (key, raw_container) in &raw.containers {
+        let mut containers = IndexMap::with_capacity(raw_containers.len());
+        for (key, raw_container) in &raw_containers {
             containers.insert(
                 key.clone(),
                 validate_container(key, raw_container, &base_dir, startup_timeout)?,
@@ -600,9 +601,9 @@ struct RawComposeFile {
     stop_timeout: Option<String>,
     #[serde(default)]
     engine: Option<RawEngineSpec>,
-    #[serde(default, deserialize_with = "deserialize_unique_map")]
-    #[schemars(with = "BTreeMap<String, RawContainer>")]
-    containers: IndexMap<String, RawContainer>,
+    #[serde(default, deserialize_with = "deserialize_optional_unique_map")]
+    #[schemars(with = "Option<BTreeMap<String, RawContainer>>")]
+    containers: Option<IndexMap<String, RawContainer>>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -660,6 +661,49 @@ where
     }
 
     deserializer.deserialize_map(UniqueMap(std::marker::PhantomData))
+}
+
+fn deserialize_optional_unique_map<'de, D, V>(
+    deserializer: D,
+) -> std::result::Result<Option<IndexMap<String, V>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    V: Deserialize<'de>,
+{
+    use serde::de::Visitor;
+
+    struct OptionalUniqueMap<V>(std::marker::PhantomData<V>);
+
+    impl<'de, V: Deserialize<'de>> Visitor<'de> for OptionalUniqueMap<V> {
+        type Value = Option<IndexMap<String, V>>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("null or a mapping with unique keys")
+        }
+
+        fn visit_none<E>(self) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_unit<E>(self) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> std::result::Result<Self::Value, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserialize_unique_map(deserializer).map(Some)
+        }
+    }
+
+    deserializer.deserialize_option(OptionalUniqueMap(std::marker::PhantomData))
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -773,7 +817,21 @@ containers:
         let schema = worker_compose_schema_json();
         assert_eq!(schema["type"], "object");
         assert!(schema["properties"]["engine"].is_object());
-        assert!(schema["properties"]["containers"].is_object());
+        let container_types = schema["properties"]["containers"]["type"]
+            .as_array()
+            .expect("containers must accept an object or null");
+        assert!(
+            container_types
+                .iter()
+                .any(|schema_type| schema_type == "object"),
+            "containers must accept an object: {container_types:?}"
+        );
+        assert!(
+            container_types
+                .iter()
+                .any(|schema_type| schema_type == "null"),
+            "containers must accept null: {container_types:?}"
+        );
         assert!(
             !schema["required"].as_array().is_some_and(|fields| {
                 fields

--- a/crates/iii-compose/src/edit.rs
+++ b/crates/iii-compose/src/edit.rs
@@ -146,6 +146,8 @@ fn invalid(spec: &str, reason: &str) -> ComposeError {
 /// not affect anything — start order comes from `start_after` — so the end is
 /// where it disturbs the smallest part of the file and of its diff.
 pub fn upsert_container(text: &str, new: &NewContainer) -> Result<Outcome> {
+    let normalized = normalize_inline_empty_containers(text);
+    let text = normalized.as_deref().unwrap_or(text);
     let lines: Vec<&str> = text.lines().collect();
     let containers = find_containers(&lines)?;
 
@@ -395,6 +397,25 @@ fn join(lines: &[String], original: &str) -> String {
         text.push('\n');
     }
     text
+}
+
+fn normalize_inline_empty_containers(text: &str) -> Option<String> {
+    let lines: Vec<&str> = text.lines().collect();
+    let (line_index, comment) = lines.iter().enumerate().find_map(|(index, line)| {
+        let rest = line.strip_prefix("containers:")?;
+        let (value, comment) = rest
+            .split_once('#')
+            .map_or((rest, None), |(value, comment)| (value, Some(comment)));
+        let inner = value.trim().strip_prefix('{')?.strip_suffix('}')?;
+        inner.trim().is_empty().then_some((index, comment))
+    })?;
+
+    let mut out: Vec<String> = lines.iter().map(|line| (*line).to_string()).collect();
+    out[line_index] = "containers:".to_string();
+    if let Some(comment) = comment {
+        out.insert(line_index + 1, format!("  #{comment}"));
+    }
+    Some(join(&out, text))
 }
 
 /// The half-open line range of the `containers:` mapping body.
@@ -872,7 +893,84 @@ containers:
     }
 
     #[test]
-    fn a_file_without_containers_is_refused() {
+    fn adds_the_first_container_to_a_bare_empty_mapping() {
+        let text = "engine:\n  workers: {}\ncontainers:\n";
+        let out = match upsert_container(text, &parse_worker("state@0.21.4").unwrap()).unwrap() {
+            Outcome::Added(text) => text,
+            other => panic!("expected an addition, got {other:?}"),
+        };
+
+        assert_eq!(out.matches("state:").count(), 1, "duplicated: {out}");
+        assert!(out.contains("# added by compose::add"), "{out}");
+        assert!(out.contains("version: \"0.21.4\""), "{out}");
+        assert!(out.ends_with('\n'), "lost the trailing newline: {out}");
+        crate::ComposeFile::parse(&out, "/tmp/worker-compose.yaml")
+            .expect("the edited file should load");
+    }
+
+    #[test]
+    fn adds_the_first_container_to_an_inline_empty_mapping() {
+        let text = "engine:\n  workers: {}\ncontainers: {}\n";
+        let out = match upsert_container(text, &parse_worker("state@0.21.4").unwrap()).unwrap() {
+            Outcome::Added(text) => text,
+            other => panic!("expected an addition, got {other:?}"),
+        };
+
+        assert!(
+            !out.contains("containers: {}"),
+            "inline map survived: {out}"
+        );
+        assert_eq!(out.matches("containers:").count(), 1, "duplicated: {out}");
+        assert_eq!(out.matches("state:").count(), 1, "duplicated: {out}");
+        assert!(out.contains("worker: package://api.workers.iii.dev/state"));
+        assert!(out.contains("version: \"0.21.4\""), "{out}");
+        crate::ComposeFile::parse(&out, "/tmp/worker-compose.yaml")
+            .expect("the edited file should load");
+    }
+
+    #[test]
+    fn preserves_an_inline_empty_mapping_comment_when_adding() {
+        let text = "engine:\n  workers: {}\ncontainers: { } # keep this empty until bootstrap\n";
+        let out = match upsert_container(text, &parse_worker("state@0.21.4").unwrap()).unwrap() {
+            Outcome::Added(text) => text,
+            other => panic!("expected an addition, got {other:?}"),
+        };
+
+        assert!(!out.contains("containers: {"), "inline map survived: {out}");
+        assert!(
+            out.contains("containers:\n  # keep this empty until bootstrap\n"),
+            "comment changed: {out}"
+        );
+        assert!(out.ends_with('\n'), "lost the trailing newline: {out}");
+        crate::ComposeFile::parse(&out, "/tmp/worker-compose.yaml")
+            .expect("the edited file should load");
+    }
+
+    #[test]
+    fn adds_multiple_containers_after_normalizing_an_inline_empty_mapping() {
+        let text = "engine:\n  workers: {}\ncontainers: {}\n";
+        let once = match upsert_container(text, &parse_worker("state@0.21.4").unwrap()).unwrap() {
+            Outcome::Added(text) => text,
+            other => panic!("expected the first addition, got {other:?}"),
+        };
+        let out = match upsert_container(&once, &parse_worker("queue@1.0.0").unwrap()).unwrap() {
+            Outcome::Added(text) => text,
+            other => panic!("expected the second addition, got {other:?}"),
+        };
+
+        assert!(
+            !out.contains("containers: {}"),
+            "inline map survived: {out}"
+        );
+        assert_eq!(out.matches("containers:").count(), 1, "duplicated: {out}");
+        assert_eq!(out.matches("state:").count(), 1, "duplicated: {out}");
+        assert_eq!(out.matches("queue:").count(), 1, "duplicated: {out}");
+        crate::ComposeFile::parse(&out, "/tmp/worker-compose.yaml")
+            .expect("the edited file should load");
+    }
+
+    #[test]
+    fn still_refuses_a_file_without_the_containers_key() {
         let err = upsert_container("namespace: default\n", &parse_worker("state").unwrap())
             .expect_err("there is nothing to add to");
         assert!(err.to_string().contains("containers"), "{err}");

--- a/crates/iii-compose/tests/config_validation.rs
+++ b/crates/iii-compose/tests/config_validation.rs
@@ -197,6 +197,34 @@ containers: {}
 }
 
 #[test]
+fn accepts_null_containers_for_a_managed_engine() {
+    let file = parse(
+        r#"
+engine:
+  workers: {}
+containers:
+"#,
+    )
+    .expect("a managed engine may start without containers");
+
+    assert!(file.containers.is_empty());
+}
+
+#[test]
+fn accepts_an_inline_empty_container_map_for_a_managed_engine() {
+    let file = parse(
+        r#"
+engine:
+  workers: {}
+containers: {}
+"#,
+    )
+    .expect("a managed engine may start with an inline empty container map");
+
+    assert!(file.containers.is_empty());
+}
+
+#[test]
 fn rejects_project_and_internal_workers_inside_engine_section() {
     assert_eq!(
         code(
@@ -283,6 +311,37 @@ containers: {}
         ),
         "EMPTY_CONTAINERS"
     );
+}
+
+#[test]
+fn rejects_null_containers_without_a_managed_engine() {
+    assert_eq!(
+        code(
+            r#"
+namespace: orders
+containers:
+"#
+        ),
+        "EMPTY_CONTAINERS"
+    );
+}
+
+#[test]
+fn rejects_a_non_mapping_containers_value() {
+    for text in [
+        r#"
+engine:
+  workers: {}
+containers: []
+"#,
+        r#"
+engine:
+  workers: {}
+containers: state
+"#,
+    ] {
+        assert_eq!(code(text), "INVALID_COMPOSE_FILE", "input: {text}");
+    }
 }
 
 #[test]

--- a/crates/iii-compose/tests/project_cache.rs
+++ b/crates/iii-compose/tests/project_cache.rs
@@ -397,6 +397,6 @@ async fn remove_validates_the_edited_file_before_writing_it() {
         .await
         .expect_err("remove must reject an empty edited project");
 
-    assert_eq!(err.code(), "INVALID_COMPOSE_FILE");
+    assert_eq!(err.code(), "EMPTY_CONTAINERS");
     assert_eq!(std::fs::read_to_string(file).unwrap(), before);
 }

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -16,9 +16,13 @@ use iii::engine::Engine;
 use iii::workers::engine_fn::EngineFunctionsWorker;
 use iii::workers::traits::Worker;
 use iii::workers::worker::WorkerManager;
-use iii_compose::{ComposeFile, daemon::Daemon, remote};
+use iii_compose::{
+    ComposeFile,
+    daemon::{Daemon, EnginePolicy},
+    remote,
+};
 use iii_sdk::protocol::TriggerRequest;
-use iii_sdk::{InitOptions, register_worker};
+use iii_sdk::{InitOptions, RegisterFunction, register_worker};
 use serde_json::{Value, json};
 use tokio::net::TcpListener;
 
@@ -514,6 +518,114 @@ containers:
     existing.shutdown_async().await;
     database.shutdown_async().await;
     web.shutdown_async().await;
+    daemon.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn add_starts_a_managed_project_declared_with_null_containers() {
+    isolate_state();
+    let port = spawn_engine().await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let worker_dir = tmp.path().join("workers/state");
+    std::fs::create_dir_all(&worker_dir).expect("worker dir");
+    std::fs::write(
+        worker_dir.join("iii.worker.yaml"),
+        "scripts:\n  start: \"echo started > started && sleep 30\"\n",
+    )
+    .expect("write worker manifest");
+
+    let file = tmp.path().join("worker-compose.yaml");
+    std::fs::write(
+        &file,
+        format!(
+            "namespace: empty-add\nstartup_timeout: 3s\nstop_timeout: 100ms\nengine:\n  url: ws://127.0.0.1:{port}\n  workers: {{}}\ncontainers:\n"
+        ),
+    )
+    .expect("write compose file");
+    let compose = ComposeFile::load(&file).expect("empty managed project should parse");
+    let engine = compose.engine.clone().expect("managed engine spec");
+
+    let daemon_namespace = "empty-add-daemon";
+    let daemon = Daemon::start(
+        format!("ws://127.0.0.1:{port}"),
+        daemon_namespace.to_string(),
+        None,
+        EnginePolicy::Managed {
+            owner: compose.path.clone(),
+            spec: engine,
+        },
+    );
+    remote::register(&daemon);
+    tokio::time::sleep(Duration::from_millis(600)).await;
+
+    let up = call_in(
+        port,
+        Some(daemon_namespace),
+        "compose::up",
+        json!({ "file": file.to_str().unwrap() }),
+    )
+    .await
+    .expect("empty managed project should start");
+    assert_eq!(up["status"], "ok", "{up}");
+    assert_eq!(up["containers"], json!([]), "{up}");
+
+    let started = worker_dir.join("started");
+    let add = call_in(
+        port,
+        Some(daemon_namespace),
+        "compose::add",
+        json!({
+            "file": file.to_str().unwrap(),
+            "workers": ["./workers/state"],
+        }),
+    );
+    let ready = async {
+        wait_for_start_markers(&[started.as_path()]).await;
+        let worker = register_test_worker(port, "empty-add", "state");
+        worker.register_function(
+            "state::ping",
+            RegisterFunction::new_async(|input: Value| async move {
+                Ok(json!({ "pong": input["message"] }))
+            }),
+        );
+        wait_for_worker_state(&daemon, "empty-add", "state", true).await;
+        worker
+    };
+    let (result, worker) = tokio::join!(add, ready);
+    let result = result.expect("compose::add should answer");
+
+    assert_eq!(result["status"], "ok", "{result}");
+    assert_eq!(result["changed"], true, "{result}");
+    assert_eq!(result["up"]["containers"][0]["state"], "ready", "{result}");
+
+    let edited = std::fs::read_to_string(&file).expect("read edited compose file");
+    assert!(
+        edited.contains("containers:\n  # added by compose::add\n  state:\n"),
+        "first worker was not written as a block: {edited}"
+    );
+
+    let ping = call_in(
+        port,
+        Some("empty-add"),
+        "state::ping",
+        json!({ "message": "hello" }),
+    )
+    .await
+    .expect("the added worker function should answer");
+    assert_eq!(ping, json!({ "pong": "hello" }));
+
+    let stop = call_in(
+        port,
+        Some(daemon_namespace),
+        "compose::stop",
+        json!({ "file": file.to_str().unwrap() }),
+    )
+    .await
+    .expect("managed project should stop");
+    assert_eq!(stop["stopping"], json!([file.to_str().unwrap()]), "{stop}");
+
+    worker.shutdown_async().await;
     daemon.shutdown().await;
 }
 


### PR DESCRIPTION
## Summary

- accept null and inline empty containers maps for managed Compose projects
- normalize inline empty maps before compose::add writes the first worker
- preserve comments, final newlines, duplicate-key validation, and missing-key errors
- cover parser, editor, schema, project-cache, and real daemon flows

## Validation

- cargo fmt --all
- cargo test -p iii-compose
- cargo test -p iii --test compose_daemon_e2e
- cargo clippy -p iii-compose --all-targets --all-features -- -D warnings
- cargo build --release -p iii

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Compose files can now use an omitted, null, or empty `containers` value when configuring a managed engine.
  - You can add the first worker to a compose file with an empty container definition.
  - Empty container definitions and inline comments are preserved when workers are added.

- **Bug Fixes**
  - Improved validation for invalid container formats and empty projects.
  - Managed projects can now start, route worker functions, persist changes, and stop correctly when initially configured without containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->