### PR TITLE
fix(compose): run local base-image workers in VMs

### DIFF
--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -47,7 +47,7 @@ pub mod state;
 pub use cli::{BuildCli, ComposeCli, ComposeCommand, ComposeLogsCli, ComposeSubcommand};
 pub use config::{ComposeFile, Container, EngineSpec, WorkerSource};
 pub use error::{ComposeError, Result};
-pub use manifest::{StartSpec, ValidationReport};
+pub use manifest::{StartSpec, ValidationReport, VmSpec};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EngineMode {

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -35,7 +35,7 @@ use crate::{
     error::{ComposeError, Result},
     hooks,
     logs::LogStore,
-    manifest::{StartSpec, resolve_start},
+    manifest::{StartSpec, VmSpec, resolve_start},
     process::{Outcome, Supervised, spawn_supervised_piped},
     report,
     spawn::{SpawnCtx, resolve_working_dir, spawn_plan},
@@ -102,7 +102,7 @@ pub struct LifecycleCtx<'a> {
     pub package_cache: &'a std::path::Path,
     /// Persistent, bounded stdout and stderr for every project worker.
     pub logs: &'a LogStore,
-    /// Root of the per-container VM state for bundle containers.
+    /// Root of the per-container VM state.
     pub vm_dir: &'a std::path::Path,
 }
 
@@ -650,9 +650,10 @@ async fn start_one_until_shutdown(
                 ),
                 // The start command is the bundle's own, read from its manifest
                 // inside the VM. Nothing on the host runs it.
-                crate::registry::Payload::Bundle(install_dir) => {
-                    (StartSpec::Vm { install_dir }, installed.default_config)
-                }
+                crate::registry::Payload::Bundle(install_dir) => (
+                    StartSpec::Vm(VmSpec::Bundle { install_dir }),
+                    installed.default_config,
+                ),
             }
         }
         crate::config::WorkerSource::Path { .. } => (resolve_start(key, container)?, None),
@@ -703,9 +704,9 @@ async fn start_one_until_shutdown(
     let plan = spawn_plan(&spawn_ctx);
     let command = match plan.command() {
         Some(command) => command,
-        // A bundle: publisher-controlled code, so it is booted in a VM instead
-        // of run here. The handle that comes back is an ordinary child, so
-        // readiness, stop, crash cascade and log capture below are unchanged.
+        // A VM worker is booted instead of run here. The handle that comes
+        // back is an ordinary child, so readiness, stop, crash cascade and log
+        // capture below are unchanged.
         None => wait_or_interrupt!(vm_command(ctx, key, &start, &plan, config.as_ref())).map_err(
             |message| ComposeError::SpawnFailed {
                 container: key.to_string(),
@@ -769,8 +770,7 @@ async fn start_one_until_shutdown(
     Ok((record, child))
 }
 
-/// Builds the boot command for a bundle container, by asking `iii-worker` for
-/// it.
+/// Builds the boot command for a VM container, by asking `iii-worker` for it.
 ///
 /// A process boundary rather than a call: libkrun needs glibc, and the engine
 /// ships a musl build so it installs on any Linux. Linked, the two do not fit
@@ -791,8 +791,13 @@ async fn vm_command(
     plan: &crate::spawn::SpawnPlan,
     config: Option<&ResolvedConfig>,
 ) -> std::result::Result<tokio::process::Command, String> {
-    let StartSpec::Vm { install_dir } = start else {
-        return Err("not a VM container".to_string());
+    let (worker_dir, run_override, prepare_command) = match start {
+        StartSpec::Vm(VmSpec::Bundle { install_dir }) => (install_dir, None, "__bundle-prepare"),
+        StartSpec::Vm(VmSpec::Local {
+            worker_dir,
+            run_override,
+        }) => (worker_dir, run_override.as_deref(), "__local-prepare"),
+        _ => return Err("not a VM container".to_string()),
     };
 
     let mut env: BTreeMap<String, String> = plan.env.clone();
@@ -831,14 +836,15 @@ async fn vm_command(
 
     let request = serde_json::json!({
         "worker_name": key,
-        "install_dir": install_dir,
+        "worker_dir": worker_dir,
         "state_dir": ctx.vm_dir.join(key),
         "engine_url": ctx.engine_url,
         "extra_env": env,
         "config_dir": config_dir,
+        "run_override": run_override,
     });
 
-    let plan = prepare_vm(&request).await?;
+    let plan = prepare_vm(prepare_command, &request).await?;
     let mut command = tokio::process::Command::new(&plan.program);
     command.args(&plan.args);
     for (name, value) in &plan.env {
@@ -857,7 +863,7 @@ async fn vm_command(
 /// constant `iii-worker` mounts it at; it is part of the request contract.
 const GUEST_CONFIG_DIR: &str = "/run/iii/config";
 
-/// What `iii-worker __bundle-prepare` answers: a program, its arguments, and
+/// What an `iii-worker` VM prepare command answers: a program, its arguments, and
 /// the environment to start it with.
 #[derive(serde::Deserialize)]
 struct VmPlan {
@@ -869,12 +875,15 @@ struct VmPlan {
     env_remove: Vec<String>,
 }
 
-/// Runs `iii-worker __bundle-prepare` and reads the plan back.
-async fn prepare_vm(request: &serde_json::Value) -> std::result::Result<VmPlan, String> {
+/// Runs an `iii-worker` VM prepare command and reads the plan back.
+async fn prepare_vm(
+    prepare_command: &str,
+    request: &serde_json::Value,
+) -> std::result::Result<VmPlan, String> {
     let program = worker_binary()?;
     let mut command = tokio::process::Command::new(&program);
     command
-        .arg("__bundle-prepare")
+        .arg(prepare_command)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
@@ -892,7 +901,7 @@ async fn prepare_vm(request: &serde_json::Value) -> std::result::Result<VmPlan, 
             .write_all(body.as_bytes())
             .await
             .map_err(|err| format!("cannot send the request to iii-worker: {err}"))?;
-        // Dropped here: __bundle-prepare reads to end of file, so it would wait
+        // Dropped here: the prepare command reads to end of file, so it would wait
         // forever on a pipe compose still holds open.
         drop(stdin);
     }
@@ -911,8 +920,8 @@ async fn prepare_vm(request: &serde_json::Value) -> std::result::Result<VmPlan, 
         // in compose rather than as the version skew it is.
         if reason.contains("unrecognized subcommand") {
             return Err(format!(
-                "{} is too old: it does not know `__bundle-prepare`, which compose uses to \
-                 build a bundle's VM. Install it from the same release as iii — they are \
+                "{} is too old: it does not know `{prepare_command}`, which compose uses to \
+                 build a worker VM. Install it from the same release as iii — they are \
                  shipped together and are updated together",
                 program.display()
             ));
@@ -951,8 +960,8 @@ fn worker_binary() -> std::result::Result<std::path::PathBuf, String> {
         .find(|candidate| candidate.is_file())
         .ok_or_else(|| {
             format!(
-                "{name} is not installed. Bundle containers run in a VM, and it is the binary \
-                 that boots one; install it beside iii, or run this project without bundles"
+                "{name} is not installed. VM containers need this binary to boot; install it \
+                 beside iii, or remove the worker's VM requirement"
             )
         })
 }

--- a/crates/iii-compose/src/manifest.rs
+++ b/crates/iii-compose/src/manifest.rs
@@ -6,9 +6,9 @@
 
 //! `iii.worker.yaml` subset parser and start-command resolution.
 //!
-//! Compose reads only `name` and `scripts.start`. The manifest is another
-//! tool's file, so unknown keys are tolerated here — the opposite of the
-//! compose file's strictness. This parser is deliberately independent from
+//! Compose reads only `scripts.start` and `runtime.base_image`. The manifest is
+//! another tool's file, so unknown keys are tolerated here — the opposite of
+//! the compose file's strictness. This parser is deliberately independent from
 //! `crates/iii-worker`: compose must not inherit the legacy lifecycle system.
 
 use std::path::{Path, PathBuf};
@@ -29,15 +29,29 @@ pub enum StartSpec {
     /// A resolved package binary. Package resolution is not implemented yet, so
     /// nothing produces this variant today.
     Exec { program: PathBuf, args: Vec<String> },
-    /// An installed bundle, started in a VM. The command is the `scripts.start`
-    /// of the manifest in `install_dir`, and it is publisher-controlled: it is
-    /// read and run inside the guest, never on the host.
-    Vm { install_dir: PathBuf },
+    /// A worker started in a VM. The source decides which validation and
+    /// workspace rules `iii-worker` applies before it builds the boot command.
+    Vm(VmSpec),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VmSpec {
+    /// An installed registry bundle. Its manifest command is publisher-owned
+    /// and is always read and run inside the guest.
+    Bundle { install_dir: PathBuf },
+    /// A local project whose manifest selected an OCI rootfs. The compose
+    /// command may replace the manifest's `scripts.start`, but still runs in
+    /// the guest.
+    Local {
+        worker_dir: PathBuf,
+        run_override: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone)]
 pub struct Manifest {
     pub start: Option<String>,
+    pub base_image: Option<String>,
 }
 
 /// Reads the manifest in `dir`, if there is one. A missing manifest is not an
@@ -55,8 +69,25 @@ pub fn read_manifest(dir: &Path) -> Result<Option<Manifest>> {
             path: path.clone(),
             message: err.to_string(),
         })?;
+    let base_image = raw
+        .runtime
+        .as_ref()
+        .and_then(serde_yaml::Value::as_mapping)
+        .and_then(|runtime| runtime.get("base_image"))
+        .map(|value| {
+            value.as_str().ok_or_else(|| ComposeError::InvalidManifest {
+                path: path.clone(),
+                message: "`runtime.base_image` must be a string".to_string(),
+            })
+        })
+        .transpose()?
+        .map(str::trim)
+        .filter(|image| !image.is_empty())
+        .map(str::to_string);
+
     Ok(Some(Manifest {
         start: raw.scripts.and_then(|scripts| scripts.start),
+        base_image,
     }))
 }
 
@@ -97,21 +128,31 @@ pub fn resolve_start(key: &str, container: &Container) -> Result<StartSpec> {
         });
     }
 
-    // Before the manifest is read, not after: a compose file that says how to
-    // run the worker does not need one, and a broken `iii.worker.yaml` next
-    // door should not fail a container that never consults it.
-    if let Some(run) = &container.scripts.run {
-        return Ok(StartSpec::Shell(run.clone()));
+    let manifest = read_manifest(dir)?;
+    let run_override = container.scripts.run.clone();
+    let Some(start) = run_override.clone().or_else(|| {
+        manifest
+            .as_ref()
+            .and_then(|manifest| manifest.start.clone())
+    }) else {
+        return Err(ComposeError::MissingStartCommand {
+            container: key.to_string(),
+            manifest: dir.join(MANIFEST_FILE),
+        });
+    };
+
+    if manifest
+        .as_ref()
+        .and_then(|manifest| manifest.base_image.as_ref())
+        .is_some()
+    {
+        return Ok(StartSpec::Vm(VmSpec::Local {
+            worker_dir: dir.clone(),
+            run_override,
+        }));
     }
 
-    let manifest = read_manifest(dir)?;
-    if let Some(start) = manifest.and_then(|manifest| manifest.start) {
-        return Ok(StartSpec::Shell(start));
-    }
-    Err(ComposeError::MissingStartCommand {
-        container: key.to_string(),
-        manifest: dir.join(MANIFEST_FILE),
-    })
+    Ok(StartSpec::Shell(start))
 }
 
 /// What one container would do on `up`.
@@ -240,6 +281,10 @@ struct RawManifest {
     // rather than rejected.
     #[serde(default)]
     scripts: Option<RawManifestScripts>,
+    /// Kept as a value so legacy scalar forms remain ignored. Compose only
+    /// consults the `base_image` key when `runtime` is a mapping.
+    #[serde(default)]
+    runtime: Option<serde_yaml::Value>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -368,9 +368,9 @@ impl Project {
         self.store.dir().join("config")
     }
 
-    /// Per-container VM state for bundle containers: rootfs, boot script, pid
-    /// file. Keyed by project rather than by worker name, so two projects
-    /// running the same bundle under the same container key stay apart.
+    /// Per-container VM state: rootfs, boot script, pid file. Keyed by project
+    /// rather than by worker name, so two projects using the same container key
+    /// stay apart.
     fn vm_dir(&self) -> PathBuf {
         self.store.dir().join("vm")
     }

--- a/crates/iii-compose/src/spawn.rs
+++ b/crates/iii-compose/src/spawn.rs
@@ -194,10 +194,10 @@ pub fn spawn_plan(ctx: &SpawnCtx<'_>) -> SpawnPlan {
     let (program, args) = match ctx.start {
         StartSpec::Shell(command) => shell_invocation(command),
         StartSpec::Exec { program, args } => (program.to_string_lossy().to_string(), args.clone()),
-        // The host execs nothing for a VM container: the start command is the
-        // bundle's own and runs inside the guest. Only the environment and the
-        // working directory computed above carry over.
-        StartSpec::Vm { .. } => (String::new(), Vec::new()),
+        // The host execs nothing for a VM container: the start command runs
+        // inside the guest. Only the environment and the working directory
+        // computed above carry over.
+        StartSpec::Vm(_) => (String::new(), Vec::new()),
     };
 
     SpawnPlan {

--- a/crates/iii-compose/tests/manifest.rs
+++ b/crates/iii-compose/tests/manifest.rs
@@ -23,6 +23,10 @@ fn start_of(file: &ComposeFile, key: &str) -> Result<StartSpec, iii_compose::Com
     iii_compose::manifest::resolve_start(key, &file.containers[key])
 }
 
+fn canonical_worker_dir(tmp: &Path) -> std::path::PathBuf {
+    std::fs::canonicalize(tmp.join("workers/api")).unwrap()
+}
+
 const MANIFEST: &str = r#"
 name: api
 runtime: rust
@@ -82,7 +86,7 @@ fn base_image_selects_the_local_vm() {
     assert_eq!(
         start_of(&file, "api").unwrap(),
         StartSpec::Vm(VmSpec::Local {
-            worker_dir: tmp.path().join("workers/api"),
+            worker_dir: canonical_worker_dir(tmp.path()),
             run_override: None,
         })
     );
@@ -100,7 +104,7 @@ fn compose_run_overrides_the_manifest_inside_the_local_vm() {
     assert_eq!(
         start_of(&file, "api").unwrap(),
         StartSpec::Vm(VmSpec::Local {
-            worker_dir: tmp.path().join("workers/api"),
+            worker_dir: canonical_worker_dir(tmp.path()),
             run_override: Some("python src/dev.py".to_string()),
         })
     );
@@ -121,7 +125,7 @@ fn compose_run_is_enough_for_a_local_vm_without_manifest_start() {
     assert_eq!(
         start_of(&file, "api").unwrap(),
         StartSpec::Vm(VmSpec::Local {
-            worker_dir: tmp.path().join("workers/api"),
+            worker_dir: canonical_worker_dir(tmp.path()),
             run_override: Some("python src/dev.py".to_string()),
         })
     );

--- a/crates/iii-compose/tests/manifest.rs
+++ b/crates/iii-compose/tests/manifest.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use iii_compose::{ComposeFile, StartSpec};
+use iii_compose::{ComposeFile, StartSpec, VmSpec};
 
 /// Writes a compose file plus optional worker dirs/manifests into a tempdir and
 /// loads it, so path resolution goes through the same code the CLI uses.
@@ -29,6 +29,15 @@ runtime: rust
 scripts:
   start: cargo run --release
   install: cargo build
+"#;
+
+const VM_MANIFEST: &str = r#"
+name: api
+runtime:
+  base_image: docker.io/iiidev/python:latest
+scripts:
+  install: pip install -e .
+  start: python src/main.py
 "#;
 
 #[test]
@@ -59,6 +68,113 @@ fn compose_run_wins_over_the_manifest() {
         start_of(&file, "api").unwrap(),
         StartSpec::Shell("./dev.sh".to_string())
     );
+}
+
+#[test]
+fn base_image_selects_the_local_vm() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = project(
+        tmp.path(),
+        "namespace: orders\ncontainers:\n  api:\n    worker: path://./workers/api\n",
+        &[("workers/api", Some(VM_MANIFEST))],
+    );
+
+    assert_eq!(
+        start_of(&file, "api").unwrap(),
+        StartSpec::Vm(VmSpec::Local {
+            worker_dir: tmp.path().join("workers/api"),
+            run_override: None,
+        })
+    );
+}
+
+#[test]
+fn compose_run_overrides_the_manifest_inside_the_local_vm() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = project(
+        tmp.path(),
+        "namespace: orders\ncontainers:\n  api:\n    worker: path://./workers/api\n    scripts:\n      run: python src/dev.py\n",
+        &[("workers/api", Some(VM_MANIFEST))],
+    );
+
+    assert_eq!(
+        start_of(&file, "api").unwrap(),
+        StartSpec::Vm(VmSpec::Local {
+            worker_dir: tmp.path().join("workers/api"),
+            run_override: Some("python src/dev.py".to_string()),
+        })
+    );
+}
+
+#[test]
+fn compose_run_is_enough_for_a_local_vm_without_manifest_start() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = project(
+        tmp.path(),
+        "namespace: orders\ncontainers:\n  api:\n    worker: path://./workers/api\n    scripts:\n      run: python src/dev.py\n",
+        &[(
+            "workers/api",
+            Some("runtime:\n  base_image: docker.io/iiidev/python:latest\n"),
+        )],
+    );
+
+    assert_eq!(
+        start_of(&file, "api").unwrap(),
+        StartSpec::Vm(VmSpec::Local {
+            worker_dir: tmp.path().join("workers/api"),
+            run_override: Some("python src/dev.py".to_string()),
+        })
+    );
+}
+
+#[test]
+fn local_vm_without_any_start_command_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = project(
+        tmp.path(),
+        "namespace: orders\ncontainers:\n  api:\n    worker: path://./workers/api\n",
+        &[(
+            "workers/api",
+            Some("runtime:\n  base_image: docker.io/iiidev/python:latest\n"),
+        )],
+    );
+
+    let error = start_of(&file, "api").expect_err("a VM still needs a start command");
+    assert_eq!(error.code(), "MISSING_START_COMMAND");
+}
+
+#[test]
+fn blank_base_image_keeps_the_host_start() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = project(
+        tmp.path(),
+        "namespace: orders\ncontainers:\n  api:\n    worker: path://./workers/api\n",
+        &[(
+            "workers/api",
+            Some("runtime:\n  base_image: '  '\nscripts:\n  start: cargo run\n"),
+        )],
+    );
+
+    assert_eq!(
+        start_of(&file, "api").unwrap(),
+        StartSpec::Shell("cargo run".to_string())
+    );
+}
+
+#[test]
+fn non_string_base_image_is_an_invalid_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = project(
+        tmp.path(),
+        "namespace: orders\ncontainers:\n  api:\n    worker: path://./workers/api\n",
+        &[(
+            "workers/api",
+            Some("runtime:\n  base_image: 42\nscripts:\n  start: cargo run\n"),
+        )],
+    );
+
+    let error = start_of(&file, "api").expect_err("a numeric image must be rejected");
+    assert_eq!(error.code(), "INVALID_MANIFEST");
 }
 
 #[test]

--- a/crates/iii-worker/src/cli/app.rs
+++ b/crates/iii-worker/src/cli/app.rs
@@ -245,6 +245,10 @@ pub enum Commands {
     #[command(name = "__bundle-prepare", hide = true)]
     BundlePrepare,
 
+    /// Internal: build a local-path worker's VM and print how to start it
+    #[command(name = "__local-prepare", hide = true)]
+    LocalPrepare,
+
     /// Internal: host-side source watcher sidecar for local-path workers
     #[command(name = "__watch-source", hide = true)]
     WatchSource(WatchSourceArgs),

--- a/crates/iii-worker/src/cli/bundle_prepare.rs
+++ b/crates/iii-worker/src/cli/bundle_prepare.rs
@@ -4,7 +4,7 @@
 // This software is patent protected. We welcome discussions - reach out at team@iii.dev
 // See LICENSE and PATENTS files for details.
 
-//! `iii-worker __bundle-prepare`: build a bundle's VM, print how to start it.
+//! Build a compose worker VM and print how to start it.
 //!
 //! The caller is compose, and it reaches this over a process boundary rather
 //! than by linking. That is not indirection for its own sake: libkrun needs
@@ -26,13 +26,15 @@ use serde::{Deserialize, Serialize};
 /// What compose asks for, on stdin.
 #[derive(Debug, Deserialize)]
 pub struct Request {
-    /// The container key, which is also `III_WORKER_NAME` and the name the
-    /// bundle's manifest is checked against.
+    /// The container key, which is also `III_WORKER_NAME`. Bundle manifests
+    /// must match it; local manifests may use another name.
     pub worker_name: String,
-    /// The extracted bundle: holds `iii.worker.yaml`.
-    pub install_dir: PathBuf,
+    /// The bundle install or local worker directory. Older bundle callers used
+    /// `install_dir`, which remains accepted across binary version skew.
+    #[serde(alias = "install_dir")]
+    pub worker_dir: PathBuf,
     /// Per-caller VM state. Keyed by the caller, not by worker name, so two
-    /// projects running the same bundle do not share a rootfs.
+    /// projects using the same container key do not share a rootfs.
     pub state_dir: PathBuf,
     /// Where the guest reaches the engine.
     pub engine_url: String,
@@ -42,6 +44,17 @@ pub struct Request {
     /// Published into the guest at `/run/iii/config`.
     #[serde(default)]
     pub config_dir: Option<PathBuf>,
+    /// Compose's `scripts.run` override. Only local workers use it.
+    #[serde(default)]
+    pub run_override: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum PrepareKind {
+    /// Apply immutable registry-bundle validation and resource limits.
+    Bundle,
+    /// Apply local project validation and workspace behavior.
+    Local,
 }
 
 /// How to start it, on stdout.
@@ -67,35 +80,53 @@ pub use super::local_worker::GUEST_CONFIG_DIR;
 
 /// Reads a [`Request`] from stdin and prints a [`Plan`], or the reason there is
 /// none. Exit code 0 with a plan, 1 with a message on stderr.
-pub async fn run() -> i32 {
+pub async fn run(kind: PrepareKind) -> i32 {
     let mut input = String::new();
     if let Err(err) = std::io::Read::read_to_string(&mut std::io::stdin(), &mut input) {
-        eprintln!("__bundle-prepare: cannot read the request: {err}");
+        eprintln!("VM prepare: cannot read the request: {err}");
         return 1;
     }
 
     let request: Request = match serde_json::from_str(&input) {
         Ok(request) => request,
         Err(err) => {
-            eprintln!("__bundle-prepare: the request is not valid JSON: {err}");
+            eprintln!("VM prepare: the request is not valid JSON: {err}");
             return 1;
         }
     };
 
+    let Request {
+        worker_name,
+        worker_dir,
+        state_dir,
+        engine_url,
+        extra_env,
+        config_dir,
+        run_override,
+    } = request;
+
     let over = super::local_worker::VmOverride {
-        state_dir: request.state_dir,
-        engine_url: &request.engine_url,
-        extra_env: request.extra_env.into_iter().collect(),
-        config_dir: request.config_dir,
+        state_dir,
+        engine_url: &engine_url,
+        extra_env: extra_env.into_iter().collect(),
+        config_dir,
     };
 
-    let built = match super::local_worker::bundle_vm_command(
-        &request.worker_name,
-        &request.install_dir,
-        over,
-    )
-    .await
-    {
+    let built = match kind {
+        PrepareKind::Bundle => {
+            super::local_worker::bundle_vm_command(&worker_name, &worker_dir, over).await
+        }
+        PrepareKind::Local => {
+            super::local_worker::local_vm_command(
+                &worker_name,
+                &worker_dir,
+                run_override.as_deref(),
+                over,
+            )
+            .await
+        }
+    };
+    let built = match built {
         Ok(built) => built,
         Err(err) => {
             eprintln!("{err}");
@@ -110,7 +141,7 @@ pub async fn run() -> i32 {
             0
         }
         Err(err) => {
-            eprintln!("__bundle-prepare: cannot serialise the plan: {err}");
+            eprintln!("VM prepare: cannot serialise the plan: {err}");
             1
         }
     }
@@ -142,5 +173,37 @@ fn describe(built: &super::worker_manager::libkrun::VmCommand) -> Plan {
             .map(|(key, _)| key.to_string_lossy().into_owned())
             .collect(),
         pid_file: built.pid_file.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_accepts_the_legacy_bundle_install_dir_field() {
+        let request: Request = serde_json::from_value(serde_json::json!({
+            "worker_name": "probe",
+            "install_dir": "/tmp/probe",
+            "state_dir": "/tmp/state",
+            "engine_url": "ws://localhost:49134"
+        }))
+        .expect("the previous bundle request must remain compatible");
+
+        assert_eq!(request.worker_dir, PathBuf::from("/tmp/probe"));
+    }
+
+    #[test]
+    fn request_reads_the_local_run_override() {
+        let request: Request = serde_json::from_value(serde_json::json!({
+            "worker_name": "probe",
+            "worker_dir": "/tmp/probe",
+            "state_dir": "/tmp/state",
+            "engine_url": "ws://localhost:49134",
+            "run_override": "python src/dev.py"
+        }))
+        .expect("the local request should parse");
+
+        assert_eq!(request.run_override.as_deref(), Some("python src/dev.py"));
     }
 }

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -883,6 +883,7 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
         /*disable_watcher=*/ false,
         /*is_bundle=*/ false,
         None,
+        None,
     )
     .await
     {
@@ -923,12 +924,81 @@ pub async fn start_bundle_worker(worker_name: &str, worker_path: &str, port: u16
         /*disable_watcher=*/ true,
         /*is_bundle=*/ true,
         None,
+        None,
     )
     .await
     {
         VmStart::Exit(code) => code,
         VmStart::Plan(_) => 1,
     }
+}
+
+/// Builds the VM for a local-path worker without starting it.
+///
+/// Compose owns the child lifecycle, so this returns the boot command and uses
+/// caller-scoped VM state. Local manifest rules still apply: setup and install
+/// are allowed, resources are not bundle-clamped, and the manifest name does
+/// not have to match the compose container key.
+pub async fn local_vm_command(
+    worker_name: &str,
+    worker_dir: &Path,
+    run_override: Option<&str>,
+    over: VmOverride<'_>,
+) -> Result<super::worker_manager::libkrun::VmCommand, String> {
+    validate_compose_base_image(worker_dir)?;
+
+    match start_worker_impl(
+        worker_name,
+        &worker_dir.to_string_lossy(),
+        // The guest reaches the engine through `over.engine_url`; no port is
+        // derived here.
+        0,
+        // Compose supervises the VM itself. A detached, name-keyed watcher
+        // could restart a different project that uses the same container key.
+        /*disable_watcher=*/
+        true,
+        /*is_bundle=*/ false,
+        Some(over),
+        run_override,
+    )
+    .await
+    {
+        VmStart::Plan(built) => Ok(*built),
+        VmStart::Exit(_) => Err(format!(
+            "could not prepare the VM for local worker '{worker_name}'"
+        )),
+    }
+}
+
+/// Compose selects a local VM only for an explicit, valid OCI image. The
+/// regular local-worker CLI keeps its warning-and-fallback behavior; compose
+/// must not silently change an invalid VM request into another image.
+fn validate_compose_base_image(worker_dir: &Path) -> Result<(), String> {
+    let manifest_path = worker_dir.join(WORKER_MANIFEST);
+    let doc = super::project::read_manifest_doc(&manifest_path)?
+        .ok_or_else(|| format!("{} does not exist", manifest_path.display()))?;
+    let value = doc
+        .get("runtime")
+        .and_then(|runtime| runtime.get("base_image"))
+        .ok_or_else(|| {
+            format!(
+                "{} must declare `runtime.base_image` to run as a compose VM",
+                manifest_path.display()
+            )
+        })?;
+    let image = value.as_str().map(str::trim).ok_or_else(|| {
+        format!(
+            "{}: `runtime.base_image` must be a string",
+            manifest_path.display()
+        )
+    })?;
+    if !super::project::is_plausible_image_ref(image) {
+        return Err(format!(
+            "{}: `runtime.base_image` must be a plausible OCI image reference",
+            manifest_path.display()
+        ));
+    }
+    Ok(())
 }
 
 /// Builds the VM for an installed bundle worker without starting it.
@@ -963,6 +1033,7 @@ pub async fn bundle_vm_command(
         /*disable_watcher=*/ true,
         /*is_bundle=*/ true,
         Some(over),
+        None,
     )
     .await
     {
@@ -991,8 +1062,8 @@ pub async fn bundle_vm_command(
 /// Without one, the worker name is the whole identity: state lands in
 /// `~/.iii/managed/<worker_name>` and a start first kills whatever else answers
 /// to that name. Compose cannot live with either — two of its projects may
-/// legitimately run the same bundle under the same container key, and killing
-/// by name would stop the other project's VM.
+/// legitimately use the same container key, and killing by name would stop the
+/// other project's VM.
 pub struct VmOverride<'a> {
     /// Per-caller VM state: rootfs (or overlay trampoline), boot script, pid
     /// file. Replaces the name-keyed managed dir.
@@ -1028,6 +1099,7 @@ async fn start_worker_impl(
     disable_watcher: bool,
     is_bundle: bool,
     over: Option<VmOverride<'_>>,
+    run_override: Option<&str>,
 ) -> VmStart {
     // Kill any stale process from a previous engine run. Skipped when the
     // caller owns the VM's identity: the name is not unique across projects
@@ -1100,7 +1172,7 @@ async fn start_worker_impl(
     }
 
     // 2. Detect language
-    let project = match load_project_info(project_path) {
+    let mut project = match load_project_info(project_path) {
         Some(p) => p,
         None => {
             eprintln!(
@@ -1111,6 +1183,10 @@ async fn start_worker_impl(
             return VmStart::Exit(1);
         }
     };
+
+    if let Some(run_override) = run_override {
+        project.run_cmd = run_override.to_string();
+    }
 
     if let Err(msg) = project.validate() {
         eprintln!("{} {}", "error:".red(), msg);

--- a/crates/iii-worker/src/main.rs
+++ b/crates/iii-worker/src/main.rs
@@ -555,7 +555,20 @@ async fn async_main() -> anyhow::Result<()> {
         },
         Commands::SandboxDaemon(args) => iii_worker::cli::sandbox_daemon::run(args).await,
         Commands::BundlePrepare => {
-            std::process::exit(iii_worker::cli::bundle_prepare::run().await);
+            std::process::exit(
+                iii_worker::cli::bundle_prepare::run(
+                    iii_worker::cli::bundle_prepare::PrepareKind::Bundle,
+                )
+                .await,
+            );
+        }
+        Commands::LocalPrepare => {
+            std::process::exit(
+                iii_worker::cli::bundle_prepare::run(
+                    iii_worker::cli::bundle_prepare::PrepareKind::Local,
+                )
+                .await,
+            );
         }
         Commands::VmBoot(args) => {
             // Run the VM on a dedicated OS thread: `msb_krun`'s virtio-blk

--- a/crates/iii-worker/tests/local_vm_command.rs
+++ b/crates/iii-worker/tests/local_vm_command.rs
@@ -1,0 +1,81 @@
+//! Compose-facing local VM preparation.
+
+use std::path::Path;
+
+use iii_worker::cli::local_worker::{VmOverride, local_vm_command};
+
+fn worker_dir(tmp: &Path, manifest: &str) -> std::path::PathBuf {
+    let dir = tmp.join("worker");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("iii.worker.yaml"), manifest).unwrap();
+    dir
+}
+
+fn over(tmp: &Path) -> VmOverride<'static> {
+    VmOverride {
+        state_dir: tmp.join("vm"),
+        engine_url: "ws://localhost:49134",
+        extra_env: std::collections::HashMap::new(),
+        config_dir: None,
+    }
+}
+
+#[tokio::test]
+async fn a_missing_base_image_is_refused_before_vm_setup() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = worker_dir(
+        tmp.path(),
+        "name: probe\nscripts:\n  start: python src/main.py\n",
+    );
+
+    let error = local_vm_command("probe", &dir, None, over(tmp.path()))
+        .await
+        .err()
+        .expect("compose local VM preparation requires base_image");
+    assert!(error.contains("runtime.base_image"), "{error}");
+}
+
+#[tokio::test]
+async fn an_implausible_base_image_is_refused_before_vm_setup() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = worker_dir(
+        tmp.path(),
+        "name: probe\nruntime:\n  base_image: 'bad image!'\nscripts:\n  start: python src/main.py\n",
+    );
+
+    let error = local_vm_command("probe", &dir, None, over(tmp.path()))
+        .await
+        .err()
+        .expect("an invalid OCI reference must be rejected");
+    assert!(error.contains("plausible OCI image"), "{error}");
+}
+
+/// The success path prepares a rootfs and therefore may pull the declared OCI
+/// image. It also proves that a compose container key may replace the manifest
+/// name and start command for a local project.
+#[tokio::test]
+#[ignore = "pulls an OCI base image"]
+async fn a_local_worker_builds_a_boot_command_with_the_compose_run_override() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = worker_dir(
+        tmp.path(),
+        "name: manifest-name\nruntime:\n  base_image: docker.io/iiidev/python:latest\nscripts:\n  install: pip install -e .\n",
+    );
+
+    let built = local_vm_command(
+        "compose-name",
+        &dir,
+        Some("python src/dev.py"),
+        over(tmp.path()),
+    )
+    .await
+    .expect("a valid local worker should build");
+
+    let rendered = format!("{:?}", built.command.as_std());
+    assert!(rendered.contains("__vm-boot"), "{rendered}");
+
+    let script = std::fs::read_to_string(tmp.path().join("vm/runtime/dev-run.sh"))
+        .or_else(|_| std::fs::read_to_string(tmp.path().join("vm/opt/iii/dev-run.sh")))
+        .expect("VM preparation should write its run script");
+    assert!(script.contains("python src/dev.py"), "{script}");
+}

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -501,6 +501,11 @@ Each key under `containers` is the worker name the container registers under.
 `MISSING_WORKER_DIRECTORY`, and a missing `env_file` fails with `MISSING_ENV_FILE` during
 validation.
 
+A path worker normally runs as a host process. A non-empty `runtime.base_image` in its
+`iii.worker.yaml` selects a local VM instead. The worker's `scripts.install` and start command then
+run inside that image, and compose keeps the VM state inside the project. An invalid image reference
+fails the start instead of falling back to the host or to another image.
+
 ### Worker kinds
 
 The registry answers with a kind, and it decides how the container runs. A kind compose cannot run
@@ -521,8 +526,8 @@ honours.
 
 A bundle's VM is booted by `iii-worker`, which the installer ships beside `iii` and which needs
 glibc on Linux. Compose runs it as a process rather than linking it, so the engine stays portable;
-a bundle container on a machine without `iii-worker` fails saying so, and every other worker kind
-is unaffected.
+a VM container on a machine without `iii-worker` fails saying so, and every host worker is
+unaffected.
 
 Bundles need a VM, and windows has none: a bundle container there fails with
 `BUNDLE_NEEDS_A_VM` before anything is downloaded. Run compose under WSL, where the VM has KVM to
@@ -541,6 +546,10 @@ Both hooks run with the container's environment, working directory, and their ow
 
 The start command for a `path://` container is `run`, then `scripts.start` from the worker's
 `iii.worker.yaml`. A container with neither fails with `MISSING_START_COMMAND`.
+
+When the manifest declares `runtime.base_image`, the same precedence applies inside the VM: `run`
+replaces `scripts.start`, but it never moves the worker back to the host. Host source changes do not
+automatically restart this VM. Use `compose::restart worker=<container>` after a source change.
 
 Where the two files describe the same thing, `worker-compose.yaml` wins and the manifest is the
 default. `run` overrides `scripts.start`, and the container key overrides the manifest's `name`: the
@@ -665,7 +674,7 @@ Everything sits under `~/.iii/compose`, or under `$III_COMPOSE_STATE_DIR` when t
 | `<ns>/<project>/state.json` | One project's child records. Owner-only.             |
 | `<ns>/<project>/config/`    | Resolved configuration files.                        |
 | `<ns>/<project>/logs/`      | Rotating stdout and stderr for every project worker.  |
-| `<ns>/<project>/vm/`        | VM state for bundle containers, one directory each, plus the config each one publishes into its guest. |
+| `<ns>/<project>/vm/`        | VM state for bundle and local-image containers, one directory each, plus the config each one publishes into its guest. |
 | `packages/`                 | Installed `package://` artefacts, shared by projects. |
 
 `<ns>` is the daemon's namespace. `<project>` is derived from the compose file's canonical path:

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -495,6 +495,11 @@ Each key under `containers` is the worker name the container registers under.
 `MISSING_WORKER_DIRECTORY`, and a missing `env_file` fails with `MISSING_ENV_FILE` during
 validation.
 
+A path worker normally runs as a host process. A non-empty `runtime.base_image` in its
+`iii.worker.yaml` selects a local VM instead. The worker's `scripts.install` and start command then
+run inside that image, and compose keeps the VM state inside the project. An invalid image reference
+fails the start instead of falling back to the host or to another image.
+
 ### Worker kinds
 
 The registry answers with a kind, and it decides how the container runs. A kind compose cannot run
@@ -515,8 +520,8 @@ honours.
 
 A bundle's VM is booted by `iii-worker`, which the installer ships beside `iii` and which needs
 glibc on Linux. Compose runs it as a process rather than linking it, so the engine stays portable;
-a bundle container on a machine without `iii-worker` fails saying so, and every other worker kind
-is unaffected.
+a VM container on a machine without `iii-worker` fails saying so, and every host worker is
+unaffected.
 
 Bundles need a VM, and windows has none: a bundle container there fails with
 `BUNDLE_NEEDS_A_VM` before anything is downloaded. Run compose under WSL, where the VM has KVM to
@@ -535,6 +540,10 @@ Both hooks run with the container's environment, working directory, and their ow
 
 The start command for a `path://` container is `run`, then `scripts.start` from the worker's
 `iii.worker.yaml`. A container with neither fails with `MISSING_START_COMMAND`.
+
+When the manifest declares `runtime.base_image`, the same precedence applies inside the VM: `run`
+replaces `scripts.start`, but it never moves the worker back to the host. Host source changes do not
+automatically restart this VM. Use `compose::restart worker=<container>` after a source change.
 
 Where the two files describe the same thing, `worker-compose.yaml` wins and the manifest is the
 default. `run` overrides `scripts.start`, and the container key overrides the manifest's `name`: the
@@ -659,7 +668,7 @@ Everything sits under `~/.iii/compose`, or under `$III_COMPOSE_STATE_DIR` when t
 | `<ns>/<project>/state.json` | One project's child records. Owner-only.             |
 | `<ns>/<project>/config/`    | Resolved configuration files.                        |
 | `<ns>/<project>/logs/`      | Rotating stdout and stderr for every project worker.  |
-| `<ns>/<project>/vm/`        | VM state for bundle containers, one directory each, plus the config each one publishes into its guest. |
+| `<ns>/<project>/vm/`        | VM state for bundle and local-image containers, one directory each, plus the config each one publishes into its guest. |
 | `packages/`                 | Installed `package://` artefacts, shared by projects. |
 
 `<ns>` is the daemon's namespace. `<project>` is derived from the compose file's canonical path:


### PR DESCRIPTION
## Summary

- detect non-empty `runtime.base_image` values for local path workers and run those workers in project-scoped VMs
- add a local VM prepare path to `iii-worker` while preserving local install behavior and compose `scripts.run` precedence
- document host versus VM behavior and cover manifest selection, validation, and VM command generation

## Testing

- `cargo fmt --all --check`
- `cargo build -p iii-compose -p iii-worker --locked`
- `cargo test -p iii-compose --locked`
- `cargo test -p iii-worker --lib --locked`
- `cargo test -p iii-worker --test bundle_vm_command --test local_vm_command --locked`
- `cargo test -p iii-worker --test local_vm_command a_local_worker_builds_a_boot_command_with_the_compose_run_override -- --ignored --exact`
- `cargo clippy -p iii-compose --all-targets --locked --no-deps -- -D warnings`
- `cargo clippy -p iii-worker --all-targets --locked --no-deps` (passes with existing warnings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local VM execution for path-based workers that define a runtime base image.
  * Added support for overriding the command run inside local worker VMs.
  * Added VM preparation support for both bundled and local workers.
  * Exposed VM specifications through the public API.

* **Bug Fixes**
  * Added validation for missing or invalid base images and missing start commands.

* **Documentation**
  * Documented local VM execution, command precedence, VM state handling, and restart requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->