### PR TITLE
Fix namespaced observability UI and live trace updates

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -641,6 +641,11 @@ impl Engine {
     /// the target of an invoke depend on who is asking, which is exactly the
     /// ambiguity namespaces exist to remove.
     ///
+    /// The sole compatibility exception is the immutable built-in
+    /// `iii-observability` UI content callback: published Console workers do
+    /// not preserve its explicit `default` target and invoke it from their
+    /// project namespace. No user function participates in that fallback.
+    ///
     /// A miss keeps the pre-existing `function_not_found` code (SDKs and the
     /// `Enqueue` provider-missing DX branch both match on it) and only enriches
     /// the message with the namespaces where the id *does* exist.
@@ -651,6 +656,19 @@ impl Engine {
     ) -> Result<Function, ErrorBody> {
         let namespace = requested_ns.unwrap_or(DEFAULT_NAMESPACE);
         if let Some(function) = self.functions.get(namespace, function_id) {
+            return Ok(function);
+        }
+
+        // Console releases published before namespace-aware trigger callbacks
+        // invoke injected UI content in the Console worker's project namespace,
+        // even when the binding targets `default`. This function serves only
+        // immutable embedded JS/CSS, so let that one legacy callback resolve to
+        // its canonical engine-owned registration without weakening namespace
+        // isolation for any other function.
+        if namespace != DEFAULT_NAMESPACE
+            && function_id == crate::workers::observability::ui::CONTENT_FUNCTION_ID
+            && let Some(function) = self.functions.get(DEFAULT_NAMESPACE, function_id)
+        {
             return Ok(function);
         }
 
@@ -1280,6 +1298,29 @@ impl Engine {
                             }
                         }
                     }
+                }
+
+                // Built-in UI functions live in the engine's `default`
+                // namespace, but Console trigger providers live with their
+                // Compose project. Install one strict asset binding for this
+                // provider before publishing the type, so the pending drain
+                // below delivers it to the correct Console. Existing bindings
+                // are left alone and get replayed by register_trigger_type on
+                // reconnect.
+                if let Err(error) =
+                    crate::workers::observability::ui::register_trigger_for_provider(
+                        self,
+                        &reg_id,
+                        &provider_namespace,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        error = %error,
+                        trigger_type_id = %reg_id,
+                        namespace = %provider_namespace,
+                        "failed to bind built-in observability UI to Console provider"
+                    );
                 }
 
                 let mut trigger_type = TriggerType::new_ns(
@@ -5927,6 +5968,195 @@ mod tests {
             engine.trigger_registry.trigger_types.is_empty(),
             "a provider with no namespace to serve must not be filed anywhere"
         );
+    }
+
+    #[tokio::test]
+    async fn published_console_can_resolve_builtin_observability_content_from_project_namespace() {
+        ensure_default_meter();
+        let engine = Arc::new(Engine::new());
+        crate::workers::observability::ui::register_function(&engine);
+
+        let function = engine
+            .resolve_function(
+                Some("harness-ns"),
+                crate::workers::observability::ui::CONTENT_FUNCTION_ID,
+            )
+            .expect("published Console callback should resolve canonical content");
+        let page = function
+            .call_handler(
+                None,
+                json!({ "path": crate::workers::observability::ui::PAGE_PATH }),
+                None,
+            )
+            .await;
+        let FunctionResult::Success(Some(page)) = page else {
+            panic!("resolved content handler should serve the page");
+        };
+        assert_eq!(page["content_type"], "text/javascript; charset=utf-8");
+
+        let Err(unrelated) = engine.resolve_function(Some("harness-ns"), "unrelated::default-only")
+        else {
+            panic!("compatibility fallback must not apply to other functions");
+        };
+        assert_eq!(unrelated.code, "function_not_found");
+    }
+
+    #[tokio::test]
+    async fn console_provider_receives_builtin_observability_assets_in_its_namespace() {
+        ensure_default_meter();
+        let engine = Engine::new();
+
+        crate::workers::observability::ui::register_triggers(&engine)
+            .await
+            .expect("no Console provider is a valid initial state");
+        assert!(engine.trigger_registry.pending_triggers.is_empty());
+
+        let (provider_tx, mut provider_rx) = mpsc::channel::<Outbound>(8);
+        let provider = WorkerConnection::new(provider_tx);
+
+        for (trigger_type, expected_id, expected_path) in [
+            (
+                "console:script",
+                "iii-observability::ui-page@harness-ns",
+                "iii-observability/page.js",
+            ),
+            (
+                "console:style",
+                "iii-observability::ui-styles@harness-ns",
+                "iii-observability/styles.css",
+            ),
+        ] {
+            engine
+                .router_msg(
+                    &provider,
+                    &Message::RegisterTriggerType {
+                        id: trigger_type.to_string(),
+                        description: format!("{trigger_type} provider"),
+                        trigger_request_format: None,
+                        call_request_format: None,
+                        namespace: Some("harness-ns".to_string()),
+                    },
+                )
+                .await
+                .expect("Console trigger type should register");
+
+            let outbound = provider_rx
+                .try_recv()
+                .expect("Console provider should receive the built-in asset binding");
+            let Outbound::Protocol(Message::RegisterTrigger {
+                id,
+                function_id,
+                config,
+                namespace,
+                trigger_namespace,
+                ..
+            }) = outbound
+            else {
+                panic!("expected RegisterTrigger, got {outbound:?}");
+            };
+
+            assert_eq!(id, expected_id);
+            assert_eq!(function_id, "iii-observability::ui-content");
+            assert_eq!(config["path"], expected_path);
+            assert_eq!(
+                namespace.as_deref(),
+                None,
+                "the canonical content function lives in default"
+            );
+            assert_eq!(trigger_namespace.as_deref(), Some("harness-ns"));
+
+            let stored = engine
+                .trigger_registry
+                .triggers
+                .get(expected_id)
+                .expect("asset binding should be live");
+            assert_eq!(stored.provider_namespace, "harness-ns");
+            assert_eq!(stored.namespace, DEFAULT_NAMESPACE);
+        }
+
+        assert!(engine.trigger_registry.pending_triggers.is_empty());
+        assert!(
+            provider_rx.try_recv().is_err(),
+            "assets must bind once each"
+        );
+    }
+
+    #[tokio::test]
+    async fn builtin_observability_assets_are_isolated_and_replayed_per_console_namespace() {
+        ensure_default_meter();
+        let engine = Engine::new();
+
+        let register_script = |namespace: &str| Message::RegisterTriggerType {
+            id: "console:script".to_string(),
+            description: "Console script provider".to_string(),
+            trigger_request_format: None,
+            call_request_format: None,
+            namespace: Some(namespace.to_string()),
+        };
+
+        let (a_tx, mut a_rx) = mpsc::channel::<Outbound>(8);
+        let provider_a = WorkerConnection::new(a_tx);
+        engine
+            .router_msg(&provider_a, &register_script("project-a"))
+            .await
+            .expect("project A provider should register");
+
+        let (b_tx, mut b_rx) = mpsc::channel::<Outbound>(8);
+        let provider_b = WorkerConnection::new(b_tx);
+        engine
+            .router_msg(&provider_b, &register_script("project-b"))
+            .await
+            .expect("project B provider should register");
+
+        let asset_id = |outbound: Outbound| match outbound {
+            Outbound::Protocol(Message::RegisterTrigger { id, .. }) => id,
+            other => panic!("expected RegisterTrigger, got {other:?}"),
+        };
+        assert_eq!(
+            asset_id(a_rx.try_recv().expect("project A asset")),
+            "iii-observability::ui-page@project-a"
+        );
+        assert_eq!(
+            asset_id(b_rx.try_recv().expect("project B asset")),
+            "iii-observability::ui-page@project-b"
+        );
+
+        assert_eq!(
+            engine
+                .trigger_registry
+                .triggers
+                .get("iii-observability::ui-page@project-a")
+                .expect("project A binding")
+                .provider_namespace,
+            "project-a"
+        );
+        assert_eq!(
+            engine
+                .trigger_registry
+                .triggers
+                .get("iii-observability::ui-page@project-b")
+                .expect("project B binding")
+                .provider_namespace,
+            "project-b"
+        );
+
+        // A replacement provider gets the existing binding replayed exactly
+        // once; the observability hook must not create a duplicate.
+        let (replacement_tx, mut replacement_rx) = mpsc::channel::<Outbound>(8);
+        let replacement = WorkerConnection::new(replacement_tx);
+        engine
+            .router_msg(&replacement, &register_script("project-a"))
+            .await
+            .expect("replacement provider should register");
+        assert_eq!(
+            asset_id(replacement_rx.try_recv().expect("replayed project A asset")),
+            "iii-observability::ui-page@project-a"
+        );
+        assert!(
+            replacement_rx.try_recv().is_err(),
+            "replacement must receive one replay"
+        );
+        assert_eq!(engine.trigger_registry.triggers.len(), 2);
     }
 
     #[tokio::test]

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -2144,6 +2144,7 @@ impl ObservabilityWorker {
                 });
 
                 let engine = engine.clone();
+                let namespace = trigger.namespace.clone();
                 let function_id = trigger.function_id.clone();
                 // Trigger metadata must ride along (state/stream/cron parity):
                 // remote consumers key delivery routing on it.
@@ -2151,7 +2152,7 @@ impl ObservabilityWorker {
 
                 tokio::spawn(async move {
                     let _ = engine
-                        .call_with_metadata(&function_id, log_data, metadata)
+                        .call_with_metadata_ns(&namespace, &function_id, log_data, metadata)
                         .await;
                 });
             }
@@ -2324,11 +2325,11 @@ impl ObservabilityWorker {
     /// `{ trace_ids: [...] }` payload — the distinct traces touched in the
     /// window that match its filter — rather than per-span full payloads.
     ///
-    /// The handler is invoked fire-and-forget via `engine.call`; results are
-    /// ignored. NOTE: that `engine.call` is itself instrumented as a span, so
-    /// the subscriber MUST exclude trigger-delivery spans before they reach
-    /// here (see `run_trace_trigger_subscriber`) or the trigger would re-fire
-    /// on its own delivery — an unbounded feedback loop.
+    /// The handler is invoked fire-and-forget in the trigger's function
+    /// namespace; results are ignored. NOTE: that engine call is itself
+    /// instrumented as a span, so the subscriber MUST exclude trigger-delivery
+    /// spans before they reach here (see `run_trace_trigger_subscriber`) or the
+    /// trigger would re-fire on its own delivery — an unbounded feedback loop.
     async fn fire_trace_triggers(
         triggers: &Arc<OtelTraceTriggers>,
         engine: &Arc<Engine>,
@@ -2354,6 +2355,7 @@ impl ObservabilityWorker {
 
             let payload = serde_json::json!({ "trace_ids": trace_ids });
             let engine = engine.clone();
+            let namespace = trigger.namespace.clone();
             let function_id = trigger.function_id.clone();
             // Trigger metadata must ride along (state/stream/cron parity):
             // remote consumers key delivery routing on it.
@@ -2361,7 +2363,7 @@ impl ObservabilityWorker {
 
             tokio::spawn(async move {
                 let _ = engine
-                    .call_with_metadata(&function_id, payload, metadata)
+                    .call_with_metadata_ns(&namespace, &function_id, payload, metadata)
                     .await;
             });
         }
@@ -4749,13 +4751,15 @@ mod tests {
         }
     }
 
-    fn register_metadata_capture(
+    fn register_metadata_capture_ns(
         engine: &Arc<Engine>,
+        namespace: &str,
         function_id: &str,
     ) -> Arc<std::sync::Mutex<Vec<Option<Value>>>> {
         let captured: Arc<std::sync::Mutex<Vec<Option<Value>>>> =
             Arc::new(std::sync::Mutex::new(Vec::new()));
-        engine.register_function(
+        engine.register_function_ns(
+            namespace,
             crate::engine::RegisterFunctionRequest {
                 function_id: function_id.to_string(),
                 description: None,
@@ -4778,23 +4782,24 @@ mod tests {
         }
     }
 
-    /// Trace trigger deliveries must carry the trigger's registered
-    /// metadata, matching the state/stream/cron fan-outs: remote consumers
-    /// (e.g. session-wake harnesses) key delivery routing on it, and a bare
-    /// `engine.call` (metadata: None) silently starves their gate.
+    /// Trace trigger deliveries must resolve the function in the trigger's
+    /// namespace and carry the trigger's registered metadata, matching the
+    /// state/stream/cron fan-outs. Remote consumers (e.g. session-wake
+    /// harnesses) depend on both for routing.
     #[tokio::test]
-    async fn fire_trace_triggers_delivers_trigger_metadata() {
+    async fn fire_trace_triggers_delivers_to_namespace_with_metadata() {
         // `engine.call` instruments invocations via the global meter; without
         // it the fire-and-forget delivery tasks panic and no payload arrives.
         metrics::ensure_default_meter();
 
         let engine = Arc::new(Engine::new());
-        let captured = register_metadata_capture(&engine, "test::trace-meta");
+        let namespace = "harness-ns";
+        let captured = register_metadata_capture_ns(&engine, namespace, "test::trace-meta");
 
         let triggers = Arc::new(OtelTraceTriggers::new());
         triggers.triggers.write().await.insert(Trigger {
             id: "t-meta".to_string(),
-            namespace: crate::protocol::DEFAULT_NAMESPACE.to_string(),
+            namespace: namespace.to_string(),
             trigger_type: TRACE_TRIGGER_TYPE.to_string(),
             function_id: "test::trace-meta".to_string(),
             config: serde_json::json!({}),
@@ -4816,19 +4821,20 @@ mod tests {
         );
     }
 
-    /// Log trigger deliveries must carry the trigger's registered metadata,
-    /// for the same reason as the trace path.
+    /// Log trigger deliveries have the same namespace and metadata contract as
+    /// the trace path.
     #[tokio::test]
-    async fn log_trigger_delivery_carries_trigger_metadata() {
+    async fn log_trigger_delivery_uses_namespace_and_metadata() {
         metrics::ensure_default_meter();
 
         let engine = Arc::new(Engine::new());
-        let captured = register_metadata_capture(&engine, "test::log-meta");
+        let namespace = "harness-ns";
+        let captured = register_metadata_capture_ns(&engine, namespace, "test::log-meta");
 
         let triggers = Arc::new(OtelLogTriggers::new());
         triggers.triggers.write().await.insert(Trigger {
             id: "t-log-meta".to_string(),
-            namespace: crate::protocol::DEFAULT_NAMESPACE.to_string(),
+            namespace: namespace.to_string(),
             trigger_type: LOG_TRIGGER_TYPE.to_string(),
             function_id: "test::log-meta".to_string(),
             config: serde_json::json!({ "level": "all" }),

--- a/engine/src/workers/observability/ui.rs
+++ b/engine/src/workers/observability/ui.rs
@@ -8,9 +8,9 @@
 //!
 //! The observability worker lives inside the engine rather than in a worker
 //! process, so it owns its Console UI bindings directly in the engine trigger
-//! registry. The Console trigger provider may connect before or after this
-//! module; the registry parks the bindings until `console:script` and
-//! `console:style` become available.
+//! registry. Console providers are namespace-scoped, while the built-in
+//! content function lives in `default`; one binding is therefore installed
+//! for every namespace that provides `console:script` / `console:style`.
 
 use std::sync::Arc;
 
@@ -19,7 +19,7 @@ use serde_json::{Value, json};
 use crate::{
     engine::{Engine, EngineTrait, Handler, RegisterFunctionRequest},
     function::FunctionResult,
-    protocol::ErrorBody,
+    protocol::{DEFAULT_NAMESPACE, ErrorBody},
     trigger::Trigger,
 };
 
@@ -85,36 +85,87 @@ pub fn register_function(engine: &Arc<Engine>) {
     );
 }
 
-/// Register the engine-owned asset bindings.
-pub async fn register_triggers(engine: &Engine) -> anyhow::Result<()> {
-    for (id, trigger_type, path) in [
-        (PAGE_TRIGGER_ID, "console:script", PAGE_PATH),
-        (STYLES_TRIGGER_ID, "console:style", STYLES_PATH),
-    ] {
-        let (trigger_namespace, home_namespace, provider_namespace) =
-            Trigger::internal_namespaces();
+fn asset_for_trigger_type(trigger_type: &str) -> Option<(&'static str, &'static str)> {
+    match trigger_type {
+        "console:script" => Some((PAGE_TRIGGER_ID, PAGE_PATH)),
+        "console:style" => Some((STYLES_TRIGGER_ID, STYLES_PATH)),
+        _ => None,
+    }
+}
 
-        engine
-            .trigger_registry
-            .register_trigger(Trigger {
-                id: id.to_string(),
-                trigger_type: trigger_type.to_string(),
-                function_id: CONTENT_FUNCTION_ID.to_string(),
-                config: json!({ "path": path }),
-                worker_id: None,
-                metadata: Some(json!({
-                    "internal": true,
-                    "source": "builtin",
-                })),
-                namespace: crate::protocol::default_namespace(),
-                trigger_namespace,
-                home_namespace,
-                provider_namespace,
-            })
-            .await
-            .map_err(|error| {
-                anyhow::anyhow!("failed to register Console UI asset {path}: {error:?}")
-            })?;
+fn namespaced_trigger_id(base_id: &str, provider_namespace: &str) -> String {
+    if provider_namespace == DEFAULT_NAMESPACE {
+        base_id.to_string()
+    } else {
+        format!("{base_id}@{provider_namespace}")
+    }
+}
+
+/// Ensure the engine-owned asset binding exists for one Console provider.
+///
+/// This runs immediately before a Console trigger type is registered. On the
+/// first connection the binding parks briefly and is drained by that type
+/// registration; on reconnect it already exists and the trigger registry
+/// replays it to the replacement provider.
+pub(crate) async fn register_trigger_for_provider(
+    engine: &Engine,
+    trigger_type: &str,
+    provider_namespace: &str,
+) -> anyhow::Result<()> {
+    let Some((base_id, path)) = asset_for_trigger_type(trigger_type) else {
+        return Ok(());
+    };
+    let id = namespaced_trigger_id(base_id, provider_namespace);
+
+    if engine.trigger_registry.triggers.contains_key(&id)
+        || engine.trigger_registry.pending_triggers.contains_key(&id)
+    {
+        return Ok(());
+    }
+
+    engine
+        .trigger_registry
+        .register_trigger(Trigger {
+            id,
+            trigger_type: trigger_type.to_string(),
+            function_id: CONTENT_FUNCTION_ID.to_string(),
+            config: json!({ "path": path }),
+            worker_id: None,
+            metadata: Some(json!({
+                "internal": true,
+                "source": "builtin",
+            })),
+            // The content function is engine-owned and remains in `default`.
+            namespace: crate::protocol::default_namespace(),
+            // The provider is strict so one project's asset cannot be sent to
+            // another project's Console when both share an engine.
+            trigger_namespace: Some(provider_namespace.to_string()),
+            home_namespace: provider_namespace.to_string(),
+            provider_namespace: provider_namespace.to_string(),
+        })
+        .await
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "failed to register Console UI asset {path} in namespace {provider_namespace}: {error:?}"
+            )
+        })?;
+
+    Ok(())
+}
+
+/// Register bindings for Console providers that already exist (for example
+/// when the observability worker is hot-reloaded after Console connected).
+pub async fn register_triggers(engine: &Engine) -> anyhow::Result<()> {
+    let providers: Vec<(String, String)> = engine
+        .trigger_registry
+        .trigger_types
+        .iter()
+        .filter(|entry| asset_for_trigger_type(&entry.value().id).is_some())
+        .map(|entry| (entry.value().id.clone(), entry.value().namespace.clone()))
+        .collect();
+
+    for (trigger_type, provider_namespace) in providers {
+        register_trigger_for_provider(engine, &trigger_type, &provider_namespace).await?;
     }
 
     Ok(())
@@ -160,10 +211,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trigger_registration_is_deferred_until_console_provider_exists() {
+    async fn trigger_registration_waits_until_console_provider_exists() {
         let engine = Engine::new();
         register_triggers(&engine)
             .await
-            .expect("missing Console provider should park, not fail");
+            .expect("missing Console provider should be a no-op");
+        assert!(engine.trigger_registry.triggers.is_empty());
+        assert!(engine.trigger_registry.pending_triggers.is_empty());
+    }
+
+    #[test]
+    fn namespaced_ids_preserve_the_default_ids_and_isolate_projects() {
+        assert_eq!(
+            namespaced_trigger_id(PAGE_TRIGGER_ID, DEFAULT_NAMESPACE),
+            PAGE_TRIGGER_ID
+        );
+        assert_eq!(
+            namespaced_trigger_id(PAGE_TRIGGER_ID, "harness-ns"),
+            "iii-observability::ui-page@harness-ns"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- publish the built-in `iii-observability` Console script and stylesheet for each Console provider namespace
- preserve strict namespace isolation while allowing published Console releases to resolve the immutable built-in UI content callback
- deliver trace and log trigger callbacks in the trigger function's namespace
- keep trace-trigger delivery spans out of the live feed to prevent recursive trace growth

## Root cause

Compose projects register the Console trigger providers and live trace callbacks in their project namespace. The built-in observability bindings were registered only for `default`, while trace and log fan-out invoked callbacks through the default-only engine helper. As a result, a fresh `iii project init -t harness` could miss the observability configuration UI and namespaced live updates.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p iii --lib trace_subscriber -- --nocapture`
- `cargo test -p iii --lib pending_internal_span_is_still_filtered_from_trigger_feed -- --nocapture`
- `cargo test -p iii --lib` — 1,751 passed, 0 failed, 1 ignored
- `cargo check -p iii`
- `cargo build -p iii --release`

Fresh Harness runtime using the release binary:

- initialized with `iii project init -t harness`
- brought up all 14 declared workers in `harness-ns`
- registered `iii-observability::ui-page@harness-ns` and `iii-observability::ui-styles@harness-ns`
- resolved the built-in page from `harness-ns` (43,409 bytes)
- namespaced trace callback received events after load and stayed stable at 2 events over the following 5 seconds
- engine health remained healthy, archive completeness was complete, and known dropped spans remained 0

Related: MOT-4490


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Observability UI assets are now available independently within each Console namespace.
  * Log and trace notifications are delivered to handlers in the correct namespace.
  * Built-in observability UI content remains available when requested from supported non-default namespaces.

* **Bug Fixes**
  * Improved namespace isolation for observability triggers and UI assets.
  * Prevented duplicate or unnecessary asset-trigger registrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->