### PR TITLE
(MOT-3944) fix(engine,sdk): scope queue providers by namespace

### DIFF
--- a/console/packages/console-rust/src/main.rs
+++ b/console/packages/console-rust/src/main.rs
@@ -171,6 +171,7 @@ async fn main() -> Result<()> {
             headers: None,
             // Resolved from III_NAMESPACE by the SDK when unset.
             namespace: None,
+            identity: Default::default(),
         },
     );
 

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -1803,45 +1803,57 @@ impl Engine {
 
                         tokio::spawn(
                             async move {
-                                let mut enqueue_input = serde_json::json!({
-                                    "queue": queue.clone(),
-                                    "function_id": function_id.clone(),
-                                    "data": data,
-                                    "messageReceiptId": message_receipt_id.clone(),
-                                    "traceparent": traceparent.clone(),
-                                    "baggage": queued_baggage,
-                                });
-                                // The standalone queue predates namespaces and
-                                // strictly rejects unknown request fields. Keep
-                                // the default namespace wire-compatible with
-                                // those releases; only a non-default target
-                                // needs the additive field understood by a
-                                // namespace-aware queue provider.
-                                if target_namespace != DEFAULT_NAMESPACE {
-                                    enqueue_input["namespace"] =
-                                        Value::String(target_namespace.clone());
-                                }
-                                // New queue workers register the provider in
-                                // the target project namespace. Old releases
-                                // registered it in `default`, so use that only
-                                // when the project-scoped provider is absent.
-                                let provider_namespace = if engine
+                                let has_target_provider = engine
                                     .functions
                                     .get(&target_namespace, ENQUEUE_PROVIDER_FUNCTION_ID)
-                                    .is_some()
+                                    .is_some();
+                                let has_legacy_default_provider = target_namespace
+                                    != DEFAULT_NAMESPACE
+                                    && engine
+                                        .functions
+                                        .get(DEFAULT_NAMESPACE, ENQUEUE_PROVIDER_FUNCTION_ID)
+                                        .is_some();
+
+                                // A legacy provider in `default` rejects the
+                                // additive namespace field. Omitting the field
+                                // would enqueue the target function in the
+                                // wrong namespace, so fail before invoking it.
+                                let result = if !has_target_provider && has_legacy_default_provider
                                 {
-                                    target_namespace.as_str()
+                                    Err(ErrorBody::new(
+                                        "queue_provider_namespace_unsupported",
+                                        format!(
+                                            "The queue provider in `{DEFAULT_NAMESPACE}` cannot \
+                                             enqueue functions in namespace `{target_namespace}`. \
+                                             Update the queue worker to a namespace-aware release \
+                                             and register it in `{target_namespace}`."
+                                        ),
+                                    ))
                                 } else {
-                                    DEFAULT_NAMESPACE
+                                    let mut enqueue_input = serde_json::json!({
+                                        "queue": queue.clone(),
+                                        "function_id": function_id.clone(),
+                                        "data": data,
+                                        "messageReceiptId": message_receipt_id.clone(),
+                                        "traceparent": traceparent.clone(),
+                                        "baggage": queued_baggage,
+                                    });
+                                    // The default namespace remains compatible
+                                    // with old providers. A scoped provider gets
+                                    // the namespace needed by its consumer.
+                                    if target_namespace != DEFAULT_NAMESPACE {
+                                        enqueue_input["namespace"] =
+                                            Value::String(target_namespace.clone());
+                                    }
+                                    engine
+                                        .call_with_metadata_ns(
+                                            &target_namespace,
+                                            ENQUEUE_PROVIDER_FUNCTION_ID,
+                                            enqueue_input,
+                                            None,
+                                        )
+                                        .await
                                 };
-                                let result = engine
-                                    .call_with_metadata_ns(
-                                        provider_namespace,
-                                        ENQUEUE_PROVIDER_FUNCTION_ID,
-                                        enqueue_input,
-                                        None,
-                                    )
-                                    .await;
 
                                 if let Some(invocation_id) = invocation_id {
                                     match result {
@@ -4579,21 +4591,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn enqueue_action_falls_back_to_legacy_default_provider() {
+    async fn enqueue_action_rejects_legacy_provider_for_namespaced_target() {
         ensure_default_meter();
         let engine = Engine::new();
         let (tx, mut rx) = mpsc::channel::<Outbound>(8);
         let worker = WorkerConnection::new(tx);
-        let captured = Arc::new(Mutex::new(None));
-        let captured_for_handler = captured.clone();
+        let legacy_calls = Arc::new(AtomicUsize::new(0));
+        let legacy_calls_for_handler = legacy_calls.clone();
 
         engine.register_function_handler(
             make_request(super::ENQUEUE_PROVIDER_FUNCTION_ID),
             super::Handler::new(move |input| {
-                let captured = captured_for_handler.clone();
+                legacy_calls_for_handler.fetch_add(1, Ordering::SeqCst);
                 async move {
-                    *captured.lock().unwrap() = Some(input);
-                    FunctionResult::Success(None)
+                    if input.get("namespace").is_some() {
+                        FunctionResult::Failure(crate::protocol::ErrorBody::new(
+                            "unknown_field",
+                            "legacy provider rejects the namespace field",
+                        ))
+                    } else {
+                        FunctionResult::Success(None)
+                    }
                 }
             }),
         );
@@ -4623,13 +4641,19 @@ mod tests {
             .expect("channel should produce an invocation result");
         match outbound {
             Outbound::Protocol(Message::InvocationResult { error, .. }) => {
-                assert!(error.is_none());
+                let error = error.expect("namespaced enqueue must reject a legacy provider");
+                assert_eq!(error.code, "enqueue_error");
+                assert!(error.message.contains("namespace-aware release"));
+                assert!(error.message.contains("project-a"));
             }
             other => panic!("expected InvocationResult, got {other:?}"),
         }
 
-        let input = captured.lock().unwrap().clone().unwrap();
-        assert_eq!(input["namespace"], "project-a");
+        assert_eq!(
+            legacy_calls.load(Ordering::SeqCst),
+            0,
+            "legacy provider must not receive a namespaced enqueue"
+        );
     }
 
     #[tokio::test]

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -54,9 +54,9 @@ const LOGS_WS_PREFIX: &[u8] = b"LOGS";
 /// down directly (wedged reader guard).
 const REATTACH_EVICT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
-/// Function provided by the standalone `queue` worker for named enqueue
-/// actions. The engine owns receipt generation and uses this function only as
-/// the durable transport boundary.
+/// Function provided by the standalone `queue` worker in each project
+/// namespace. The engine owns receipt generation and uses this function only
+/// as the durable transport boundary.
 const ENQUEUE_PROVIDER_FUNCTION_ID: &str = "engine::queue::enqueue";
 
 /// How long a freshly connected worker's registrations wait for the namespace
@@ -1821,8 +1821,22 @@ impl Engine {
                                     enqueue_input["namespace"] =
                                         Value::String(target_namespace.clone());
                                 }
+                                // New queue workers register the provider in
+                                // the target project namespace. Old releases
+                                // registered it in `default`, so use that only
+                                // when the project-scoped provider is absent.
+                                let provider_namespace = if engine
+                                    .functions
+                                    .get(&target_namespace, ENQUEUE_PROVIDER_FUNCTION_ID)
+                                    .is_some()
+                                {
+                                    target_namespace.as_str()
+                                } else {
+                                    DEFAULT_NAMESPACE
+                                };
                                 let result = engine
-                                    .call_with_metadata(
+                                    .call_with_metadata_ns(
+                                        provider_namespace,
                                         ENQUEUE_PROVIDER_FUNCTION_ID,
                                         enqueue_input,
                                         None,
@@ -4496,6 +4510,126 @@ mod tests {
         assert!(queued_baggage.contains("iii.session.id=s1"));
         assert!(queued_baggage.contains("iii.function.id=harness::turn"));
         assert!(!queued_baggage.contains("harness::send"));
+    }
+
+    #[tokio::test]
+    async fn enqueue_action_prefers_provider_in_target_namespace() {
+        ensure_default_meter();
+        let engine = Engine::new();
+        let (tx, mut rx) = mpsc::channel::<Outbound>(8);
+        let worker = WorkerConnection::new(tx);
+        let captured = Arc::new(Mutex::new(None));
+        let captured_for_handler = captured.clone();
+        let legacy_calls = Arc::new(AtomicUsize::new(0));
+        let legacy_calls_for_handler = legacy_calls.clone();
+
+        engine.register_function_handler(
+            make_request(super::ENQUEUE_PROVIDER_FUNCTION_ID),
+            super::Handler::new(move |_input| {
+                legacy_calls_for_handler.fetch_add(1, Ordering::SeqCst);
+                async move { FunctionResult::Success(None) }
+            }),
+        );
+        engine.register_function_handler_ns(
+            "project-a",
+            make_request(super::ENQUEUE_PROVIDER_FUNCTION_ID),
+            super::Handler::new(move |input| {
+                let captured = captured_for_handler.clone();
+                async move {
+                    *captured.lock().unwrap() = Some(input);
+                    FunctionResult::Success(None)
+                }
+            }),
+        );
+
+        let invocation_id = uuid::Uuid::new_v4();
+        engine
+            .router_msg(
+                &worker,
+                &Message::InvokeFunction {
+                    invocation_id: Some(invocation_id),
+                    function_id: "harness::turn".to_string(),
+                    data: json!({"session_id": "s1"}),
+                    traceparent: None,
+                    baggage: None,
+                    action: Some(crate::protocol::TriggerAction::Enqueue {
+                        queue: "harness-turn".to_string(),
+                    }),
+                    metadata: None,
+                    namespace: Some("project-a".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+
+        let outbound = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for enqueue acknowledgement")
+            .expect("channel should produce an invocation result");
+        match outbound {
+            Outbound::Protocol(Message::InvocationResult { error, .. }) => {
+                assert!(error.is_none());
+            }
+            other => panic!("expected InvocationResult, got {other:?}"),
+        }
+
+        let input = captured.lock().unwrap().clone().unwrap();
+        assert_eq!(input["namespace"], "project-a");
+        assert_eq!(legacy_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn enqueue_action_falls_back_to_legacy_default_provider() {
+        ensure_default_meter();
+        let engine = Engine::new();
+        let (tx, mut rx) = mpsc::channel::<Outbound>(8);
+        let worker = WorkerConnection::new(tx);
+        let captured = Arc::new(Mutex::new(None));
+        let captured_for_handler = captured.clone();
+
+        engine.register_function_handler(
+            make_request(super::ENQUEUE_PROVIDER_FUNCTION_ID),
+            super::Handler::new(move |input| {
+                let captured = captured_for_handler.clone();
+                async move {
+                    *captured.lock().unwrap() = Some(input);
+                    FunctionResult::Success(None)
+                }
+            }),
+        );
+
+        engine
+            .router_msg(
+                &worker,
+                &Message::InvokeFunction {
+                    invocation_id: Some(uuid::Uuid::new_v4()),
+                    function_id: "harness::turn".to_string(),
+                    data: json!({"session_id": "s1"}),
+                    traceparent: None,
+                    baggage: None,
+                    action: Some(crate::protocol::TriggerAction::Enqueue {
+                        queue: "harness-turn".to_string(),
+                    }),
+                    metadata: None,
+                    namespace: Some("project-a".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+
+        let outbound = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for enqueue acknowledgement")
+            .expect("channel should produce an invocation result");
+        match outbound {
+            Outbound::Protocol(Message::InvocationResult { error, .. }) => {
+                assert!(error.is_none());
+            }
+            other => panic!("expected InvocationResult, got {other:?}"),
+        }
+
+        let input = captured.lock().unwrap().clone().unwrap();
+        assert_eq!(input["namespace"], "project-a");
     }
 
     #[tokio::test]

--- a/engine/src/workers/bridge.rs
+++ b/engine/src/workers/bridge.rs
@@ -4,7 +4,7 @@
 // This software is patent protected. We welcome discussions - reach out at team@iii.dev
 // See LICENSE and PATENTS files for details.
 
-use iii_sdk::InitOptions;
+use iii_sdk::{InitOptions, WorkerIdentityMode};
 
 /// `InitOptions` for an engine-internal bridge adapter connection.
 ///
@@ -17,6 +17,7 @@ pub(crate) fn bridge_init_options(worker_name: &str) -> InitOptions {
             name: worker_name.to_string(),
             ..Default::default()
         }),
+        identity: WorkerIdentityMode::Explicit,
         ..Default::default()
     }
 }

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -348,7 +348,7 @@ fn apply_managed_identity_from_env(metadata: &mut WorkerMetadata) {
     if metadata.namespace.is_none() {
         metadata.namespace = std::env::var("III_NAMESPACE")
             .ok()
-            .filter(|namespace| !namespace.is_empty());
+            .filter(|namespace| !namespace.trim().is_empty());
     }
 }
 
@@ -968,6 +968,7 @@ impl IIIClient {
         Self::with_identity(address, metadata, WorkerIdentityMode::Managed)
     }
 
+    /// Create a client with explicit control over managed environment identity.
     pub(crate) fn with_identity(
         address: &str,
         mut metadata: WorkerMetadata,
@@ -3291,6 +3292,16 @@ mod tests {
             IIIClient::with_identity("ws://127.0.0.1:0", metadata, WorkerIdentityMode::Explicit);
 
         assert_eq!(iii.namespace().as_deref(), Some("remote-namespace"));
+    }
+
+    #[test]
+    fn managed_identity_ignores_whitespace_only_namespace() {
+        let env = ScopedEnvVar::new("III_NAMESPACE");
+        env.set(" \t ");
+
+        let iii = IIIClient::with_metadata("ws://127.0.0.1:0", WorkerMetadata::default());
+
+        assert!(iii.namespace().is_none());
     }
 
     #[test]

--- a/sdk/packages/rust/iii/src/iii.rs
+++ b/sdk/packages/rust/iii/src/iii.rs
@@ -23,7 +23,7 @@ use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::{
-    sync::{mpsc, oneshot},
+    sync::{Notify, mpsc, oneshot},
     time::{Instant, interval, sleep, sleep_until},
 };
 use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
@@ -258,8 +258,9 @@ pub struct TelemetryOptions {
 pub struct WorkerMetadata {
     pub runtime: String,
     pub version: String,
-    /// Worker name reported to the engine. A non-empty `III_WORKER_NAME`
-    /// overrides this value when the client is created.
+    /// Worker name reported to the engine. In managed identity mode, a
+    /// non-empty `III_WORKER_NAME` overrides this value when the client is
+    /// created.
     pub name: String,
     pub os: String,
     /// One-line, human/LLM-readable summary of what this worker does.
@@ -274,8 +275,8 @@ pub struct WorkerMetadata {
     pub isolation: Option<String>,
     /// Namespace this worker belongs to, and therefore the one its calls and
     /// its trigger bindings resolve in unless they name another. Absent means
-    /// the engine applies its default namespace. Resolved from
-    /// `InitOptions.namespace` / `III_NAMESPACE` (see [`resolve_namespace`]).
+    /// the engine applies its default namespace. Managed clients also use
+    /// `III_NAMESPACE` when no explicit namespace is present.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
 }
@@ -304,11 +305,7 @@ impl Default for WorkerMetadata {
         Self {
             runtime: "rust".to_string(),
             version: SDK_VERSION.to_string(),
-            // III_WORKER_NAME carries the orchestrator-assigned name (set by
-            // iii-worker for engine-managed workers). The engine matches live
-            // registrations by name, so that identity must win over the
-            // hostname:pid fallback.
-            name: worker_name_from_env().unwrap_or_else(|| format!("{}:{}", hostname, pid)),
+            name: format!("{}:{}", hostname, pid),
             os: os_info,
             description: None,
             pid: Some(pid),
@@ -320,15 +317,22 @@ impl Default for WorkerMetadata {
             isolation: std::env::var("III_ISOLATION")
                 .ok()
                 .filter(|s| !s.is_empty()),
-            // III_NAMESPACE carries the namespace for managed workers, the same
-            // way III_WORKER_NAME carries the name. Absent leaves routing to the
-            // engine's default namespace. `InitOptions.namespace` overrides this
-            // (see `resolve_namespace`).
-            namespace: std::env::var("III_NAMESPACE")
-                .ok()
-                .filter(|s| !s.is_empty()),
+            namespace: None,
         }
     }
+}
+
+/// Selects where a worker connection gets its engine identity.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum WorkerIdentityMode {
+    /// Use the supervisor-managed `III_WORKER_NAME` and `III_NAMESPACE` values
+    /// when present. This is the default for normal worker connections.
+    #[default]
+    Managed,
+    /// Keep the name from [`WorkerMetadata`] and the namespace from explicit
+    /// options or metadata. Process-wide identity environment variables are
+    /// ignored. Use this for auxiliary connections created by one worker.
+    Explicit,
 }
 
 fn worker_name_from_env() -> Option<String> {
@@ -337,9 +341,14 @@ fn worker_name_from_env() -> Option<String> {
         .filter(|name| !name.is_empty())
 }
 
-fn apply_worker_name_from_env(metadata: &mut WorkerMetadata) {
+fn apply_managed_identity_from_env(metadata: &mut WorkerMetadata) {
     if let Some(managed_name) = worker_name_from_env() {
         metadata.name = managed_name;
+    }
+    if metadata.namespace.is_none() {
+        metadata.namespace = std::env::var("III_NAMESPACE")
+            .ok()
+            .filter(|namespace| !namespace.is_empty());
     }
 }
 
@@ -933,6 +942,8 @@ struct IIIInner {
     /// frame); required by the engine to authorize the reattach — ids alone
     /// are publicly discoverable.
     reattach_token: Mutex<Option<String>>,
+    identity_mode: WorkerIdentityMode,
+    registration_changed: Notify,
 }
 
 /// WebSocket client for communication with the III Engine.
@@ -951,10 +962,20 @@ impl IIIClient {
 
     /// Create a new III with custom worker metadata.
     ///
-    /// A non-empty `III_WORKER_NAME` overrides `metadata.name` so an
-    /// orchestrator can assign the worker identity.
-    pub fn with_metadata(address: &str, mut metadata: WorkerMetadata) -> Self {
-        apply_worker_name_from_env(&mut metadata);
+    /// Non-empty managed identity environment variables override matching
+    /// metadata fields so an orchestrator can assign the worker identity.
+    pub fn with_metadata(address: &str, metadata: WorkerMetadata) -> Self {
+        Self::with_identity(address, metadata, WorkerIdentityMode::Managed)
+    }
+
+    pub(crate) fn with_identity(
+        address: &str,
+        mut metadata: WorkerMetadata,
+        identity_mode: WorkerIdentityMode,
+    ) -> Self {
+        if identity_mode == WorkerIdentityMode::Managed {
+            apply_managed_identity_from_env(&mut metadata);
+        }
         let (tx, rx) = mpsc::unbounded_channel();
         let inner = IIIInner {
             address: address.into(),
@@ -975,6 +996,8 @@ impl IIIClient {
             timings: Mutex::new(ConnTimings::default()),
             worker_id: Mutex::new(None),
             reattach_token: Mutex::new(None),
+            identity_mode,
+            registration_changed: Notify::new(),
         };
         Self {
             inner: Arc::new(inner),
@@ -988,9 +1011,12 @@ impl IIIClient {
 
     /// Set custom worker metadata (call before connect).
     ///
-    /// A non-empty `III_WORKER_NAME` overrides `metadata.name`.
+    /// In managed identity mode, process-wide identity environment variables
+    /// override the matching metadata fields.
     pub fn set_metadata(&self, mut metadata: WorkerMetadata) {
-        apply_worker_name_from_env(&mut metadata);
+        if self.inner.identity_mode == WorkerIdentityMode::Managed {
+            apply_managed_identity_from_env(&mut metadata);
+        }
         *self.inner.worker_metadata.lock_or_recover() = Some(metadata);
     }
 
@@ -1027,6 +1053,39 @@ impl IIIClient {
     /// reconnect once this is populated.
     pub fn fatal_error(&self) -> Option<Error> {
         self.inner.fatal_error.lock_or_recover().clone()
+    }
+
+    /// Wait until the engine accepts this worker's initial registration.
+    ///
+    /// Returns [`Error::RegistrationRejected`] for a fatal identity conflict,
+    /// [`Error::Timeout`] when the deadline expires, and
+    /// [`Error::NotConnected`] when called before the client starts or after it
+    /// stops.
+    pub async fn wait_until_registered(&self, timeout: Duration) -> Result<(), Error> {
+        if !self.inner.started.load(Ordering::SeqCst) {
+            return Err(Error::NotConnected);
+        }
+
+        let deadline = Instant::now() + timeout;
+        loop {
+            let notified = self.inner.registration_changed.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            if let Some(err) = self.fatal_error() {
+                return Err(err);
+            }
+            if self.inner.worker_id.lock_or_recover().is_some() {
+                return Ok(());
+            }
+            if !self.inner.running.load(Ordering::SeqCst) {
+                return Err(Error::NotConnected);
+            }
+
+            if tokio::time::timeout_at(deadline, notified).await.is_err() {
+                return Err(Error::Timeout);
+            }
+        }
     }
 
     /// Set custom HTTP headers for the WebSocket handshake (call before connect).
@@ -1106,6 +1165,7 @@ impl IIIClient {
     /// ```
     pub fn shutdown(&self) {
         self.inner.running.store(false, Ordering::SeqCst);
+        self.inner.registration_changed.notify_waiters();
         let _ = self.inner.outbound.send(Outbound::Shutdown);
         self.set_connection_state(IIIConnectionState::Disconnected);
 
@@ -1136,6 +1196,7 @@ impl IIIClient {
     /// ```
     pub async fn shutdown_async(&self) {
         self.inner.running.store(false, Ordering::SeqCst);
+        self.inner.registration_changed.notify_waiters();
         let _ = self.inner.outbound.send(Outbound::Shutdown);
         self.set_connection_state(IIIConnectionState::Disconnected);
     }
@@ -2002,6 +2063,7 @@ impl IIIClient {
                 tracing::debug!(worker_id = %worker_id, "Worker registered");
                 *self.inner.worker_id.lock_or_recover() = Some(worker_id);
                 *self.inner.reattach_token.lock_or_recover() = reattach_token;
+                self.inner.registration_changed.notify_waiters();
             }
             Message::RegistrationRejected {
                 code,
@@ -2127,6 +2189,7 @@ impl IIIClient {
         *self.inner.fatal_error.lock_or_recover() = Some(err);
         self.set_connection_state(IIIConnectionState::Failed);
         self.inner.running.store(false, Ordering::SeqCst);
+        self.inner.registration_changed.notify_waiters();
     }
 
     fn handle_invocation_result(
@@ -3159,7 +3222,7 @@ mod tests {
         assert_eq!(explicit_name, "explicit-worker");
 
         env.set("managed-worker");
-        assert_eq!(WorkerMetadata::default().name, "managed-worker");
+        assert_ne!(WorkerMetadata::default().name, "managed-worker");
 
         let metadata = WorkerMetadata {
             name: "explicit-worker".to_string(),
@@ -3190,6 +3253,44 @@ mod tests {
             .name
             .clone();
         assert_eq!(replaced_name, "managed-worker");
+    }
+
+    #[test]
+    fn explicit_identity_preserves_metadata_name() {
+        let env = ScopedEnvVar::new("III_WORKER_NAME");
+        env.set("managed-worker");
+
+        let metadata = WorkerMetadata {
+            name: "remote-bridge".to_string(),
+            ..WorkerMetadata::default()
+        };
+        let iii =
+            IIIClient::with_identity("ws://127.0.0.1:0", metadata, WorkerIdentityMode::Explicit);
+        let resolved_name = iii
+            .inner
+            .worker_metadata
+            .lock_or_recover()
+            .as_ref()
+            .unwrap()
+            .name
+            .clone();
+
+        assert_eq!(resolved_name, "remote-bridge");
+    }
+
+    #[test]
+    fn explicit_identity_preserves_metadata_namespace() {
+        let env = ScopedEnvVar::new("III_NAMESPACE");
+        env.set("managed-namespace");
+
+        let metadata = WorkerMetadata {
+            namespace: Some("remote-namespace".to_string()),
+            ..WorkerMetadata::default()
+        };
+        let iii =
+            IIIClient::with_identity("ws://127.0.0.1:0", metadata, WorkerIdentityMode::Explicit);
+
+        assert_eq!(iii.namespace().as_deref(), Some("remote-namespace"));
     }
 
     #[test]
@@ -3462,11 +3563,9 @@ mod tests {
         );
 
         env.set("orders");
-        // III_NAMESPACE flows into worker metadata, mirroring III_WORKER_NAME.
-        assert_eq!(
-            WorkerMetadata::default().namespace.as_deref(),
-            Some("orders")
-        );
+        // Raw metadata has no process-wide identity until a managed client is
+        // created from it.
+        assert!(WorkerMetadata::default().namespace.is_none());
         // Env is the fallback when no explicit option is given.
         assert_eq!(resolve_namespace(None).as_deref(), Some("orders"));
         // options.namespace beats the env var.
@@ -3586,6 +3685,47 @@ mod tests {
             }
             other => panic!("expected RegistrationRejected, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn wait_until_registered_completes_after_engine_accepts_worker() {
+        let iii = IIIClient::new("ws://localhost:1234");
+        iii.inner.started.store(true, Ordering::SeqCst);
+        iii.inner.running.store(true, Ordering::SeqCst);
+        let waiter = {
+            let iii = iii.clone();
+            tokio::spawn(async move { iii.wait_until_registered(Duration::from_secs(1)).await })
+        };
+
+        tokio::task::yield_now().await;
+        let payload = json!({
+            "type": "workerregistered",
+            "worker_id": "worker-accepted",
+            "reattach_token": "secret",
+        })
+        .to_string();
+        iii.handle_message(&payload).unwrap();
+
+        assert!(waiter.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn wait_until_registered_returns_registration_rejection() {
+        let iii = IIIClient::new("ws://localhost:1234");
+        iii.inner.started.store(true, Ordering::SeqCst);
+        iii.inner.running.store(true, Ordering::SeqCst);
+        let payload = json!({
+            "type": "registrationrejected",
+            "code": "WORKER_NAMESPACE_CONFLICT",
+            "namespace": "orders",
+            "worker_name": "checkout",
+            "owner_worker_id": "worker-abc",
+        })
+        .to_string();
+        iii.handle_message(&payload).unwrap();
+
+        let result = iii.wait_until_registered(Duration::from_secs(1)).await;
+        assert!(matches!(result, Err(Error::RegistrationRejected { .. })));
     }
 
     #[test]

--- a/sdk/packages/rust/iii/src/lib.rs
+++ b/sdk/packages/rust/iii/src/lib.rs
@@ -13,8 +13,8 @@ pub mod types;
 /// Public runtime/worker types. (Stage 1 submodule grouping.)
 pub mod runtime {
     pub use crate::iii::{
-        FunctionInfo, FunctionRef, IIIConnectionState, TriggerInfo, TriggerTypeRef, WorkerInfo,
-        WorkerMetadata,
+        FunctionInfo, FunctionRef, IIIConnectionState, TriggerInfo, TriggerTypeRef,
+        WorkerIdentityMode, WorkerInfo, WorkerMetadata,
     };
 }
 
@@ -47,7 +47,7 @@ pub mod errors {
 
 pub use error::{Error, InvocationError};
 pub use iii::TelemetryOptions;
-pub use iii::{IIIClient, RegisterFunction, RegisterTriggerType};
+pub use iii::{IIIClient, RegisterFunction, RegisterTriggerType, WorkerIdentityMode};
 pub use iii_helpers::queue::EnqueueResult;
 pub use protocol::{Message, TriggerAction};
 pub use stream_provider::IStream;
@@ -64,16 +64,16 @@ pub use types::{StreamRequest, StreamResponse};
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct InitOptions {
-    /// Custom worker metadata. Auto-detected if `None`. A non-empty
-    /// `III_WORKER_NAME` overrides `metadata.name`.
+    /// Custom worker metadata. Auto-detected if `None`. In managed identity
+    /// mode, process-wide identity variables override matching fields.
     pub metadata: Option<iii::WorkerMetadata>,
     /// Custom HTTP headers sent during the WebSocket handshake.
     pub headers: Option<std::collections::HashMap<String, String>>,
     /// OpenTelemetry configuration.
     pub otel: Option<iii_helpers::observability::OtelConfig>,
-    /// Namespace this worker belongs to. Resolution order:
-    /// `namespace` > env `III_NAMESPACE` > `None` (the engine then applies its
-    /// default namespace).
+    /// Namespace this worker belongs to. In managed mode, resolution order is
+    /// `namespace` > env `III_NAMESPACE` > `None`. In explicit mode, the
+    /// environment is not used.
     ///
     /// It scopes more than the registration. The worker and its functions
     /// register here, and everything the worker does afterwards follows it: a
@@ -81,6 +81,10 @@ pub struct InitOptions {
     /// [`IIIClient::register_trigger`] binds here, unless the call names
     /// another namespace.
     pub namespace: Option<String>,
+    /// Selects whether process-wide managed identity variables can override
+    /// this connection's metadata. Auxiliary connections should use
+    /// [`WorkerIdentityMode::Explicit`].
+    pub identity: WorkerIdentityMode,
 }
 
 /// Register the worker with a iii instance, returns a connected worker client.
@@ -144,17 +148,23 @@ pub fn register_worker(address: &str, options: InitOptions) -> IIIClient {
         headers,
         otel,
         namespace,
+        identity,
     } = options;
 
-    let iii = if let Some(metadata) = metadata {
-        IIIClient::with_metadata(address, metadata)
-    } else {
-        IIIClient::new(address)
-    };
+    let iii = IIIClient::with_identity(address, metadata.unwrap_or_default(), identity);
 
-    // options.namespace > III_NAMESPACE > None (engine applies its default).
-    if let Some(ns) = iii::resolve_namespace(namespace) {
-        iii.set_namespace(ns);
+    match identity {
+        WorkerIdentityMode::Managed => {
+            // options.namespace > III_NAMESPACE > None (engine applies its default).
+            if let Some(ns) = iii::resolve_namespace(namespace) {
+                iii.set_namespace(ns);
+            }
+        }
+        WorkerIdentityMode::Explicit => {
+            if let Some(ns) = namespace {
+                iii.set_namespace(ns);
+            }
+        }
     }
 
     if let Some(h) = headers {


### PR DESCRIPTION
Refs MOT-3944

## Summary

- Route `TriggerAction::Enqueue` only to `engine::queue::enqueue` in the target namespace.
- Keep legacy queue providers compatible for targets in the `default` namespace.
- Return an upgrade error instead of sending a namespaced request to an incompatible legacy provider.
- Add managed and explicit worker identity modes to the Rust SDK.
- Add `IIIClient::wait_until_registered` so startup code can fail on rejected registrations.
- Protect engine-internal bridge client names from process-wide managed identity overrides.

## Problem

The standalone queue worker currently opens a project connection and a second connection in `default`. Compose sets `III_WORKER_NAME=queue` for the process. The SDK applies that value to both clients, so the intended `queue-engine` identity becomes `queue`. In the default namespace both connections claim the same worker lease. Across custom namespaces, every queue process still competes for the same global provider in `default`.

The old provider also rejects unknown request fields. It cannot accept a `namespace` field, and omitting that field would enqueue the target function in the wrong namespace.

## Behavior

```text
TriggerAction::Enqueue(target namespace)
                  |
                  +-- target is default -> use default provider
                  |
                  +-- scoped provider exists -> use scoped provider
                  |
                  +-- only legacy default provider exists -> return upgrade error
                  |
                  +-- no provider exists -> return installation guidance
```

Existing queue workers remain compatible for functions in `default`. Custom namespaces require a namespace-aware queue worker registered in the target namespace. The one-connection queue worker update will be released separately after the SDK version from this PR is available.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p iii`
- `cargo check -p iii-console`
- `cargo test -p iii --lib` — 1749 passed, 1 ignored
- `cargo test -p iii --lib enqueue_action_` — 4 passed
- `cargo test -p iii-sdk --lib` — 70 passed
- `cargo test -p iii-sdk --tests --no-run`
- `cargo test -p iii-sdk --test namespace_inheritance` — 15 passed
- `cargo test -p iii-sdk --test env_contract`
- `cargo test -p iii-sdk --test error_wire`
- `cargo test -p iii-sdk --test reattach`
- `cargo test -p iii-sdk --test registration_dedup`
- `cargo test -p iii-sdk --doc` — 44 passed
- `cargo clippy -p iii-sdk --all-targets -- -D warnings`

Engine-wide Clippy currently reports existing warnings outside the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for explicit or managed worker identity configuration, including namespace handling.
  - Added an API for waiting until a worker finishes registering.
  - Queue requests now use the target namespace when supported.

- **Bug Fixes**
  - Prevented namespaced queue requests from incorrectly using legacy providers.
  - Added clearer migration errors when a compatible namespaced provider is unavailable.
  - Improved handling of blank namespace configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->