### PR TITLE
fix(worker): forward local source changes into VMs

### DIFF
--- a/crates/iii-init/src/lib.rs
+++ b/crates/iii-init/src/lib.rs
@@ -25,6 +25,8 @@ pub mod child_exits;
 #[cfg(target_os = "linux")]
 pub mod shell_dispatcher;
 #[cfg(target_os = "linux")]
+pub mod source_sync;
+#[cfg(target_os = "linux")]
 pub mod supervisor;
 // Filesystem operation handlers. Linux-only because the module calls
 // std::os::unix::fs APIs and references shell_dispatcher internals.

--- a/crates/iii-init/src/source_sync.rs
+++ b/crates/iii-init/src/source_sync.rs
@@ -1,0 +1,362 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Guest-side receiver for host source changes.
+//!
+//! Entries are applied with ordinary guest filesystem operations. This is the
+//! important part of the design: the guest kernel then emits native fsnotify /
+//! inotify events, so the worker's own `watchfiles`, `node --watch`, `tsx`, or
+//! `cargo watch` process decides how and when to restart.
+
+use std::ffi::OsString;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Read, Write};
+use std::os::unix::ffi::OsStringExt;
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use iii_supervisor::source_sync::{self, EntryHeader, EntryKind};
+
+const MAX_SYMLINK_BYTES: u64 = 64 * 1024;
+static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+pub fn run(port_path: &Path, workspace: &Path, ready_path: &Path) -> io::Result<()> {
+    while !ready_path.exists() {
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    fs::create_dir_all(workspace)?;
+    let mut port = OpenOptions::new().read(true).write(true).open(port_path)?;
+    loop {
+        let header = read_header_when_ready(&mut port)?;
+
+        let result = apply_entry(&mut port, workspace, &header);
+        match &result {
+            Ok(()) => source_sync::write_ack(&mut port, Ok(()))?,
+            Err(error) => source_sync::write_ack(&mut port, Err(&error.to_string()))?,
+        }
+    }
+}
+
+fn read_header_when_ready(reader: &mut impl Read) -> io::Result<EntryHeader> {
+    loop {
+        match source_sync::read_header(&mut *reader) {
+            Ok(header) => return Ok(header),
+            // A virtio-console port can report a transient EOF before its host
+            // backend is ready. Keep the guest receiver alive until the first
+            // source event arrives instead of permanently disabling sync.
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::UnexpectedEof | io::ErrorKind::WouldBlock
+                ) =>
+            {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn apply_entry(reader: &mut impl Read, workspace: &Path, header: &EntryHeader) -> io::Result<()> {
+    let relative = source_sync::validate_relative_path(&header.path)?;
+    let target = workspace.join(&relative);
+
+    match header.kind {
+        EntryKind::Remove => {
+            reject_payload(header)?;
+            ensure_safe_parent(workspace, &relative)?;
+            remove_existing(&target)
+        }
+        EntryKind::Directory => {
+            reject_payload(header)?;
+            ensure_safe_parent(workspace, &relative)?;
+            replace_with_directory(&target, header.mode)
+        }
+        EntryKind::File => apply_file(reader, workspace, &relative, header),
+        EntryKind::Symlink => apply_symlink(reader, workspace, &relative, header),
+    }
+}
+
+fn reject_payload(header: &EntryHeader) -> io::Result<()> {
+    if header.payload_len == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{:?} entry cannot carry a payload", header.kind),
+        ))
+    }
+}
+
+fn apply_file(
+    reader: &mut impl Read,
+    workspace: &Path,
+    relative: &Path,
+    header: &EntryHeader,
+) -> io::Result<()> {
+    ensure_safe_parent(workspace, relative)?;
+    let target = workspace.join(relative);
+    let parent = target
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "file has no parent"))?;
+    let file_name = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("entry");
+    let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let temp = parent.join(format!(
+        ".{file_name}.iii-sync-{}-{sequence}",
+        std::process::id()
+    ));
+
+    let result = (|| {
+        let mut output = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temp)?;
+        let mut payload = reader.take(header.payload_len);
+        let copied = io::copy(&mut payload, &mut output)?;
+        if copied != header.payload_len {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!(
+                    "source-sync file {} ended after {copied} of {} bytes",
+                    header.path, header.payload_len
+                ),
+            ));
+        }
+        output.flush()?;
+        output.set_permissions(fs::Permissions::from_mode(header.mode & 0o7777))?;
+        drop(output);
+
+        if target.is_dir() {
+            fs::remove_dir_all(&target)?;
+        } else if fs::symlink_metadata(&target).is_ok_and(|meta| meta.file_type().is_symlink()) {
+            fs::remove_file(&target)?;
+        }
+        fs::rename(&temp, &target)
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+    result
+}
+
+fn apply_symlink(
+    reader: &mut impl Read,
+    workspace: &Path,
+    relative: &Path,
+    header: &EntryHeader,
+) -> io::Result<()> {
+    if header.payload_len > MAX_SYMLINK_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "source-sync symlink target is too long",
+        ));
+    }
+    ensure_safe_parent(workspace, relative)?;
+    let mut bytes = vec![0u8; header.payload_len as usize];
+    reader.read_exact(&mut bytes)?;
+    let target = workspace.join(relative);
+    remove_existing(&target)?;
+    symlink(OsString::from_vec(bytes), target)
+}
+
+fn ensure_safe_parent(workspace: &Path, relative: &Path) -> io::Result<()> {
+    let Some(parent) = relative.parent() else {
+        return Ok(());
+    };
+    let mut current = workspace.to_path_buf();
+    for component in parent.components() {
+        current.push(component.as_os_str());
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("source-sync parent is a symlink: {}", current.display()),
+                ));
+            }
+            Ok(metadata) if metadata.is_dir() => {}
+            Ok(_) => {
+                remove_existing(&current)?;
+                fs::create_dir(&current)?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                fs::create_dir(&current)?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn replace_with_directory(path: &Path, mode: u32) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {}
+        Ok(_) => {
+            remove_existing(path)?;
+            fs::create_dir(path)?;
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => fs::create_dir(path)?,
+        Err(error) => return Err(error),
+    }
+    fs::set_permissions(path, fs::Permissions::from_mode(mode & 0o7777))
+}
+
+fn remove_existing(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+            fs::remove_dir_all(path)
+        }
+        Ok(_) => fs::remove_file(path),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TransientEof {
+        returned_eof: bool,
+        bytes: io::Cursor<Vec<u8>>,
+    }
+
+    impl Read for TransientEof {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            if !self.returned_eof {
+                self.returned_eof = true;
+                return Ok(0);
+            }
+            self.bytes.read(buffer)
+        }
+    }
+
+    fn header(kind: EntryKind, path: &str, payload_len: u64) -> EntryHeader {
+        EntryHeader {
+            kind,
+            path: path.to_string(),
+            mode: 0o100644,
+            payload_len,
+        }
+    }
+
+    #[test]
+    fn transient_console_eof_does_not_stop_receiver() {
+        let expected = header(EntryKind::File, "src/main.py", 5);
+        let mut bytes = Vec::new();
+        source_sync::write_header(&mut bytes, &expected).unwrap();
+        let mut reader = TransientEof {
+            returned_eof: false,
+            bytes: io::Cursor::new(bytes),
+        };
+
+        assert_eq!(read_header_when_ready(&mut reader).unwrap(), expected);
+    }
+
+    #[test]
+    fn file_entry_replaces_content() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path();
+        fs::create_dir(workspace.join("src")).unwrap();
+        fs::write(workspace.join("src/main.py"), "before").unwrap();
+        let mut payload = b"after".as_slice();
+
+        apply_entry(
+            &mut payload,
+            workspace,
+            &header(EntryKind::File, "src/main.py", 5),
+        )
+        .unwrap();
+
+        assert_eq!(fs::read(workspace.join("src/main.py")).unwrap(), b"after");
+    }
+
+    #[test]
+    fn remove_entry_deletes_directory_tree() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("removed/child");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("file"), "data").unwrap();
+        let mut payload = io::empty();
+
+        apply_entry(
+            &mut payload,
+            temp.path(),
+            &header(EntryKind::Remove, "removed", 0),
+        )
+        .unwrap();
+
+        assert!(!temp.path().join("removed").exists());
+    }
+
+    #[test]
+    fn symlink_parent_cannot_escape_workspace() {
+        let temp = tempfile::tempdir().unwrap();
+        symlink("/tmp", temp.path().join("escape")).unwrap();
+        let mut payload = b"blocked".as_slice();
+
+        let error = apply_entry(
+            &mut payload,
+            temp.path(),
+            &header(EntryKind::File, "escape/file", 7),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn file_entry_emits_inotify_event() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let watched = temp.path().join("src");
+        fs::create_dir(&watched).unwrap();
+        let fd = unsafe { libc::inotify_init1(libc::IN_CLOEXEC | libc::IN_NONBLOCK) };
+        assert!(
+            fd >= 0,
+            "inotify_init1 failed: {}",
+            io::Error::last_os_error()
+        );
+        let watched_c = CString::new(watched.as_os_str().as_bytes()).unwrap();
+        let wd = unsafe {
+            libc::inotify_add_watch(
+                fd,
+                watched_c.as_ptr(),
+                libc::IN_CREATE | libc::IN_MODIFY | libc::IN_MOVED_TO | libc::IN_CLOSE_WRITE,
+            )
+        };
+        assert!(
+            wd >= 0,
+            "inotify_add_watch failed: {}",
+            io::Error::last_os_error()
+        );
+
+        let mut payload = b"print('changed')\n".as_slice();
+        let payload_len = payload.len() as u64;
+        apply_entry(
+            &mut payload,
+            temp.path(),
+            &header(EntryKind::File, "src/math_worker.py", payload_len),
+        )
+        .unwrap();
+
+        let mut events = [0u8; 4096];
+        let read = unsafe { libc::read(fd, events.as_mut_ptr().cast(), events.len()) };
+        unsafe { libc::close(fd) };
+        assert!(
+            read > 0,
+            "guest-side file write did not emit an inotify event"
+        );
+    }
+}

--- a/crates/iii-init/src/source_sync.rs
+++ b/crates/iii-init/src/source_sync.rs
@@ -35,10 +35,15 @@ pub fn run(port_path: &Path, workspace: &Path, ready_path: &Path) -> io::Result<
     loop {
         let header = read_header_when_ready(&mut port)?;
 
-        let result = apply_entry(&mut port, workspace, &header);
-        match &result {
+        match apply_entry(&mut port, workspace, &header) {
             Ok(()) => source_sync::write_ack(&mut port, Ok(()))?,
-            Err(error) => source_sync::write_ack(&mut port, Err(&error.to_string()))?,
+            Err(error) => {
+                source_sync::write_ack(&mut port, Err(&error.to_string()))?;
+                return Err(io::Error::new(
+                    error.kind(),
+                    format!("source-sync frame rejected: {error}"),
+                ));
+            }
         }
     }
 }
@@ -100,6 +105,16 @@ fn apply_file(
     relative: &Path,
     header: &EntryHeader,
 ) -> io::Result<()> {
+    if header.payload_len > source_sync::MAX_FILE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "source-sync file payload is too large: {} bytes (maximum {})",
+                header.payload_len,
+                source_sync::MAX_FILE_BYTES
+            ),
+        ));
+    }
     ensure_safe_parent(workspace, relative)?;
     let target = workspace.join(relative);
     let parent = target
@@ -358,5 +373,25 @@ mod tests {
             read > 0,
             "guest-side file write did not emit an inotify event"
         );
+    }
+
+    #[test]
+    fn apply_file_rejects_payload_over_shared_limit() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut payload = io::empty();
+
+        let error = apply_entry(
+            &mut payload,
+            temp.path(),
+            &header(
+                EntryKind::File,
+                "large.bin",
+                source_sync::MAX_FILE_BYTES + 1,
+            ),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(!temp.path().join("large.bin").exists());
     }
 }

--- a/crates/iii-init/src/supervisor.rs
+++ b/crates/iii-init/src/supervisor.rs
@@ -59,6 +59,13 @@ const III_WORKER_WORKDIR_ENV: &str = "III_WORKER_WORKDIR";
 /// for this VM — the worker child keeps running normally.
 const III_SHELL_PORT_ENV: &str = "III_SHELL_PORT";
 
+/// Virtio-console port carrying host source changes. The receiver only writes
+/// files; the worker's own watcher remains responsible for process restarts.
+const III_SOURCE_SYNC_PORT_ENV: &str = "III_SOURCE_SYNC_PORT";
+
+const III_SOURCE_SYNC_ROOT_ENV: &str = "III_SOURCE_SYNC_ROOT";
+const III_SOURCE_SYNC_READY_ENV: &str = "III_SOURCE_SYNC_READY";
+
 /// Stores the current child worker PID for async-signal-safe signal
 /// forwarding. 0 means no child has been spawned yet. Updated both on
 /// initial spawn and after every respawn inside supervisor mode.
@@ -118,6 +125,7 @@ pub fn exec_worker() -> Result<(), InitError> {
     // sysfs (host forgot `--shell-sock`, or sysfs not mounted), we
     // log and continue without exec; the worker still runs normally.
     maybe_spawn_shell_dispatcher();
+    maybe_spawn_source_sync();
 
     if let Ok(port_name) = std::env::var(III_CONTROL_PORT_ENV) {
         let workdir =
@@ -126,6 +134,40 @@ pub fn exec_worker() -> Result<(), InitError> {
     }
 
     run_legacy(cmd)
+}
+
+fn maybe_spawn_source_sync() {
+    let port_name = match std::env::var(III_SOURCE_SYNC_PORT_ENV) {
+        Ok(port) => port,
+        Err(_) => return,
+    };
+    let workspace =
+        std::env::var(III_SOURCE_SYNC_ROOT_ENV).unwrap_or_else(|_| "/workspace".to_string());
+    let ready = std::env::var(III_SOURCE_SYNC_READY_ENV)
+        .unwrap_or_else(|_| "/run/iii/source-ready".to_string());
+
+    match iii_supervisor::control::find_virtio_port_by_name(&port_name) {
+        Some(port_path) => {
+            std::thread::Builder::new()
+                .name("iii-init-source-sync".to_string())
+                .spawn(move || {
+                    if let Err(error) = crate::source_sync::run(
+                        &port_path,
+                        Path::new(&workspace),
+                        Path::new(&ready),
+                    ) {
+                        eprintln!("iii-init: source sync error: {error}");
+                    }
+                })
+                .expect("spawn source sync thread");
+        }
+        None => {
+            eprintln!(
+                "iii-init: warning: III_SOURCE_SYNC_PORT={port_name} but no matching port \
+                 in /sys/class/virtio-ports. Host source changes will not be forwarded."
+            );
+        }
+    }
 }
 
 /// Look up `III_SHELL_PORT`, resolve the named virtio-console port via

--- a/crates/iii-supervisor/src/lib.rs
+++ b/crates/iii-supervisor/src/lib.rs
@@ -15,3 +15,4 @@ pub mod child;
 pub mod control;
 pub mod protocol;
 pub mod shell_protocol;
+pub mod source_sync;

--- a/crates/iii-supervisor/src/source_sync.rs
+++ b/crates/iii-supervisor/src/source_sync.rs
@@ -16,6 +16,7 @@ use std::io::{self, Read, Write};
 use std::path::{Component, Path, PathBuf};
 
 pub const SOURCE_SYNC_PORT_NAME: &str = "iii.source-sync";
+pub const MAX_FILE_BYTES: u64 = 64 * 1024 * 1024;
 
 const FRAME_MAGIC: [u8; 4] = *b"IIIS";
 const ACK_MAGIC: [u8; 4] = *b"IIIA";
@@ -58,6 +59,12 @@ pub struct EntryHeader {
 
 pub fn write_header(mut writer: impl Write, header: &EntryHeader) -> io::Result<()> {
     validate_relative_path(&header.path)?;
+    if header.kind == EntryKind::File && header.payload_len > MAX_FILE_BYTES {
+        return Err(invalid_input(format!(
+            "source-sync file payload is too large: {} bytes (maximum {MAX_FILE_BYTES})",
+            header.payload_len
+        )));
+    }
     let path = header.path.as_bytes();
     if path.len() > MAX_PATH_BYTES {
         return Err(invalid_input(format!(
@@ -98,6 +105,11 @@ pub fn read_header(mut reader: impl Read) -> io::Result<EntryHeader> {
     }
     let mode = u32::from_be_bytes(fixed[8..12].try_into().expect("fixed header slice"));
     let payload_len = u64::from_be_bytes(fixed[12..20].try_into().expect("fixed header slice"));
+    if kind == EntryKind::File && payload_len > MAX_FILE_BYTES {
+        return Err(invalid_data(format!(
+            "source-sync file payload is too large: {payload_len} bytes (maximum {MAX_FILE_BYTES})"
+        )));
+    }
 
     let mut path = vec![0u8; path_len];
     reader.read_exact(&mut path)?;
@@ -212,5 +224,36 @@ mod tests {
 
         let error = read_ack(bytes.as_slice()).unwrap_err();
         assert!(error.to_string().contains("cannot replace target"));
+    }
+
+    #[test]
+    fn oversized_file_payload_is_rejected_when_writing() {
+        let header = EntryHeader {
+            kind: EntryKind::File,
+            path: "large.bin".to_string(),
+            mode: 0o100644,
+            payload_len: MAX_FILE_BYTES + 1,
+        };
+
+        let error = write_header(Vec::new(), &header).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn oversized_file_payload_is_rejected_when_reading() {
+        let header = EntryHeader {
+            kind: EntryKind::File,
+            path: "large.bin".to_string(),
+            mode: 0o100644,
+            payload_len: MAX_FILE_BYTES,
+        };
+        let mut bytes = Vec::new();
+        write_header(&mut bytes, &header).unwrap();
+        bytes[16..24].copy_from_slice(&(MAX_FILE_BYTES + 1).to_be_bytes());
+
+        let error = read_header(bytes.as_slice()).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }
 }

--- a/crates/iii-supervisor/src/source_sync.rs
+++ b/crates/iii-supervisor/src/source_sync.rs
@@ -1,0 +1,216 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Wire protocol for forwarding host source changes into a worker VM.
+//!
+//! Virtiofs exposes current file contents to the guest, but host-side changes
+//! do not produce guest `inotify` events. The host therefore sends the changed
+//! entries over a dedicated virtio-console port. `iii-init` applies them to
+//! `/workspace`; because those writes originate in the guest, normal file
+//! watchers receive native kernel events.
+
+use std::io::{self, Read, Write};
+use std::path::{Component, Path, PathBuf};
+
+pub const SOURCE_SYNC_PORT_NAME: &str = "iii.source-sync";
+
+const FRAME_MAGIC: [u8; 4] = *b"IIIS";
+const ACK_MAGIC: [u8; 4] = *b"IIIA";
+const PROTOCOL_VERSION: u8 = 1;
+const MAX_PATH_BYTES: usize = 64 * 1024;
+const MAX_ACK_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum EntryKind {
+    Remove = 1,
+    Directory = 2,
+    File = 3,
+    Symlink = 4,
+}
+
+impl TryFrom<u8> for EntryKind {
+    type Error = io::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Remove),
+            2 => Ok(Self::Directory),
+            3 => Ok(Self::File),
+            4 => Ok(Self::Symlink),
+            _ => Err(invalid_data(format!(
+                "unknown source-sync entry kind {value}"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntryHeader {
+    pub kind: EntryKind,
+    pub path: String,
+    pub mode: u32,
+    pub payload_len: u64,
+}
+
+pub fn write_header(mut writer: impl Write, header: &EntryHeader) -> io::Result<()> {
+    validate_relative_path(&header.path)?;
+    let path = header.path.as_bytes();
+    if path.len() > MAX_PATH_BYTES {
+        return Err(invalid_input(format!(
+            "source-sync path is too long: {} bytes",
+            path.len()
+        )));
+    }
+
+    writer.write_all(&FRAME_MAGIC)?;
+    writer.write_all(&[PROTOCOL_VERSION, header.kind as u8, 0, 0])?;
+    writer.write_all(&(path.len() as u32).to_be_bytes())?;
+    writer.write_all(&header.mode.to_be_bytes())?;
+    writer.write_all(&header.payload_len.to_be_bytes())?;
+    writer.write_all(path)
+}
+
+pub fn read_header(mut reader: impl Read) -> io::Result<EntryHeader> {
+    let mut magic = [0u8; 4];
+    reader.read_exact(&mut magic)?;
+    if magic != FRAME_MAGIC {
+        return Err(invalid_data("invalid source-sync frame magic"));
+    }
+
+    let mut fixed = [0u8; 20];
+    reader.read_exact(&mut fixed)?;
+    if fixed[0] != PROTOCOL_VERSION {
+        return Err(invalid_data(format!(
+            "unsupported source-sync protocol version {}",
+            fixed[0]
+        )));
+    }
+    let kind = EntryKind::try_from(fixed[1])?;
+    let path_len = u32::from_be_bytes(fixed[4..8].try_into().expect("fixed header slice")) as usize;
+    if path_len == 0 || path_len > MAX_PATH_BYTES {
+        return Err(invalid_data(format!(
+            "source-sync path length {path_len} is out of range"
+        )));
+    }
+    let mode = u32::from_be_bytes(fixed[8..12].try_into().expect("fixed header slice"));
+    let payload_len = u64::from_be_bytes(fixed[12..20].try_into().expect("fixed header slice"));
+
+    let mut path = vec![0u8; path_len];
+    reader.read_exact(&mut path)?;
+    let path =
+        String::from_utf8(path).map_err(|_| invalid_data("source-sync path is not UTF-8"))?;
+    validate_relative_path(&path)?;
+
+    Ok(EntryHeader {
+        kind,
+        path,
+        mode,
+        payload_len,
+    })
+}
+
+pub fn write_ack(mut writer: impl Write, result: Result<(), &str>) -> io::Result<()> {
+    let (status, message) = match result {
+        Ok(()) => (0u8, ""),
+        Err(message) => (1u8, message),
+    };
+    let bytes = message.as_bytes();
+    if bytes.len() > MAX_ACK_BYTES {
+        return Err(invalid_input("source-sync acknowledgement is too long"));
+    }
+    writer.write_all(&ACK_MAGIC)?;
+    writer.write_all(&[status])?;
+    writer.write_all(&(bytes.len() as u32).to_be_bytes())?;
+    writer.write_all(bytes)?;
+    writer.flush()
+}
+
+pub fn read_ack(mut reader: impl Read) -> io::Result<()> {
+    let mut magic = [0u8; 4];
+    reader.read_exact(&mut magic)?;
+    if magic != ACK_MAGIC {
+        return Err(invalid_data("invalid source-sync acknowledgement magic"));
+    }
+    let mut fixed = [0u8; 5];
+    reader.read_exact(&mut fixed)?;
+    let status = fixed[0];
+    let len =
+        u32::from_be_bytes(fixed[1..5].try_into().expect("fixed acknowledgement slice")) as usize;
+    if len > MAX_ACK_BYTES {
+        return Err(invalid_data(format!(
+            "source-sync acknowledgement length {len} is out of range"
+        )));
+    }
+    let mut message = vec![0u8; len];
+    reader.read_exact(&mut message)?;
+    if status == 0 {
+        return Ok(());
+    }
+    let message = String::from_utf8_lossy(&message);
+    Err(io::Error::other(format!(
+        "guest rejected source change: {message}"
+    )))
+}
+
+pub fn validate_relative_path(value: &str) -> io::Result<PathBuf> {
+    let path = Path::new(value);
+    if value.is_empty() || path.is_absolute() {
+        return Err(invalid_input("source-sync path must be relative"));
+    }
+    if path
+        .components()
+        .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(invalid_input(format!(
+            "source-sync path contains an unsafe component: {value}"
+        )));
+    }
+    Ok(path.to_path_buf())
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_roundtrips() {
+        let expected = EntryHeader {
+            kind: EntryKind::File,
+            path: "src/main.rs".to_string(),
+            mode: 0o100644,
+            payload_len: 123,
+        };
+        let mut bytes = Vec::new();
+        write_header(&mut bytes, &expected).unwrap();
+
+        assert_eq!(read_header(bytes.as_slice()).unwrap(), expected);
+    }
+
+    #[test]
+    fn parent_component_is_rejected() {
+        let error = validate_relative_path("src/../../etc/passwd").unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn error_ack_is_reported_to_host() {
+        let mut bytes = Vec::new();
+        write_ack(&mut bytes, Err("cannot replace target")).unwrap();
+
+        let error = read_ack(bytes.as_slice()).unwrap_err();
+        assert!(error.to_string().contains("cannot replace target"));
+    }
+}

--- a/crates/iii-worker/src/cli/local_worker.rs
+++ b/crates/iii-worker/src/cli/local_worker.rs
@@ -14,6 +14,8 @@ use std::path::{Path, PathBuf};
 use super::project::{ProjectInfo, WORKER_MANIFEST, load_project_info};
 use super::rootfs::clone_rootfs;
 
+const PREPARED_MARKER_VERSION: &str = "workspace-copy-in-v1";
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Shared helpers (extracted from dev.rs)
 // ──────────────────────────────────────────────────────────────────────────────
@@ -53,6 +55,10 @@ pub fn engine_url_for_runtime(
     _lan_ip: &Option<String>,
 ) -> String {
     format!("ws://localhost:{}", port)
+}
+
+fn prepared_marker_matches_current_workspace(marker: &Path) -> bool {
+    std::fs::read_to_string(marker).is_ok_and(|contents| contents.trim() == PREPARED_MARKER_VERSION)
 }
 
 /// Ensure the terminal is in cooked (canonical) mode with proper input and
@@ -167,14 +173,9 @@ pub fn copy_dir_contents(src: &Path, dst: &Path) -> Result<(), String> {
 /// the separate `/opt/iii/supervisor` binary and its install plumbing
 /// that this function used to emit as `exec /opt/iii/supervisor ...`.
 ///
-/// `is_bundle` controls dep-directory bind-mount behavior:
-///   * local-path workers (false): bind-mount VM-local dirs over
-///     /workspace/{node_modules,.venv,target,dist,...} so dependency
-///     installs run inside the guest without polluting the host repo.
-///   * bundle workers (true): SKIP the bind-mount block entirely. The
-///     bundle is immutable and ships vendored deps (a bundle's
-///     `dist/index.js` IS the worker; masking it with an empty rootfs
-///     dir breaks the boot).
+/// `is_bundle` controls workspace behavior:
+///   * local-path workers copy host source into a guest-local `/workspace`;
+///   * bundle workers mount their immutable install directory at `/workspace`.
 pub fn build_libkrun_local_script(
     project: &ProjectInfo,
     prepared: bool,
@@ -182,34 +183,24 @@ pub fn build_libkrun_local_script(
     overlay: bool,
 ) -> String {
     let env_exports = build_env_exports(&project.env);
-    let mut parts: Vec<String> = Vec::new();
+    let mut parts = vec![
+        "set -e".to_string(),
+        "export HOME=${HOME:-/root}".to_string(),
+        "export PATH=/usr/local/bin:/usr/bin:/bin:$PATH".to_string(),
+        "export LANG=${LANG:-C.UTF-8}".to_string(),
+    ];
 
-    parts.push("set -e".to_string());
-    parts.push("export HOME=${HOME:-/root}".to_string());
-    parts.push("export PATH=/usr/local/bin:/usr/bin:/bin:$PATH".to_string());
-    parts.push("export LANG=${LANG:-C.UTF-8}".to_string());
-
-    // Workspace strategy (three cases):
+    // Workspace strategy:
     //
     //  - BUNDLE: the immutable install dir is mounted live at /workspace via
     //    virtiofs; vendored deps ship inside it, so no dep handling is needed.
     //
-    //  - OVERLAY local (W1 copy-in): the host project is mounted READ-ONLY at
-    //    /mnt/host-src and COPIED into a VM-local /workspace (on the ext4
-    //    upper). Dep installs (node_modules, .venv, …) and build outputs land
-    //    in the VM-local /workspace and persist across restarts on the upper —
-    //    and the host project is never WRITTEN, so the empty dep-dir folders
-    //    the bind-mount model created in the host repo no longer appear. Host
-    //    edits propagate via the source watcher restarting the VM (which
-    //    re-copies). The dep dirs are excluded from the copy so VM-local deps
-    //    survive a re-copy and host clutter isn't pulled in.
-    //
-    //  - LEGACY local: host project mounted live at /workspace (virtiofs) with
-    //    dep dirs bind-mounted from the rootfs to keep their writes VM-local.
-    //    Tradeoff: each bind target must exist, so a `mkdir /workspace/$d`
-    //    creates an empty dir in the host repo (the bug W1 fixes for overlay).
-    //    We tried overlayfs with a virtiofs lower and hit errno 102 (copy-up
-    //    fails for PassthroughFs reads); bind-mounts sidestep that.
+    //  - LOCAL: the host project is mounted temporarily at /mnt/host-src and
+    //    copied into /workspace. The share is detached before user code runs.
+    //    Later changes arrive over `iii.source-sync` and are written by
+    //    iii-init, which makes the guest kernel emit native inotify events.
+    //    Dependency and build directories remain VM-local and are excluded
+    //    from both the initial copy and later synchronization.
     //
     // The mountpoint checks guard against iii-init's mount_virtiofs_shares()
     // swallowing a mount failure as a warning (leaving the path
@@ -227,7 +218,7 @@ cd /workspace
 echo "iii: workspace ready (bundle worker; dep-dir bind-mounts skipped — vendored deps are shipped in the bundle)" >&2"#
                 .to_string(),
         );
-    } else if overlay {
+    } else {
         parts.push(
             r#"SRC=/mnt/host-src
 mkdir -p /workspace
@@ -256,55 +247,27 @@ find /workspace -mindepth 1 -maxdepth 1 \
 # isn't pulled in. Only /mnt/host-src is read; the host project is never
 # written, so no empty dep folders appear there.
 ( set -o pipefail; ( cd "$SRC" && tar -cf - --exclude=node_modules --exclude=.venv --exclude=target --exclude=dist --exclude=__pycache__ --exclude=.pytest_cache --exclude=.next --exclude=.git . ) | ( cd /workspace && tar -xpf - ) ) || { echo "iii: ERROR workspace copy-in failed" >&2; exit 1; }
-# Enforce "host project untouched": DETACH the host source now that it's copied
-# in, so worker code cannot write back to the host repo via /mnt/host-src. cd
-# out first so the mount isn't busy. The unmount is FATAL: the share is mounted
-# read-write, so if we can't detach it we refuse to run user code rather than
-# risk mutating the host repo. The host-side watcher re-copies on the next boot.
+# Enforce "host project untouched": detach the initial source share before
+# user code runs. Later edits arrive as file operations over iii.source-sync.
 cd /
 umount "$SRC" || { echo "iii: ERROR could not detach $SRC; refusing to run with host source writable" >&2; exit 1; }
+mkdir -p /run/iii
+touch /run/iii/source-ready
 cd /workspace
 echo "iii: workspace ready (copy-in from host; deps stay VM-local, host project untouched)" >&2"#
-                .to_string(),
-        );
-    } else {
-        parts.push(
-            r#"if ! { mountpoint -q /workspace 2>/dev/null || awk '$5 == "/workspace" && / - virtiofs /' /proc/self/mountinfo | grep -q .; }; then
-  echo "iii: ERROR /workspace is not a virtiofs mountpoint (share missing or mount failed)" >&2
-  echo "--- III_VIRTIOFS_MOUNTS=${III_VIRTIOFS_MOUNTS:-<unset>} ---" >&2
-  cat /proc/self/mountinfo >&2 2>/dev/null || cat /proc/mounts >&2 2>/dev/null || mount >&2
-  exit 1
-fi
-DEPS_ROOT=/var/iii/deps
-for d in node_modules .venv target dist __pycache__ .pytest_cache .next; do
-  mkdir -p "$DEPS_ROOT/$d"
-  if [ ! -e "/workspace/$d" ]; then
-    mkdir "/workspace/$d"
-  elif [ ! -d "/workspace/$d" ]; then
-    echo "iii: WARN /workspace/$d exists but is not a directory, skipping bind" >&2
-    continue
-  fi
-  mount --bind "$DEPS_ROOT/$d" "/workspace/$d"
-done
-cd /workspace
-echo "iii: workspace ready; deps mounted VM-local from $DEPS_ROOT" >&2"#
                 .to_string(),
         );
     }
 
     parts.push("echo $$ > /sys/fs/cgroup/worker/cgroup.procs 2>/dev/null || true".to_string());
 
-    // Host source changes are handled by the host-side `__watch-source`
-    // sidecar (see source_watcher.rs), which restarts the whole VM on
-    // change. In-VM watchers are not expected to detect host edits, so
-    // no polling env vars are exported here — they'd just add overhead
-    // and couldn't help tsx 4.x anyway (tsx uses fs.watch with no
-    // polling fallback, and doesn't depend on chokidar).
+    // Host source changes are transported into /workspace by iii-init. The
+    // resulting guest-side filesystem operations produce normal inotify
+    // events; the command declared by the worker owns restart behavior.
 
     // Provisioning (setup + install) gating:
-    //   - legacy: the host decides via `prepared` — it can see the marker in
-    //     the per-worker clone (`managed_dir/var/.iii-prepared`) and omits the
-    //     block entirely once prepared.
+    //   - legacy: the host validates the versioned marker in the per-worker
+    //     clone and omits the block once the current workspace layout is ready.
     //   - overlay: the marker lives on the persistent ext4 upper, which the
     //     host CANNOT see (it's inside a block device). So always emit the
     //     block but guard it IN-GUEST on the marker. The upper persists across
@@ -321,15 +284,20 @@ echo "iii: workspace ready; deps mounted VM-local from $DEPS_ROOT" >&2"#
             prov.push_str(&project.install_cmd);
             prov.push('\n');
         }
-        // `&& sync` flushes the just-installed deps + the marker from the guest
-        // page cache to the ext4 upper (/dev/vdb) the instant install finishes.
+        // `sync` flushes the just-installed deps + the marker from the guest
+        // page cache to the ext4 upper (/dev/vdb) after install finishes.
         // Without it, a worker that exits within ext4's ~5s commit window tears
         // the VM down before the write lands, losing both and re-running install
         // next boot. ponytail: belt-and-suspenders with iii-init's sync-on-exit
         // (supervisor::sync_and_exit); this also covers a SIGKILL that lands
         // after install but before the worker exits.
         parts.push(format!(
-            "if [ ! -e /var/.iii-prepared ]; then\n{prov}mkdir -p /var && touch /var/.iii-prepared && sync\nfi"
+            r#"if [ "$(cat /var/.iii-prepared 2>/dev/null || true)" != "{PREPARED_MARKER_VERSION}" ]; then
+rm -f /var/.iii-prepared
+{prov}mkdir -p /var
+printf '%s\n' '{PREPARED_MARKER_VERSION}' > /var/.iii-prepared
+sync
+fi"#
         ));
         // Host-visible readiness: /opt/iii is a virtiofs mount of the host's
         // managed_dir/runtime, so the host (status / `--wait`) can see this
@@ -343,7 +311,9 @@ echo "iii: workspace ready; deps mounted VM-local from $DEPS_ROOT" >&2"#
         if !project.install_cmd.is_empty() {
             parts.push(project.install_cmd.clone());
         }
-        parts.push("mkdir -p /var && touch /var/.iii-prepared".to_string());
+        parts.push(format!(
+            r#"mkdir -p /var && printf '%s\n' '{PREPARED_MARKER_VERSION}' > /var/.iii-prepared"#
+        ));
     }
 
     // Exec the user command directly. When the host has configured a
@@ -880,7 +850,6 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
         worker_name,
         worker_path,
         port,
-        /*disable_watcher=*/ false,
         /*is_bundle=*/ false,
         None,
         None,
@@ -896,8 +865,7 @@ pub async fn start_local_worker(worker_name: &str, worker_path: &str, port: u16)
 /// Start a bundle worker VM. Same libkrun rails as
 /// `start_local_worker`, but two bundle-specific behaviors apply:
 ///
-/// 1. The host-side source watcher is NOT spawned (bundle is
-///    immutable; nothing to watch).
+/// 1. Source synchronization is not enabled because the bundle is immutable.
 /// 2. Resources from `iii.worker.yaml` are clamped against the
 ///    bundle resource caps BEFORE libkrun boot. The install-time
 ///    clamp (handle_bundle_add) only emits a warning; without this
@@ -921,7 +889,6 @@ pub async fn start_bundle_worker(worker_name: &str, worker_path: &str, port: u16
         worker_name,
         worker_path,
         port,
-        /*disable_watcher=*/ true,
         /*is_bundle=*/ true,
         None,
         None,
@@ -953,10 +920,6 @@ pub async fn local_vm_command(
         // The guest reaches the engine through `over.engine_url`; no port is
         // derived here.
         0,
-        // Compose supervises the VM itself. A detached, name-keyed watcher
-        // could restart a different project that uses the same container key.
-        /*disable_watcher=*/
-        true,
         /*is_bundle=*/ false,
         Some(over),
         run_override,
@@ -1030,7 +993,6 @@ pub async fn bundle_vm_command(
         // The guest reaches the engine through `over.engine_url`; no port is
         // derived here.
         0,
-        /*disable_watcher=*/ true,
         /*is_bundle=*/ true,
         Some(over),
         None,
@@ -1049,10 +1011,8 @@ pub async fn bundle_vm_command(
 
 /// Shared body for `start_local_worker` and `start_bundle_worker`.
 ///
-/// Three flags differ between callers:
-///   * `disable_watcher` — bundle installs are immutable, so the
-///     host-side source watcher is suppressed.
-///   * `is_bundle` — when true, resources are parsed and clamped via
+/// `is_bundle` changes resource and workspace handling: when true, resources
+/// are parsed and clamped via
 ///     `bundle_download::parse_bundle_resources` (saturating + capped)
 ///     rather than the permissive `parse_manifest_resources`. Local
 ///     workers continue to honor whatever the user wrote.
@@ -1096,7 +1056,6 @@ async fn start_worker_impl(
     worker_name: &str,
     worker_path: &str,
     port: u16,
-    disable_watcher: bool,
     is_bundle: bool,
     over: Option<VmOverride<'_>>,
     run_override: Option<&str>,
@@ -1304,14 +1263,9 @@ async fn start_worker_impl(
         }
     }
 
-    // 5. Workspace staging. The actual strategy lives in the boot script
-    //    (build_libkrun_local_script) and depends on mode:
-    //      - legacy/bundle: the host project (or install dir) is shared LIVE at
-    //        guest /workspace via virtiofs; legacy also bind-mounts dep dirs
-    //        VM-local.
-    //      - overlay: the host project is shared at /mnt/host-src and COPIED
-    //        into a VM-local /workspace on the ext4 upper (W1 copy-in), so the
-    //        host repo is never written.
+    // 5. Workspace staging. Bundle installs are shared live at `/workspace`.
+    //    Local workers use `/mnt/host-src` only for initial copy-in, in both
+    //    legacy and overlay modes, so the host repo is never written.
     //    Pre-create the managed-dir mountpoint so the legacy clone (which IS
     //    the guest root) has /workspace to mount onto; harmless under overlay.
     let workspace_dir = managed_dir.join("workspace");
@@ -1325,16 +1279,29 @@ async fn start_worker_impl(
         return VmStart::Exit(1);
     }
 
-    // Check the .iii-prepared marker. Silent when true — the boot script
-    //    skips setup_cmd/install_cmd and nothing user-visible is happening
-    //    in the fast path. Printing a "Using cached deps" banner every
-    //    start made it look like install was running every restart (it
-    //    wasn't), which confused users reading watcher.log tails.
-    // Derive from the already-resolved `managed_dir` (built behind the strict
-    // home_dir() guard above) rather than re-resolving via worker name, so the
-    // marker check can't diverge from the dir this function actually uses.
+    // An empty marker from the former bind-mounted dependency layout is stale:
+    // its packages live under /var/iii/deps, while copy-in workers load them
+    // from /workspace. Remove stale markers before boot so status cannot report
+    // Ready while the replacement install is still running.
     let prepared_marker = super::managed::prepared_marker_in(&managed_dir);
-    let is_prepared = prepared_marker.exists();
+    let is_prepared = prepared_marker_matches_current_workspace(&prepared_marker);
+    if !is_prepared {
+        match std::fs::remove_file(&prepared_marker) {
+            Ok(()) => {
+                tracing::debug!(marker = %prepared_marker.display(), "removed stale prepared marker");
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                eprintln!(
+                    "{} Could not remove stale prepared marker {}: {}",
+                    "error:".red(),
+                    prepared_marker.display(),
+                    error
+                );
+                return VmStart::Exit(1);
+            }
+        }
+    }
 
     // 6. Build env with engine URL + OCI env + config.yaml env
     let engine_url = match over.as_ref() {
@@ -1507,11 +1474,10 @@ async fn start_worker_impl(
         parse_manifest_resources(&manifest_path)
     };
 
-    // W1 copy-in (overlay local only): share the host project READ-ONLY at
-    // /mnt/host-src and let the boot script copy it into a VM-local /workspace,
-    // so dep installs/build outputs never write the host repo (no empty dep
-    // folders). Bundles and legacy keep the live /workspace virtiofs mount.
-    let copy_in = overlay && !is_bundle;
+    // Local workers always copy into /workspace. This is required for native
+    // guest file events: later host changes are applied by iii-init rather than
+    // appearing as out-of-band mutations on a live virtiofs mount.
+    let copy_in = !is_bundle;
     let workspace_guest = if copy_in {
         "/mnt/host-src"
     } else {
@@ -1574,8 +1540,7 @@ async fn start_worker_impl(
     };
 
     // A caller with its own supervisor takes the built command and stops here:
-    // spawning, waiting and stopping are its job, and the source watcher below
-    // has nothing to watch on an immutable install.
+    // spawning, waiting, and stopping are its job.
     if over.is_some() {
         return match super::worker_manager::libkrun::build_vm_command(
             exec_path,
@@ -1588,6 +1553,7 @@ async fn start_worker_impl(
             rootfs_mode,
             rootfs_upper,
             &mounts,
+            (!is_bundle).then_some(project_path),
         ) {
             Ok(built) => VmStart::Plan(Box::new(built)),
             Err(e) => {
@@ -1597,7 +1563,6 @@ async fn start_worker_impl(
         };
     }
 
-    let managed_dir_for_watcher = managed_dir.clone();
     let exit_code = super::worker_manager::libkrun::run_dev(
         kind,
         worker_path,
@@ -1613,125 +1578,11 @@ async fn start_worker_impl(
         true,
         worker_name,
         &mounts,
+        (!is_bundle).then_some(project_path),
     )
     .await;
 
-    // Spawn the host-side source watcher sidecar. Virtiofs doesn't
-    // propagate inotify, so in-VM watchers (tsx watch, node --watch,
-    // cargo watch, etc.) don't see host edits — we watch from the host
-    // and re-invoke `iii-worker start` on change to kill+restart.
-    //
-    // Only spawn after the VM was successfully started; otherwise a
-    // watcher fire would race into kill_stale_worker against nothing.
-    //
-    // Bundle workers (disable_watcher=true) skip this entirely: the
-    // install dir is immutable and there is nothing to watch.
-    if !disable_watcher
-        && exit_code == 0
-        && let Err(e) =
-            spawn_source_watcher(worker_name, project_path, &managed_dir_for_watcher, overlay).await
-    {
-        eprintln!(
-            "  {} source watcher failed to start: {}. Source edits will not auto-restart.",
-            "warning:".yellow(),
-            e
-        );
-    }
-
     VmStart::Exit(exit_code)
-}
-
-// Sidecar pidfile writes delegate to super::pidfile::write_pid_file for
-// unified hardening across all managed-dir pidfiles. See that module
-// for rationale; in short, O_NOFOLLOW + 0o600 on Unix so a symlink
-// pre-planted at watch.pid can't redirect our write to a sensitive
-// target.
-use super::pidfile::write_pid_file;
-
-/// Spawn the hidden `__watch-source` sidecar process, detached, with
-/// its PID recorded so `kill_stale_worker` can reap it on stop.
-async fn spawn_source_watcher(
-    worker_name: &str,
-    project_path: &Path,
-    managed_dir: &Path,
-    overlay: bool,
-) -> std::io::Result<()> {
-    use std::path::PathBuf;
-
-    // If a watcher is already running for this worker (stale PID file
-    // from a crashed previous start), reap it first so we don't stack
-    // sidecars that fight over the same project dir. Delegates to the
-    // grace-period reaper in managed.rs so both reap paths stay in sync.
-    super::managed::reap_source_watcher(worker_name).await;
-
-    let pid_file = managed_dir.join("watch.pid");
-    let self_exe = std::env::current_exe()?;
-    let logs_dir = dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join(".iii/logs")
-        .join(worker_name);
-    std::fs::create_dir_all(&logs_dir)?;
-    // Lock log dir to 0o700 so another local user can't traverse in and
-    // plant a symlink at watcher.log pointing at, e.g., ~/.ssh/authorized_keys.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&logs_dir, std::fs::Permissions::from_mode(0o700));
-    }
-    let log_path = logs_dir.join("watcher.log");
-    let mut log_opts = std::fs::OpenOptions::new();
-    log_opts.create(true).append(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        // O_NOFOLLOW on the final path component so a pre-planted
-        // symlink (by another local user with dir-traverse access)
-        // can't redirect our appends to an arbitrary file.
-        log_opts.custom_flags(nix::libc::O_NOFOLLOW);
-        // Create as 0o600 — owner-only.
-        log_opts.mode(0o600);
-    }
-    let log_file = log_opts.open(&log_path)?;
-    let log_file2 = log_file.try_clone()?;
-
-    let project_abs =
-        std::fs::canonicalize(project_path).unwrap_or_else(|_| project_path.to_path_buf());
-
-    let mut cmd = std::process::Command::new(&self_exe);
-    cmd.arg("__watch-source")
-        .arg("--worker")
-        .arg(worker_name)
-        .arg("--project")
-        .arg(&project_abs)
-        .stdin(std::process::Stdio::null())
-        .stdout(log_file)
-        .stderr(log_file2);
-    // Hand the authoritative workspace model to the watcher so it never has to
-    // re-derive overlay-ness from the (best-effort, ambiguous) .iii-layout
-    // marker. Only passed when overlay; absence means live-mount.
-    if overlay {
-        cmd.arg("--overlay");
-    }
-
-    #[cfg(unix)]
-    unsafe {
-        use std::os::unix::process::CommandExt;
-        cmd.pre_exec(|| {
-            nix::unistd::setsid().map_err(std::io::Error::other)?;
-            Ok(())
-        });
-    }
-
-    let child = cmd.spawn()?;
-    let pid = child.id();
-    write_pid_file(&pid_file, pid);
-
-    eprintln!(
-        "  {} source watcher online (pid: {})",
-        "\u{2713}".green(),
-        pid
-    );
-    Ok(())
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -1827,11 +1678,11 @@ mod tests {
         assert!(script.contains("npm install"));
         assert!(script.contains("node server.js"));
         assert!(script.contains(".iii-prepared"));
-        assert!(script.contains("mount --bind"));
-        assert!(script.contains("/var/iii/deps"));
+        assert!(script.contains("SRC=/mnt/host-src"));
+        assert!(script.contains("touch /run/iii/source-ready"));
+        assert!(!script.contains("mount --bind"));
         assert!(script.contains("node_modules"));
-        // Polling env vars were removed — the host-side __watch-source
-        // sidecar handles reload-on-edit by restarting the whole VM.
+        // The guest receives real file operations over iii.source-sync.
         assert!(!script.contains("CHOKIDAR_USEPOLLING"));
         assert!(!script.contains("WATCHFILES_FORCE_POLLING"));
         assert!(!script.contains("TSC_WATCHFILE"));
@@ -1854,7 +1705,42 @@ mod tests {
         assert!(!script.contains("apt-get install nodejs"));
         assert!(!script.contains("npm install"));
         assert!(script.contains("node server.js"));
-        assert!(script.contains("mount --bind"));
+        assert!(script.contains("SRC=/mnt/host-src"));
+        assert!(script.contains("touch /run/iii/source-ready"));
+    }
+
+    #[test]
+    fn legacy_empty_prepared_marker_reruns_install_after_copy_in_migration() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join(".iii-prepared");
+        std::fs::write(&marker, "").unwrap();
+        let project = ProjectInfo {
+            name: "test".to_string(),
+            kind: Some("typescript".to_string()),
+            setup_cmd: String::new(),
+            install_cmd: "npm install".to_string(),
+            run_cmd: "npm run start".to_string(),
+            env: HashMap::new(),
+            base_image: None,
+        };
+
+        let script = build_libkrun_local_script(
+            &project,
+            prepared_marker_matches_current_workspace(&marker),
+            /*is_bundle=*/ false,
+            /*overlay=*/ false,
+        );
+
+        assert!(script.contains("npm install"));
+    }
+
+    #[test]
+    fn current_prepared_marker_matches_copy_in_workspace() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join(".iii-prepared");
+        std::fs::write(&marker, PREPARED_MARKER_VERSION).unwrap();
+
+        assert!(prepared_marker_matches_current_workspace(&marker));
     }
 
     #[test]
@@ -1874,16 +1760,18 @@ mod tests {
         let script = build_libkrun_local_script(
             &project, /*prepared=*/ true, /*is_bundle=*/ false, true,
         );
-        assert!(script.contains("if [ ! -e /var/.iii-prepared ]; then"));
+        assert!(script.contains("cat /var/.iii-prepared"));
+        assert!(script.contains(PREPARED_MARKER_VERSION));
+        assert!(script.contains("rm -f /var/.iii-prepared"));
         assert!(script.contains("apt-get install nodejs"));
         assert!(script.contains("npm install"));
         // Durability: the marker write is followed by `sync` so deps + marker
         // flush to the ext4 upper before a fast worker exit tears the VM down.
-        assert!(script.contains("touch /var/.iii-prepared && sync"));
+        assert!(script.contains("printf '%s\\n'"));
+        assert!(script.contains("sync\nfi"));
         assert!(script.contains("node server.js"));
-        // W1 copy-in: overlay copies host source from /mnt/host-src into a
-        // VM-local /workspace and does NOT bind-mount dep dirs (which would
-        // mkdir empty folders in the host repo).
+        // Local workers copy host source from /mnt/host-src into /workspace
+        // and do not bind-mount dependency directories.
         assert!(script.contains("SRC=/mnt/host-src"));
         assert!(script.contains("tar -cf -"));
         // Re-sync deletions: clear /workspace (minus dep dirs) before extract so
@@ -1907,9 +1795,7 @@ mod tests {
     }
 
     #[test]
-    fn build_libkrun_local_script_legacy_still_uses_bind_loop() {
-        // Legacy (overlay=false) keeps the live /workspace + dep bind-mounts;
-        // W1 copy-in is overlay-only.
+    fn build_libkrun_local_script_legacy_uses_copy_in_for_native_events() {
         let project = ProjectInfo {
             name: "test".to_string(),
             kind: Some("typescript".to_string()),
@@ -1922,9 +1808,10 @@ mod tests {
         let script = build_libkrun_local_script(
             &project, /*prepared=*/ false, /*is_bundle=*/ false, false,
         );
-        assert!(script.contains("mount --bind"));
-        assert!(script.contains("/var/iii/deps"));
-        assert!(!script.contains("SRC=/mnt/host-src"));
+        assert!(!script.contains("mount --bind"));
+        assert!(!script.contains("/var/iii/deps"));
+        assert!(script.contains("SRC=/mnt/host-src"));
+        assert!(script.contains("touch /run/iii/source-ready"));
     }
 
     #[test]

--- a/crates/iii-worker/src/cli/mod.rs
+++ b/crates/iii-worker/src/cli/mod.rs
@@ -31,6 +31,7 @@ pub mod sandbox;
 pub mod sandbox_daemon;
 pub mod shell_client;
 pub mod shell_relay;
+pub mod source_sync_host;
 pub mod source_watcher;
 pub mod spinner;
 pub mod status;

--- a/crates/iii-worker/src/cli/pidfile.rs
+++ b/crates/iii-worker/src/cli/pidfile.rs
@@ -232,7 +232,6 @@ mod tests {
     fn known_call_sites_route_through_module() {
         let manifest = env!("CARGO_MANIFEST_DIR");
         let cases: &[(&str, &str)] = &[
-            ("src/cli/local_worker.rs", "pidfile::write_pid_file"),
             ("src/cli/managed.rs", "pidfile::write_pid_file"),
             (
                 "src/cli/worker_manager/libkrun.rs",

--- a/crates/iii-worker/src/cli/source_sync_host.rs
+++ b/crates/iii-worker/src/cli/source_sync_host.rs
@@ -1,0 +1,265 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Host-side source transport for local worker VMs.
+//!
+//! This module observes the host project and sends changed entries to
+//! `iii-init`. It never restarts a process or VM. Restart policy stays inside
+//! the worker, where normal tools consume the guest kernel's file events.
+
+use std::collections::{BTreeSet, HashSet};
+use std::fs::File;
+use std::io::{self, Write};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::time::Duration;
+
+use iii_supervisor::source_sync::{self, EntryHeader, EntryKind};
+use notify::{Event, EventKind, Watcher};
+
+use super::source_watcher::{DEBOUNCE_MS, register_new_dirs, should_ignore_path, watch_pruned};
+
+pub fn spawn(source_root: PathBuf, stream: UnixStream) -> io::Result<()> {
+    let source_root = std::fs::canonicalize(&source_root)?;
+    let (tx, rx) = mpsc::channel::<Event>();
+    let filter_root = source_root.clone();
+    let mut watcher = notify::RecommendedWatcher::new(
+        move |result: Result<Event, notify::Error>| match result {
+            Ok(event)
+                if matches!(
+                    event.kind,
+                    EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_)
+                ) && event.paths.iter().any(|path| {
+                    path != &filter_root && !should_ignore_path(path, &filter_root)
+                }) =>
+            {
+                let _ = tx.send(event);
+            }
+            Ok(_) => {}
+            Err(error) => tracing::warn!(%error, "source sync: notify backend error"),
+        },
+        notify::Config::default(),
+    )
+    .map_err(io::Error::other)?;
+
+    let mut registered = HashSet::new();
+    watch_pruned(&mut watcher, &source_root, &mut registered).map_err(io::Error::other)?;
+
+    std::thread::Builder::new()
+        .name("iii-source-sync".to_string())
+        .spawn(move || {
+            if let Err(error) = run_loop(source_root, stream, watcher, registered, rx) {
+                tracing::warn!(%error, "source sync stopped");
+            }
+        })?;
+    Ok(())
+}
+
+fn run_loop(
+    source_root: PathBuf,
+    mut stream: UnixStream,
+    mut watcher: notify::RecommendedWatcher,
+    mut registered: HashSet<PathBuf>,
+    rx: mpsc::Receiver<Event>,
+) -> io::Result<()> {
+    tracing::info!(path = %source_root.display(), "source sync: online");
+
+    loop {
+        let first = match rx.recv() {
+            Ok(event) => event,
+            Err(_) => return Ok(()),
+        };
+        let mut paths = first.paths;
+        loop {
+            match rx.recv_timeout(Duration::from_millis(DEBOUNCE_MS)) {
+                Ok(event) => paths.extend(event.paths),
+                Err(RecvTimeoutError::Timeout) => break,
+                Err(RecvTimeoutError::Disconnected) => return Ok(()),
+            }
+        }
+
+        register_new_dirs(&mut watcher, &paths, &source_root, &mut registered);
+        for path in coalesce_paths(paths, &source_root) {
+            send_current_entry(&mut stream, &source_root, &path)?;
+        }
+    }
+}
+
+fn coalesce_paths(paths: Vec<PathBuf>, root: &Path) -> Vec<PathBuf> {
+    let mut unique: Vec<PathBuf> = paths
+        .into_iter()
+        .filter(|path| path != root && path.starts_with(root))
+        .filter(|path| !should_ignore_path(path, root))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    unique.sort_by_key(|path| path.components().count());
+
+    let mut selected: Vec<PathBuf> = Vec::new();
+    for path in unique {
+        if selected.iter().any(|parent| path.starts_with(parent)) {
+            continue;
+        }
+        selected.push(path);
+    }
+    selected
+}
+
+fn send_current_entry(stream: &mut UnixStream, root: &Path, path: &Path) -> io::Result<()> {
+    if should_ignore_path(path, root) {
+        return Ok(());
+    }
+    let relative = relative_utf8(root, path)?;
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let link = std::fs::read_link(path)?;
+            let bytes = link.as_os_str().as_bytes();
+            send_header(
+                stream,
+                EntryKind::Symlink,
+                relative,
+                metadata.permissions().mode(),
+                bytes.len() as u64,
+            )?;
+            stream.write_all(bytes)?;
+            finish_entry(stream)
+        }
+        Ok(metadata) if metadata.is_dir() => {
+            send_header(
+                stream,
+                EntryKind::Directory,
+                relative,
+                metadata.permissions().mode(),
+                0,
+            )?;
+            finish_entry(stream)?;
+
+            let mut children = std::fs::read_dir(path)?.collect::<Result<Vec<_>, _>>()?;
+            children.sort_by_key(|entry| entry.file_name());
+            for child in children {
+                send_current_entry(stream, root, &child.path())?;
+            }
+            Ok(())
+        }
+        Ok(metadata) if metadata.is_file() => {
+            let mut file = File::open(path)?;
+            let metadata = file.metadata()?;
+            send_header(
+                stream,
+                EntryKind::File,
+                relative,
+                metadata.permissions().mode(),
+                metadata.len(),
+            )?;
+            let copied = io::copy(&mut file, stream)?;
+            if copied != metadata.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "source file {} changed while it was being synchronized",
+                        path.display()
+                    ),
+                ));
+            }
+            finish_entry(stream)
+        }
+        Ok(_) => {
+            tracing::debug!(path = %path.display(), "source sync: unsupported file type skipped");
+            Ok(())
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            send_header(stream, EntryKind::Remove, relative, 0, 0)?;
+            finish_entry(stream)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn send_header(
+    stream: &mut UnixStream,
+    kind: EntryKind,
+    path: &str,
+    mode: u32,
+    payload_len: u64,
+) -> io::Result<()> {
+    source_sync::write_header(
+        stream,
+        &EntryHeader {
+            kind,
+            path: path.to_string(),
+            mode,
+            payload_len,
+        },
+    )
+}
+
+fn finish_entry(stream: &mut UnixStream) -> io::Result<()> {
+    stream.flush()?;
+    source_sync::read_ack(stream)
+}
+
+fn relative_utf8<'a>(root: &Path, path: &'a Path) -> io::Result<&'a str> {
+    path.strip_prefix(root)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path is outside source root"))?
+        .to_str()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "source path is not UTF-8"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn child_paths_are_collapsed_under_changed_directory() {
+        let root = Path::new("/project");
+        let paths = vec![
+            root.join("src/lib.rs"),
+            root.join("src"),
+            root.join("src/nested/mod.rs"),
+        ];
+
+        assert_eq!(coalesce_paths(paths, root), vec![root.join("src")]);
+    }
+
+    #[test]
+    fn ignored_dependency_paths_are_removed_from_burst() {
+        let root = Path::new("/project");
+        let paths = vec![
+            root.join("node_modules/pkg/index.js"),
+            root.join("src/index.js"),
+        ];
+
+        assert_eq!(coalesce_paths(paths, root), vec![root.join("src/index.js")]);
+    }
+
+    #[test]
+    fn changed_file_is_framed_with_its_content() {
+        use std::io::Read;
+
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        let changed = source.join("main.rs");
+        std::fs::write(&changed, b"fn main() {}\n").unwrap();
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+
+        let receiver = std::thread::spawn(move || {
+            let header = source_sync::read_header(&mut guest).unwrap();
+            let mut payload = vec![0u8; header.payload_len as usize];
+            guest.read_exact(&mut payload).unwrap();
+            source_sync::write_ack(&mut guest, Ok(())).unwrap();
+            (header, payload)
+        });
+
+        send_current_entry(&mut host, &source, &changed).unwrap();
+        let (header, payload) = receiver.join().unwrap();
+        assert_eq!(header.path, "main.rs");
+        assert_eq!(payload, b"fn main() {}\n");
+    }
+}

--- a/crates/iii-worker/src/cli/source_sync_host.rs
+++ b/crates/iii-worker/src/cli/source_sync_host.rs
@@ -11,10 +11,10 @@
 //! the worker, where normal tools consume the guest kernel's file events.
 
 use std::collections::{BTreeSet, HashSet};
-use std::fs::File;
-use std::io::{self, Write};
+use std::fs::{File, Metadata};
+use std::io::{self, Read, Write};
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, RecvTimeoutError};
@@ -24,6 +24,14 @@ use iii_supervisor::source_sync::{self, EntryHeader, EntryKind};
 use notify::{Event, EventKind, Watcher};
 
 use super::source_watcher::{DEBOUNCE_MS, register_new_dirs, should_ignore_path, watch_pruned};
+
+const FILE_READ_ATTEMPTS: usize = 3;
+
+#[derive(Debug)]
+struct FileSnapshot {
+    contents: Vec<u8>,
+    mode: u32,
+}
 
 pub fn spawn(source_root: PathBuf, stream: UnixStream) -> io::Result<()> {
     let source_root = std::fs::canonicalize(&source_root)?;
@@ -148,25 +156,31 @@ fn send_current_entry(stream: &mut UnixStream, root: &Path, path: &Path) -> io::
             Ok(())
         }
         Ok(metadata) if metadata.is_file() => {
-            let mut file = File::open(path)?;
-            let metadata = file.metadata()?;
+            let snapshot = match read_stable_file(path) {
+                Ok(snapshot) => snapshot,
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::InvalidData | io::ErrorKind::WouldBlock
+                    ) =>
+                {
+                    tracing::warn!(path = %path.display(), %error, "source sync: file skipped");
+                    return Ok(());
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    send_header(stream, EntryKind::Remove, relative, 0, 0)?;
+                    return finish_entry(stream);
+                }
+                Err(error) => return Err(error),
+            };
             send_header(
                 stream,
                 EntryKind::File,
                 relative,
-                metadata.permissions().mode(),
-                metadata.len(),
+                snapshot.mode,
+                snapshot.contents.len() as u64,
             )?;
-            let copied = io::copy(&mut file, stream)?;
-            if copied != metadata.len() {
-                return Err(io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    format!(
-                        "source file {} changed while it was being synchronized",
-                        path.display()
-                    ),
-                ));
-            }
+            stream.write_all(&snapshot.contents)?;
             finish_entry(stream)
         }
         Ok(_) => {
@@ -179,6 +193,70 @@ fn send_current_entry(stream: &mut UnixStream, root: &Path, path: &Path) -> io::
         }
         Err(error) => Err(error),
     }
+}
+
+fn read_stable_file(path: &Path) -> io::Result<FileSnapshot> {
+    for attempt in 0..FILE_READ_ATTEMPTS {
+        let mut file = File::open(path)?;
+        let before = file.metadata()?;
+        if before.len() > source_sync::MAX_FILE_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "source file is too large: {} bytes (maximum {})",
+                    before.len(),
+                    source_sync::MAX_FILE_BYTES
+                ),
+            ));
+        }
+
+        let capacity = usize::try_from(before.len()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "source file size does not fit in memory on this host",
+            )
+        })?;
+        let mut contents = Vec::new();
+        contents.try_reserve_exact(capacity).map_err(|error| {
+            io::Error::other(format!(
+                "could not reserve memory for source file {}: {error}",
+                path.display()
+            ))
+        })?;
+        let copied = (&mut file).take(before.len()).read_to_end(&mut contents)? as u64;
+        let after = std::fs::symlink_metadata(path)?;
+
+        if copied == before.len() && same_file_version(&before, &after) {
+            return Ok(FileSnapshot {
+                contents,
+                mode: before.permissions().mode(),
+            });
+        }
+
+        if attempt + 1 < FILE_READ_ATTEMPTS {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::WouldBlock,
+        format!(
+            "source file {} kept changing while it was being synchronized",
+            path.display()
+        ),
+    ))
+}
+
+fn same_file_version(before: &Metadata, after: &Metadata) -> bool {
+    after.is_file()
+        && before.dev() == after.dev()
+        && before.ino() == after.ino()
+        && before.len() == after.len()
+        && before.mtime() == after.mtime()
+        && before.mtime_nsec() == after.mtime_nsec()
+        && before.ctime() == after.ctime()
+        && before.ctime_nsec() == after.ctime_nsec()
+        && before.permissions().mode() == after.permissions().mode()
 }
 
 fn send_header(
@@ -240,8 +318,6 @@ mod tests {
 
     #[test]
     fn changed_file_is_framed_with_its_content() {
-        use std::io::Read;
-
         let temp = tempfile::tempdir().unwrap();
         let source = temp.path().join("source");
         std::fs::create_dir(&source).unwrap();
@@ -261,5 +337,17 @@ mod tests {
         let (header, payload) = receiver.join().unwrap();
         assert_eq!(header.path, "main.rs");
         assert_eq!(payload, b"fn main() {}\n");
+    }
+
+    #[test]
+    fn oversized_file_is_rejected_before_a_frame_is_sent() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("large.bin");
+        let file = File::create(&path).unwrap();
+        file.set_len(source_sync::MAX_FILE_BYTES + 1).unwrap();
+
+        let error = read_stable_file(&path).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }
 }

--- a/crates/iii-worker/src/cli/source_watcher.rs
+++ b/crates/iii-worker/src/cli/source_watcher.rs
@@ -4,7 +4,7 @@
 // This software is patent protected. We welcome discussions - reach out at team@iii.dev
 // See LICENSE and PATENTS files for details.
 
-//! Host-side source watcher for local-path workers.
+//! Legacy restart watcher and shared host-watch helpers.
 //!
 //! Virtiofs propagates file content and metadata from the host into the
 //! guest VM, but inotify events do NOT cross the FUSE boundary — so
@@ -12,15 +12,10 @@
 //! never fire on host edits unless they opt into polling. Some runtimes
 //! (notably tsx 4.x) don't support a polling fallback at all.
 //!
-//! This module works around that by watching the project directory on
-//! the *host* with `notify`, debouncing rapid writes, and re-invoking
-//! `iii-worker start <name>` to kill the stale VM and boot a fresh one.
-//! The engine re-registers the worker automatically when its websocket
-//! reconnects.
-//!
-//! Spawned as a hidden `__watch-source` subprocess alongside the VM so
-//! the watcher survives independent of the short-lived `iii worker start`
-//! CLI invocation.
+//! New VM launches use `source_sync_host`: it reuses the path filters and
+//! watch-tree helpers in this module, then forwards file operations into the
+//! guest. The hidden `__watch-source` restart command remains for compatibility
+//! but is not started by the local-worker path.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -30,7 +25,7 @@ use std::time::Duration;
 use notify::{RecursiveMode, Watcher};
 
 /// Debounce window: collapse rapid writes (editor save-then-rename,
-/// multi-file renames, etc.) into a single restart.
+/// multi-file renames, etc.) into one operation.
 pub const DEBOUNCE_MS: u64 = 500;
 
 /// Directories whose contents should NEVER trigger a restart. These are
@@ -187,7 +182,7 @@ pub fn should_ignore_path(path: &Path, project_root: &Path) -> bool {
 ///
 /// Best-effort: permission errors on subdirs are logged and skipped,
 /// not propagated. The watcher stays online for the rest of the tree.
-fn watch_pruned(
+pub(crate) fn watch_pruned(
     watcher: &mut notify::RecommendedWatcher,
     root: &Path,
     registered: &mut HashSet<PathBuf>,
@@ -286,7 +281,7 @@ fn watch_pruned(
 ///
 /// macOS FSEvents is inherently recursive and auto-covers new subdirs
 /// already, so this call is a no-op there aside from the logging cost.
-fn register_new_dirs(
+pub(crate) fn register_new_dirs(
     watcher: &mut notify::RecommendedWatcher,
     paths: &[PathBuf],
     root: &Path,
@@ -599,9 +594,8 @@ fn try_fast_restart(worker_name: &str) -> anyhow::Result<()> {
 /// path. Factored out of `restart_via_full_vm` so the contract can be
 /// regression-tested without spawning a real process.
 ///
-/// `--no-wait` is load-bearing: the watcher runs with stdout/stderr
-/// redirected to `watcher.log` (see `spawn_source_watcher`), so any
-/// output the child emits gets appended to that file. The default
+/// `--no-wait` is load-bearing: legacy watcher launchers redirect output to
+/// `watcher.log`, so any output the child emits gets appended to that file. The default
 /// wait path prints the 500ms status-panel redraw loop plus
 /// "✓ started / ✓ ready / <name>" lines, all of which would pollute
 /// watcher.log on every slow-path restart.

--- a/crates/iii-worker/src/cli/vm_boot.rs
+++ b/crates/iii-worker/src/cli/vm_boot.rs
@@ -142,6 +142,12 @@ pub struct VmBootArgs {
     #[arg(long)]
     pub shell_sock: Option<String>,
 
+    /// Host source directory whose changes are forwarded into the guest over
+    /// `iii.source-sync`. Local-path workers set this; immutable bundles and
+    /// ordinary volume mounts do not.
+    #[arg(long)]
+    pub source_sync: Option<String>,
+
     /// Enable network egress for the guest. When false, the smoltcp
     /// userspace TCP/IP stack is not initialized and no virtio-net
     /// device is attached, so the VM has no network interface — useful
@@ -910,6 +916,26 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
             }
         }
     }
+    let mut source_sync_port_env = false;
+    let mut guest_source_sync_fd: Option<i32> = None;
+    if let Some(source_root) = args.source_sync.clone() {
+        let (host_end, guest_fd) = setup_control_socketpair()?;
+        match crate::cli::source_sync_host::spawn(std::path::PathBuf::from(source_root), host_end) {
+            Ok(()) => {
+                guest_source_sync_fd = Some(guest_fd);
+                source_sync_port_env = true;
+            }
+            Err(error) => {
+                eprintln!(
+                    "warning: source sync failed to start ({error}). \
+                     Host source changes will not reach the guest."
+                );
+                unsafe {
+                    libc::close(guest_fd);
+                }
+            }
+        }
+    }
     let control_workdir = args.workdir.clone();
     let nofile_limit = args.nofile_limit;
 
@@ -968,6 +994,14 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
                 "III_SHELL_PORT",
                 iii_supervisor::shell_protocol::SHELL_PORT_NAME,
             );
+        }
+        if source_sync_port_env {
+            e = e.env(
+                "III_SOURCE_SYNC_PORT",
+                iii_supervisor::source_sync::SOURCE_SYNC_PORT_NAME,
+            );
+            e = e.env("III_SOURCE_SYNC_ROOT", "/workspace");
+            e = e.env("III_SOURCE_SYNC_READY", "/run/iii/source-ready");
         }
         if !virtiofs_mount_env.is_empty() {
             e = e.env("III_VIRTIOFS_MOUNTS", &virtiofs_mount_env);
@@ -1031,6 +1065,9 @@ fn boot_vm(args: &VmBootArgs) -> Result<std::convert::Infallible, String> {
         }
         if let Some(fd) = guest_shell_fd {
             c = c.port(iii_supervisor::shell_protocol::SHELL_PORT_NAME, fd, fd);
+        }
+        if let Some(fd) = guest_source_sync_fd {
+            c = c.port(iii_supervisor::source_sync::SOURCE_SYNC_PORT_NAME, fd, fd);
         }
         c
     });

--- a/crates/iii-worker/src/cli/worker_manager/libkrun.rs
+++ b/crates/iii-worker/src/cli/worker_manager/libkrun.rs
@@ -148,6 +148,7 @@ pub fn build_vm_command(
     rootfs_mode: String,
     rootfs_upper: Option<PathBuf>,
     mounts: &[(String, String)],
+    source_sync: Option<&Path>,
 ) -> Result<VmCommand, String> {
     let env = build_vm_env(env);
 
@@ -187,6 +188,7 @@ pub fn build_vm_command(
         &pid_file,
         &control_sock,
         &shell_sock,
+        source_sync,
         &env_pairs,
         mounts,
         args,
@@ -250,6 +252,7 @@ pub async fn run_dev(
     background: bool,
     worker_name: &str,
     mounts: &[(String, String)],
+    source_sync: Option<&Path>,
 ) -> i32 {
     let VmCommand {
         command: mut cmd,
@@ -265,6 +268,7 @@ pub async fn run_dev(
         rootfs_mode,
         rootfs_upper,
         mounts,
+        source_sync,
     ) {
         Ok(built) => built,
         Err(e) => {
@@ -468,6 +472,7 @@ fn vm_boot_args_dev(
     pid_file: &Path,
     control_sock: &Path,
     shell_sock: &Path,
+    source_sync: Option<&Path>,
     env: &[(String, String)],
     mounts: &[(String, String)],
     exec_args: &[String],
@@ -494,6 +499,10 @@ fn vm_boot_args_dev(
     out.push(control_sock.as_os_str().to_owned());
     out.push(OsString::from("--shell-sock"));
     out.push(shell_sock.as_os_str().to_owned());
+    if let Some(source_sync) = source_sync {
+        out.push(OsString::from("--source-sync"));
+        out.push(source_sync.as_os_str().to_owned());
+    }
     out.push(OsString::from(VM_BOOT_NETWORK_FLAG));
     for (k, v) in env {
         out.push(OsString::from("--env"));
@@ -1111,6 +1120,7 @@ mod tests {
         assert_eq!(parsed.console_output.as_deref(), Some("/tmp/console.log"));
         assert_eq!(parsed.control_sock.as_deref(), Some("/tmp/control.sock"));
         assert_eq!(parsed.shell_sock.as_deref(), Some("/tmp/shell.sock"));
+        assert_eq!(parsed.source_sync, None);
         assert_eq!(parsed.env, vec!["III_URL=ws://localhost:3111".to_string()]);
         assert_eq!(parsed.arg, exec_args);
         assert_eq!(parsed.rootfs_lower.as_deref(), Some("/tmp/base.erofs"));
@@ -1135,6 +1145,7 @@ mod tests {
             Path::new("/tmp/vm.pid"),
             Path::new("/tmp/control.sock"),
             Path::new("/tmp/shell.sock"),
+            Some(Path::new("/host/src")),
             &env,
             &mounts,
             &exec_args,
@@ -1149,6 +1160,7 @@ mod tests {
         assert_eq!(parsed.pid_file.as_deref(), Some("/tmp/vm.pid"));
         assert_eq!(parsed.control_sock.as_deref(), Some("/tmp/control.sock"));
         assert_eq!(parsed.shell_sock.as_deref(), Some("/tmp/shell.sock"));
+        assert_eq!(parsed.source_sync.as_deref(), Some("/host/src"));
         assert_eq!(parsed.env, vec!["III_URL=ws://localhost:3111".to_string()]);
         assert_eq!(parsed.mount, vec!["/host/src:/guest/src".to_string()]);
         assert_eq!(parsed.arg, exec_args);


### PR DESCRIPTION
## Summary

- forward local source changes over a dedicated virtio-console channel and apply them inside the guest workspace
- let worker-owned tools such as `watchfiles`, `tsx watch`, and `cargo watch` receive native guest filesystem events without restarting the VM or enabling polling
- use copy-in workspaces for local workers in both overlay and legacy modes, while keeping dependency directories VM-local
- version the prepared marker so workers from the former bind-mounted dependency layout run their install script again during migration

## Implementation

- add a bounded source-sync protocol with relative-path validation and acknowledgements
- watch the host project with the existing pruned ignore rules and send coalesced file, directory, symlink, and remove operations
- apply file changes atomically in `iii-init` after the initial workspace copy is complete
- keep immutable bundle workers outside the source-sync path

## Validation

- `cargo fmt --all --check`
- `cargo check -p iii-supervisor -p iii-init -p iii-worker -p iii-compose`
- `cargo test -p iii-supervisor -p iii-init -p iii-worker -p iii-compose --lib` (`1255 passed`, `1 ignored`)
- `cargo clippy -p iii-supervisor -p iii-init -p iii-worker -p iii-compose --all-targets`
- `cargo build -p iii-init --target x86_64-unknown-linux-musl --release`
- `cargo build --release -p iii-worker --features embed-init`
- verified that `watchfiles` restarted a Python worker after host edits while the VM PID stayed unchanged
- verified that `tsx watch` restarted a TypeScript worker after a host edit
- verified legacy migration from an empty prepared marker and missing workspace dependencies: `npm install` ran, `tsx` was restored, and the worker registered successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live source synchronization between host projects and local worker environments.
  * File, directory, symlink, and removal changes are forwarded into worker workspaces.
  * Added acknowledgments, safety validation, and file-size limits for synchronized changes.
  * Added versioned workspace preparation markers to refresh stale copies automatically.

* **Bug Fixes**
  * Improved handling of rapid file changes and transient connection interruptions.
  * Prevented unsafe paths, incomplete file copies, and inconsistent file snapshots during synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->