### PR TITLE
feat(compose): add observable batch worker operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,6 +2791,7 @@ name = "iii-compose"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "colored",
  "dirs 6.0.0",

--- a/crates/iii-compose/Cargo.toml
+++ b/crates/iii-compose/Cargo.toml
@@ -10,6 +10,7 @@ name = "iii_compose"
 path = "src/lib.rs"
 
 [dependencies]
+async-trait = "0.1"
 clap = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/iii-compose/src/cli.rs
+++ b/crates/iii-compose/src/cli.rs
@@ -82,6 +82,21 @@ pub enum ComposeSubcommand {
     Build(BuildCli),
     /// Read retained worker stdout and stderr from a running Compose daemon.
     Logs(ComposeLogsCli),
+    /// Add registry workers and stream their dependency-tree progress.
+    Add(ComposeAddCli),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ComposeAddCli {
+    /// Worker names, name@version references, registry references, or paths.
+    #[arg(required = true, value_name = "WORKER")]
+    pub workers: Vec<String>,
+    #[arg(long, value_name = "URL")]
+    pub engine: Option<String>,
+    #[arg(short = 'n', long = "namespace", value_name = "NS")]
+    pub namespace: Option<String>,
+    #[arg(short = 'f', long, value_name = "PATH")]
+    pub file: Option<PathBuf>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -169,6 +184,13 @@ pub enum ComposeCommand {
         follow: bool,
         stream: Option<LogStream>,
     },
+    /// Add workers through a running daemon and render pushed tree progress.
+    Add {
+        explicit_engine_url: Option<String>,
+        explicit_daemon_namespace: Option<String>,
+        file: Option<PathBuf>,
+        workers: Vec<String>,
+    },
 }
 
 impl ComposeCli {
@@ -193,6 +215,12 @@ impl ComposeCli {
                     tail: logs.tail.min(crate::logs::MAX_TAIL_LINES),
                     follow: logs.follow,
                     stream: logs.stream,
+                }),
+                ComposeSubcommand::Add(add) => Ok(ComposeCommand::Add {
+                    explicit_engine_url: add.engine.clone().filter(|url| !url.trim().is_empty()),
+                    explicit_daemon_namespace: validated_namespace(add.namespace.as_deref())?,
+                    file: add.file.clone(),
+                    workers: add.workers.clone(),
                 }),
             };
         }

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -23,6 +23,8 @@ use std::{
     time::Duration,
 };
 
+use futures::StreamExt;
+
 use serde_json::Value;
 use tokio::sync::{Mutex, OnceCell};
 
@@ -182,6 +184,8 @@ pub struct Daemon {
     /// Different projects can still change in parallel, while two edits to one
     /// file cannot overwrite each other after reading the same source text.
     mutations: Mutex<BTreeMap<PathBuf, Arc<Mutex<()>>>>,
+    /// Long-running mutations publish progress independently of their caller.
+    pub operations: crate::operation::OperationManager,
     /// Set by `compose::stop`. The serve loop reads it and leaves through the
     /// same path a SIGTERM takes, so a remote stop and a local one cannot
     /// diverge in what they tear down.
@@ -220,10 +224,11 @@ impl Daemon {
             daemon_namespace,
             project_namespace_override,
             engine_url,
-            engine,
+            engine: Arc::clone(&engine),
             engine_policy,
             projects: Mutex::new(BTreeMap::new()),
             mutations: Mutex::new(BTreeMap::new()),
+            operations: crate::operation::OperationManager::new(engine.client()),
             stop_requested: std::sync::atomic::AtomicBool::new(false),
         });
 
@@ -402,11 +407,62 @@ impl Daemon {
         // Dependencies first and the worker last: with no `start_after`, start
         // order is declaration order, so this is what makes a worker start
         // after the things it calls.
+        let mut expanded = futures::stream::iter(asked.clone().into_iter().enumerate().map(
+            |(index, worker)| async move {
+                let graph = self.expand(&worker).await;
+                (index, graph)
+            },
+        ))
+        .buffer_unordered(4)
+        .collect::<Vec<_>>()
+        .await;
+        expanded.sort_by_key(|(index, _)| *index);
         let mut wanted = Vec::new();
-        for worker in &asked {
-            wanted.extend(self.expand(worker).await?);
+        for (_, graph) in expanded {
+            wanted.extend(graph?);
         }
         let wanted = coalesce_expanded(wanted)?;
+
+        // Acquire registry artifacts before taking either the file mutation lock
+        // or the project's runtime lock. `lifecycle::start_one` calls install
+        // again, but that second call is a cheap verified cache hit.
+        let package_cache = crate::state::StateStore::package_cache()?;
+        let operation = crate::operation::active(&operation_id);
+        let installs: Vec<(String, String, String)> = wanted
+            .iter()
+            .filter_map(|worker| match &worker.source {
+                crate::edit::Source::Package {
+                    reference,
+                    version: Some(version),
+                } => Some((worker.key.clone(), reference.clone(), version.clone())),
+                _ => None,
+            })
+            .collect();
+        let acquired: Vec<Result<()>> =
+            futures::stream::iter(installs.into_iter().map(|(key, reference, version)| {
+                let package_cache = package_cache.clone();
+                let operation = operation.clone();
+                async move {
+                    if let Some(operation) = operation {
+                        operation
+                            .emit(
+                                Some(&key),
+                                "installing",
+                                format!("acquiring {reference}@{version}"),
+                            )
+                            .await;
+                    }
+                    crate::registry::install(&key, &reference, &version, &package_cache)
+                        .await
+                        .map(|_| ())
+                }
+            }))
+            .buffer_unordered(4)
+            .collect()
+            .await;
+        for result in acquired {
+            result?;
+        }
 
         let _mutation = self.lock_mutation(path).await;
         let text = std::fs::read_to_string(path).map_err(|source| ComposeError::Io {
@@ -864,6 +920,7 @@ impl Daemon {
     /// down mid-reply would leave them holding a broken socket instead of an
     /// answer.
     pub async fn request_stop(&self) -> serde_json::Value {
+        self.operations.cancel_all().await;
         self.stop_requested
             .store(true, std::sync::atomic::Ordering::SeqCst);
 

--- a/crates/iii-compose/src/engine.rs
+++ b/crates/iii-compose/src/engine.rs
@@ -352,6 +352,29 @@ impl EngineClient {
         baseline: &ReadinessBaseline,
         log_dir: &std::path::Path,
     ) -> Result<()> {
+        match tokio::time::timeout(
+            timeout,
+            self.wait_until_ready_inner(namespace, container, child, timeout, baseline, log_dir),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(ComposeError::ReadinessTimeout {
+                container: container.to_string(),
+                seconds: timeout.as_secs(),
+            }),
+        }
+    }
+
+    async fn wait_until_ready_inner(
+        &self,
+        namespace: &str,
+        container: &str,
+        child: &Supervised,
+        timeout: Duration,
+        baseline: &ReadinessBaseline,
+        log_dir: &std::path::Path,
+    ) -> Result<()> {
         let deadline = tokio::time::Instant::now() + timeout;
         let ReadinessBaseline {
             present: present_before,

--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -34,6 +34,7 @@ pub mod logs;
 mod managed_engine;
 pub mod manifest;
 pub mod namespace;
+pub mod operation;
 mod parallelism;
 pub mod process;
 pub mod project;
@@ -124,6 +125,22 @@ pub async fn run(cli: ComposeCli) -> i32 {
             Ok(()) => 0,
             Err(err) => report_error(&err),
         },
+        ComposeCommand::Add {
+            explicit_engine_url,
+            explicit_daemon_namespace,
+            file,
+            workers,
+        } => match add_workers(
+            explicit_engine_url,
+            explicit_daemon_namespace,
+            file,
+            workers,
+        )
+        .await
+        {
+            Ok(()) => 0,
+            Err(err) => report_error(&err),
+        },
         ComposeCommand::Logs {
             explicit_engine_url,
             explicit_daemon_namespace,
@@ -146,6 +163,139 @@ pub async fn run(cli: ComposeCli) -> i32 {
             Ok(()) => 0,
             Err(err) => report_error(&err),
         },
+    }
+}
+
+async fn add_workers(
+    explicit_engine_url: Option<String>,
+    explicit_daemon_namespace: Option<String>,
+    file: Option<std::path::PathBuf>,
+    workers: Vec<String>,
+) -> Result<()> {
+    use iii_sdk::{
+        InitOptions, RegisterFunction,
+        protocol::{RegisterTriggerInput, TriggerRequest},
+        register_worker,
+    };
+    use tokio::sync::mpsc;
+
+    let local_path = file
+        .as_deref()
+        .unwrap_or_else(|| std::path::Path::new(cli::DEFAULT_COMPOSE_FILE));
+    let local_file = load_invocation_file(local_path, false)?;
+    let daemon_namespace = resolve_daemon_namespace(explicit_daemon_namespace, local_file.as_ref());
+    let environment_engine_url = std::env::var("III_URL")
+        .ok()
+        .filter(|url| !url.trim().is_empty());
+    let engine_url = match resolve_engine_mode(
+        local_file.as_ref(),
+        false,
+        explicit_engine_url.as_deref(),
+        environment_engine_url.as_deref(),
+    ) {
+        EngineMode::Managed { url } | EngineMode::External { url } => url,
+    };
+    let client_namespace = format!("compose-cli-{}", uuid::Uuid::new_v4());
+    let client = register_worker(
+        &engine_url,
+        InitOptions {
+            metadata: Some(iii_sdk::iii::WorkerMetadata {
+                name: client_namespace.clone(),
+                description: Some("Render Compose operation progress".into()),
+                ..Default::default()
+            }),
+            namespace: Some(client_namespace.clone()),
+            ..Default::default()
+        },
+    );
+    let operation_id = format!("compose:{}", uuid::Uuid::new_v4());
+    let callback = format!("compose-cli::progress:{}", uuid::Uuid::new_v4());
+    let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+    client.register_function(
+        &callback,
+        RegisterFunction::new(move |event: operation::ProgressEvent| {
+            let _ = events_tx.send(event);
+            Ok(serde_json::json!({ "received": true }))
+        }),
+    );
+    let binding = client
+        .register_trigger(
+            RegisterTriggerInput::new(
+                "compose-operation",
+                callback,
+                serde_json::json!({ "operation_id": operation_id }),
+            )
+            .in_namespace(&client_namespace)
+            .in_trigger_namespace(&daemon_namespace),
+        )
+        .map_err(|error| ComposeError::EngineCallFailed {
+            function: "compose-operation".into(),
+            message: error.to_string(),
+        })?;
+
+    let mut payload = serde_json::json!({ "workers": workers, "operation_id": operation_id });
+    if let Some(file) = file {
+        payload["file"] = serde_json::Value::String(file.to_string_lossy().into_owned());
+    }
+    client
+        .trigger(
+            TriggerRequest {
+                function_id: "compose::add".into(),
+                payload,
+                action: None,
+                timeout_ms: Some(10_000),
+            }
+            .namespace(&daemon_namespace),
+        )
+        .await
+        .map_err(|error| ComposeError::EngineCallFailed {
+            function: "compose::add".into(),
+            message: error.to_string(),
+        })?;
+
+    let mut outline: Vec<(String, usize)> = Vec::new();
+    let mut tree_started = false;
+    loop {
+        tokio::select! {
+            event = events_rx.recv() => {
+                let Some(event) = event else {
+                    return Err(ComposeError::EngineCallFailed {
+                        function: "compose-operation".into(),
+                        message: "progress stream closed before completion".into(),
+                    });
+                };
+                if event.phase == "waiting" {
+                    if let Some(container) = event.container.as_ref() {
+                        outline.push((container.clone(), event.total.unwrap_or_default() as usize));
+                    }
+                    continue;
+                }
+                if !tree_started && !outline.is_empty() {
+                    report::plan(&outline);
+                    tree_started = true;
+                }
+                report::progress_event(&event);
+                if event.terminal {
+                    report::plan_done();
+                    binding.unregister();
+                    client.shutdown_async().await;
+                    return if event.detail.contains("ready") {
+                        Ok(())
+                    } else {
+                        Err(ComposeError::EngineCallFailed {
+                            function: "compose::add".into(),
+                            message: event.detail,
+                        })
+                    };
+                }
+            }
+            _ = tokio::signal::ctrl_c() => {
+                let _ = client.trigger(TriggerRequest { function_id: "compose::cancel".into(), payload: serde_json::json!({ "operation_id": operation_id }), action: None, timeout_ms: Some(10_000) }.namespace(&daemon_namespace)).await;
+                binding.unregister();
+                client.shutdown_async().await;
+                return Ok(());
+            }
+        }
     }
 }
 
@@ -481,7 +631,6 @@ async fn serve_daemon(
         project_namespace_override,
         engine_policy,
     );
-    remote::register(&daemon);
 
     // Announce only once the engine has accepted this daemon. A rejection
     // arrives within a round trip, and printing "serving" before hearing it
@@ -580,6 +729,11 @@ async fn serve_daemon(
             }
         }
     }
+    // Publish compose::* only after the foreground startup tree is complete.
+    // The renderer intentionally owns one global in-place block; admitting a
+    // remote mutation during initial --up would replace that block and interleave
+    // two operations' cursor movement.
+    remote::register(&daemon);
 
     // Serve until asked to stop, or until the engine refuses this identity.
     //

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -108,7 +108,6 @@ pub struct LifecycleCtx<'a> {
 
 /// What one container's start produced: which one, how long it took, and
 /// whether it came up.
-type StartOutcome = (String, Duration, StartAttempt);
 
 enum StartAttempt {
     Ready(ChildRecord, Supervised),
@@ -184,6 +183,15 @@ async fn up_inner(
     // Everything this operation will touch, drawn before any of it moves, so an
     // operator sees the shape rather than a line at a time.
     report::plan(&dag::outline(ctx.file, &order));
+    if let Some(operation) = crate::operation::active(&operation_id) {
+        let outline = dag::outline(ctx.file, &order);
+        operation.plan(outline.len()).await;
+        for (key, depth) in &outline {
+            operation
+                .emit_tree(key, *depth, "waiting for dependencies")
+                .await;
+        }
+    }
 
     // Grouped rather than listed: only a declared dependency has to wait, and
     // in a project of fourteen where one worker calls the other thirteen, the
@@ -199,6 +207,10 @@ async fn up_inner(
         for key in &wave {
             if is_running(children, key) {
                 report::unchanged(key, "already running");
+                if let Some(operation) = crate::operation::active(&operation_id) {
+                    operation.emit(Some(key), "ready", "already running").await;
+                    operation.completed_one().await;
+                }
                 results.push(ContainerResult {
                     container: key.clone(),
                     state: ChildStatus::Ready,
@@ -208,34 +220,33 @@ async fn up_inner(
                 continue;
             }
             report::starting(key, "starting");
+            if let Some(operation) = crate::operation::active(&operation_id) {
+                operation
+                    .emit(Some(key), "starting", "starting worker")
+                    .await;
+            }
             starting.push(key.clone());
         }
-        if starting.is_empty() {
-            continue;
-        }
-
         // Bounded: a wave may hold every container in the file, and each one
         // can be a download, a process, or a VM. An operator's machine should
         // not have to survive all of them at once.
-        let outcomes: Vec<StartOutcome> = futures::stream::iter(starting.into_iter().map(|key| {
+        let mut outcomes = futures::stream::iter(starting.into_iter().map(|key| {
             let shutdown = shutdown.clone();
+            let start_operation_id = operation_id.clone();
             async move {
                 let began = Instant::now();
-                let outcome = start_one_attempt(ctx, &key, shutdown).await;
+                let outcome =
+                    start_one_attempt(ctx, &key, shutdown, Some(&start_operation_id)).await;
                 (key, began.elapsed(), outcome)
             }
         }))
-        .buffer_unordered(max_parallel_workers)
-        .collect()
-        .await;
+        .buffer_unordered(max_parallel_workers);
 
-        // The whole wave is awaited before a failure is acted on. Stopping
-        // early would leave containers half-started, which is a worse state to
-        // describe than one more container that came up and is then rolled
-        // back.
+        // Adopt and publish each worker as soon as it settles. We still drain
+        // the already-launched wave before rollback so no child is orphaned.
         let mut failure: Option<(String, ComposeError)> = None;
         let mut interrupted = false;
-        for (key, took, outcome) in outcomes {
+        while let Some((key, took, outcome)) = outcomes.next().await {
             let key = &key;
             match outcome {
                 StartAttempt::Ready(record, child) => {
@@ -243,6 +254,12 @@ async fn up_inner(
                     records.insert(key.clone(), record);
                     children.insert(key.clone(), child);
                     started.push(key.clone());
+                    if let Some(operation) = crate::operation::active(&operation_id) {
+                        operation
+                            .emit(Some(key), "ready", "registered with engine")
+                            .await;
+                        operation.completed_one().await;
+                    }
                     results.push(ContainerResult {
                         container: key.clone(),
                         state: ChildStatus::Ready,
@@ -262,6 +279,9 @@ async fn up_inner(
                         changed: false,
                         error: Some(OpError::from(&error)),
                     });
+                    if let Some(operation) = crate::operation::active(&operation_id) {
+                        operation.emit(Some(key), "failed", error.to_string()).await;
+                    }
                     if failure.is_none() {
                         failure = Some((key.clone(), error));
                     }
@@ -269,6 +289,7 @@ async fn up_inner(
                 StartAttempt::Interrupted => interrupted = true,
             }
         }
+        drop(outcomes);
 
         if interrupted {
             report::plan_done();
@@ -557,7 +578,7 @@ pub async fn down(
 /// start together and a shared `&mut` would serialise exactly what this exists
 /// to overlap.
 async fn start_one(ctx: &LifecycleCtx<'_>, key: &str) -> Result<(ChildRecord, Supervised)> {
-    match start_one_attempt(ctx, key, None).await {
+    match start_one_attempt(ctx, key, None, None).await {
         StartAttempt::Ready(record, child) => Ok((record, child)),
         StartAttempt::Failed(error) => Err(error),
         StartAttempt::Interrupted => {
@@ -570,8 +591,9 @@ async fn start_one_attempt(
     ctx: &LifecycleCtx<'_>,
     key: &str,
     shutdown: Option<crate::shutdown::ShutdownSignal>,
+    operation_id: Option<&str>,
 ) -> StartAttempt {
-    match start_one_until_shutdown(ctx, key, shutdown).await {
+    match start_one_until_shutdown(ctx, key, shutdown, operation_id).await {
         Ok((record, child)) => StartAttempt::Ready(record, child),
         Err(StartFailure::Failed(error)) => StartAttempt::Failed(error),
         Err(StartFailure::Interrupted) => StartAttempt::Interrupted,
@@ -582,6 +604,7 @@ async fn start_one_until_shutdown(
     ctx: &LifecycleCtx<'_>,
     key: &str,
     mut shutdown: Option<crate::shutdown::ShutdownSignal>,
+    operation_id: Option<&str>,
 ) -> std::result::Result<(ChildRecord, Supervised), StartFailure> {
     macro_rules! wait_or_interrupt {
         ($future:expr) => {{
@@ -630,6 +653,15 @@ async fn start_one_until_shutdown(
         crate::config::WorkerSource::Package { reference } => {
             let range = container.version.as_deref().unwrap_or("*");
             report::starting(key, &format!("installing {reference}@{range}"));
+            if let Some(operation) = operation_id.and_then(crate::operation::active) {
+                operation
+                    .emit(
+                        Some(key),
+                        "installing",
+                        format!("installing {reference}@{range}"),
+                    )
+                    .await;
+            }
             let installed = wait_or_interrupt!(crate::registry::install(
                 key,
                 reference,
@@ -658,6 +690,12 @@ async fn start_one_until_shutdown(
         }
         crate::config::WorkerSource::Path { .. } => (resolve_start(key, container)?, None),
     };
+
+    if let Some(operation) = operation_id.and_then(crate::operation::active) {
+        operation
+            .emit(Some(key), "configuring", "resolving configuration")
+            .await;
+    }
 
     let user_env = container.resolve_user_env(key)?;
     let config = wait_or_interrupt!(resolve_config(ctx, container, key, shipped_config))?;
@@ -707,12 +745,19 @@ async fn start_one_until_shutdown(
         // A VM worker is booted instead of run here. The handle that comes
         // back is an ordinary child, so readiness, stop, crash cascade and log
         // capture below are unchanged.
-        None => wait_or_interrupt!(vm_command(ctx, key, &start, &plan, config.as_ref())).map_err(
-            |message| ComposeError::SpawnFailed {
-                container: key.to_string(),
-                message,
-            },
-        )?,
+        None => {
+            if let Some(operation) = operation_id.and_then(crate::operation::active) {
+                operation
+                    .emit(Some(key), "preparing", "preparing VM runtime")
+                    .await;
+            }
+            wait_or_interrupt!(vm_command(ctx, key, &start, &plan, config.as_ref())).map_err(
+                |message| ComposeError::SpawnFailed {
+                    container: key.to_string(),
+                    message,
+                },
+            )?
+        }
     };
 
     if shutdown.as_ref().is_some_and(|signal| signal.requested()) {
@@ -724,6 +769,11 @@ async fn start_one_until_shutdown(
             container: key.to_string(),
             message: err.to_string(),
         })?;
+    if let Some(operation) = operation_id.and_then(crate::operation::active) {
+        operation
+            .emit(Some(key), "registering", "waiting for engine registration")
+            .await;
+    }
     // Capture before waiting on readiness: whatever the child prints while
     // starting is exactly what an operator needs when it does not.
     ctx.logs.capture(key, output.stdout, output.stderr);
@@ -906,10 +956,13 @@ async fn prepare_vm(
         drop(stdin);
     }
 
-    let output = child
-        .wait_with_output()
-        .await
-        .map_err(|err| format!("iii-worker did not answer: {err}"))?;
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(20 * 60),
+        child.wait_with_output(),
+    )
+    .await
+    .map_err(|_| "iii-worker VM preparation timed out after 20 minutes".to_string())?
+    .map_err(|err| format!("iii-worker did not answer: {err}"))?;
 
     if !output.status.success() {
         let reason = String::from_utf8_lossy(&output.stderr);

--- a/crates/iii-compose/src/operation.rs
+++ b/crates/iii-compose/src/operation.rs
@@ -1,0 +1,377 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+//! Observable operations for long Compose mutations.
+//!
+//! Compose is a trigger provider. Clients bind `compose-operation` before
+//! submitting an add and receive structured dependency-tree transitions. A
+//! compact snapshot remains available for reconnect/recovery only; normal
+//! progress delivery never polls.
+
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex, OnceLock, Weak},
+    time::Instant,
+};
+
+use iii_sdk::{
+    Error, IIIClient, RegisterTriggerType,
+    protocol::{TriggerAction, TriggerRequest},
+    trigger::{TriggerConfig, TriggerHandler},
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{RwLock, watch};
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ProgressSubscription {
+    /// Operation to follow. Omit to receive every operation from this daemon.
+    pub operation_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ProgressEvent {
+    pub sequence: u64,
+    pub operation_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container: Option<String>,
+    pub phase: String,
+    pub detail: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total: Option<u64>,
+    pub elapsed_ms: u64,
+    pub terminal: bool,
+}
+#[derive(Default)]
+struct ProgressTriggers {
+    bindings: Arc<Mutex<BTreeMap<String, TriggerConfig>>>,
+}
+
+#[async_trait::async_trait]
+impl TriggerHandler for ProgressTriggers {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
+        self.bindings
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(config.id.clone(), config);
+        Ok(())
+    }
+
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
+        self.bindings
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .remove(&config.id);
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct ProgressEmitter {
+    client: IIIClient,
+    bindings: Arc<Mutex<BTreeMap<String, TriggerConfig>>>,
+}
+
+impl ProgressEmitter {
+    pub fn register(client: &IIIClient) -> Self {
+        let handler = ProgressTriggers::default();
+        let bindings = Arc::clone(&handler.bindings);
+        client.register_trigger_type(
+            RegisterTriggerType::new(
+                "compose-operation",
+                "Streams structured progress for Compose dependency-tree operations",
+                handler,
+            )
+            .trigger_request_format::<ProgressSubscription>()
+            .call_request_format::<ProgressEvent>(),
+        );
+        Self {
+            client: client.clone(),
+            bindings,
+        }
+    }
+
+    async fn publish(&self, event: &ProgressEvent) {
+        let bindings: Vec<TriggerConfig> = self
+            .bindings
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .values()
+            .filter(|binding| {
+                serde_json::from_value::<ProgressSubscription>(binding.config.clone())
+                    .ok()
+                    .and_then(|config| config.operation_id)
+                    .is_none_or(|id| id == event.operation_id)
+            })
+            .cloned()
+            .collect();
+        let deliveries = bindings.into_iter().map(|binding| {
+            let client = self.client.clone();
+            let event = event.clone();
+            async move {
+                let request = TriggerRequest {
+                    function_id: binding.function_id,
+                    payload: serde_json::to_value(event).unwrap_or_default(),
+                    action: Some(TriggerAction::Void),
+                    timeout_ms: Some(5_000),
+                };
+                let request = if let Some(namespace) = binding.namespace {
+                    request.namespace(namespace)
+                } else {
+                    request.into()
+                };
+                let _ = client.trigger(request).await;
+            }
+        });
+        futures::future::join_all(deliveries).await;
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationStatus {
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct OperationSnapshot {
+    pub operation_id: String,
+    pub status: OperationStatus,
+    pub phase: String,
+    pub requested: usize,
+    pub total: usize,
+    pub completed: usize,
+    pub last_sequence: u64,
+    pub last_event: Option<ProgressEvent>,
+}
+fn active_operations() -> &'static Mutex<BTreeMap<String, Weak<Operation>>> {
+    static ACTIVE: OnceLock<Mutex<BTreeMap<String, Weak<Operation>>>> = OnceLock::new();
+    ACTIVE.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+pub fn active(id: &str) -> Option<Arc<Operation>> {
+    let operations = active_operations()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    if let Some(operation) = operations.get(id).and_then(Weak::upgrade) {
+        return Some(operation);
+    }
+    // Reconciliation appends descriptive child suffixes (`-up`,
+    // `-restart-<key>`). Choose the longest active prefix so those lifecycle
+    // events remain attached to the caller-visible root operation.
+    operations
+        .iter()
+        .filter(|(root, _)| id.starts_with(root.as_str()))
+        .max_by_key(|(root, _)| root.len())
+        .and_then(|(_, operation)| Weak::upgrade(operation))
+}
+
+struct State {
+    status: OperationStatus,
+    phase: String,
+    requested: usize,
+    total: usize,
+    completed: usize,
+    sequence: u64,
+    last_event: Option<ProgressEvent>,
+}
+
+pub struct Operation {
+    id: String,
+    began: Instant,
+    state: RwLock<State>,
+    cancel: watch::Sender<bool>,
+    emitter: ProgressEmitter,
+}
+
+impl Operation {
+    fn new(id: String, requested: usize, emitter: ProgressEmitter) -> Arc<Self> {
+        let (cancel, _) = watch::channel(false);
+        Arc::new(Self {
+            id,
+            began: Instant::now(),
+            state: RwLock::new(State {
+                status: OperationStatus::Running,
+                phase: "accepted".into(),
+                requested,
+                total: 0,
+                completed: 0,
+                sequence: 0,
+                last_event: None,
+            }),
+            cancel,
+            emitter,
+        })
+    }
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+    pub fn cancellation(&self) -> watch::Receiver<bool> {
+        self.cancel.subscribe()
+    }
+    pub fn cancel(&self) {
+        let _ = self.cancel.send(true);
+    }
+    pub async fn emit_tree(&self, container: &str, depth: usize, detail: impl Into<String>) {
+        self.emit_progress(
+            Some(container),
+            "waiting",
+            detail,
+            None,
+            Some(depth as u64),
+            false,
+        )
+        .await;
+    }
+
+    async fn emit_progress(
+        &self,
+        container: Option<&str>,
+        phase: &str,
+        detail: impl Into<String>,
+        current: Option<u64>,
+        total: Option<u64>,
+        terminal: bool,
+    ) {
+        let event = {
+            let mut state = self.state.write().await;
+            state.phase = phase.into();
+            state.sequence += 1;
+            let event = ProgressEvent {
+                sequence: state.sequence,
+                operation_id: self.id.clone(),
+                container: container.map(str::to_string),
+                phase: phase.into(),
+                detail: detail.into(),
+                current,
+                total,
+                elapsed_ms: self.began.elapsed().as_millis() as u64,
+                terminal,
+            };
+            state.last_event = Some(event.clone());
+            event
+        };
+        self.emitter.publish(&event).await;
+    }
+    pub async fn emit(&self, container: Option<&str>, phase: &str, detail: impl Into<String>) {
+        self.emit_progress(container, phase, detail, None, None, false)
+            .await;
+    }
+    pub async fn plan(&self, total: usize) {
+        self.state.write().await.total = total;
+    }
+    pub async fn completed_one(&self) {
+        self.state.write().await.completed += 1;
+    }
+    pub async fn finish(&self, status: OperationStatus, detail: impl Into<String>) {
+        let event = {
+            let mut state = self.state.write().await;
+            state.status = status;
+            state.phase = "complete".into();
+            state.sequence += 1;
+            let event = ProgressEvent {
+                sequence: state.sequence,
+                operation_id: self.id.clone(),
+                container: None,
+                phase: "complete".into(),
+                detail: detail.into(),
+                current: Some(state.completed as u64),
+                total: Some(state.total as u64),
+                elapsed_ms: self.began.elapsed().as_millis() as u64,
+                terminal: true,
+            };
+            state.last_event = Some(event.clone());
+            event
+        };
+        self.emitter.publish(&event).await;
+    }
+    pub async fn snapshot(&self) -> OperationSnapshot {
+        let s = self.state.read().await;
+        OperationSnapshot {
+            operation_id: self.id.clone(),
+            status: s.status,
+            phase: s.phase.clone(),
+            requested: s.requested,
+            total: s.total,
+            completed: s.completed,
+            last_sequence: s.sequence,
+            last_event: s.last_event.clone(),
+        }
+    }
+}
+
+pub struct OperationManager {
+    operations: RwLock<BTreeMap<String, Arc<Operation>>>,
+    emitter: ProgressEmitter,
+}
+impl OperationManager {
+    pub fn new(client: &IIIClient) -> Self {
+        Self {
+            operations: RwLock::new(BTreeMap::new()),
+            emitter: ProgressEmitter::register(client),
+        }
+    }
+    pub async fn create(&self, requested: usize) -> Arc<Operation> {
+        self.create_with_id(format!("compose:{}", uuid::Uuid::new_v4()), requested)
+            .await
+    }
+    pub async fn create_with_id(&self, id: String, requested: usize) -> Arc<Operation> {
+        let op = Operation::new(id.clone(), requested, self.emitter.clone());
+        self.operations
+            .write()
+            .await
+            .insert(id.clone(), Arc::clone(&op));
+        active_operations()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(id, Arc::downgrade(&op));
+        op
+    }
+    pub async fn get(&self, id: &str) -> Option<Arc<Operation>> {
+        self.operations.read().await.get(id).cloned()
+    }
+    pub async fn cancel(&self, id: &str) -> bool {
+        let Some(op) = self.get(id).await else {
+            return false;
+        };
+        op.cancel();
+        true
+    }
+    pub async fn cancel_all(&self) {
+        for operation in self.operations.read().await.values() {
+            if operation.snapshot().await.status == OperationStatus::Running {
+                operation.cancel();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_suffixes_resolve_to_the_root_operation() {
+        let client = IIIClient::new("ws://127.0.0.1:1/ws");
+        let emitter = ProgressEmitter {
+            client,
+            bindings: Arc::new(Mutex::new(BTreeMap::new())),
+        };
+        let root = Operation::new("compose:test-root".into(), 1, emitter);
+        active_operations()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(root.id().into(), Arc::downgrade(&root));
+
+        assert!(Arc::ptr_eq(&active("compose:test-root-up").unwrap(), &root));
+        assert!(Arc::ptr_eq(
+            &active("compose:test-root-restart-worker").unwrap(),
+            &root
+        ));
+    }
+}

--- a/crates/iii-compose/src/process/unix.rs
+++ b/crates/iii-compose/src/process/unix.rs
@@ -78,6 +78,11 @@ fn spawn_supervised_inner(
 ) -> std::io::Result<(Supervised, ChildOutput)> {
     // Group leader: killpg then reaches the worker and everything it spawns.
     command.process_group(0);
+    // Workers are background process-group leaders. Inheriting the daemon's
+    // terminal stdin lets a read trigger SIGTTIN, leaving the child stopped in
+    // `T` state while readiness waits forever. Workers communicate through iii,
+    // never through Compose's controlling terminal.
+    command.stdin(std::process::Stdio::null());
     if piped {
         command
             .stdout(std::process::Stdio::piped())

--- a/crates/iii-compose/src/process/windows.rs
+++ b/crates/iii-compose/src/process/windows.rs
@@ -104,6 +104,9 @@ fn spawn_supervised_inner(
     // Its own console group: CTRL_BREAK can then be aimed at the child alone,
     // rather than at every process sharing the daemon's console.
     command.creation_flags(CREATE_NEW_PROCESS_GROUP);
+    // A worker is not an interactive child of Compose. Inheriting stdin can
+    // block startup indefinitely and differs from daemon/service semantics.
+    command.stdin(std::process::Stdio::null());
     if piped {
         command
             .stdout(std::process::Stdio::piped())

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -502,14 +502,33 @@ impl Project {
                 .await,
             );
         }
-        let up = lifecycle::up(
-            &ctx,
-            children,
-            &mut state.containers,
-            None,
-            format!("{operation_id}-up"),
-        )
-        .await;
+        let up = if let Some(operation) = crate::operation::active(&operation_id) {
+            let shutdown = crate::shutdown::ShutdownSignal::from_receiver(operation.cancellation());
+            lifecycle::up_until_shutdown(
+                &ctx,
+                children,
+                &mut state.containers,
+                None,
+                format!("{operation_id}-up"),
+                shutdown,
+            )
+            .await
+            .unwrap_or_else(|| OpResult {
+                operation_id: format!("{operation_id}-up"),
+                status: crate::lifecycle::OpStatus::Failed,
+                changed: false,
+                containers: Vec::new(),
+            })
+        } else {
+            lifecycle::up(
+                &ctx,
+                children,
+                &mut state.containers,
+                None,
+                format!("{operation_id}-up"),
+            )
+            .await
+        };
 
         let snapshot = state.clone();
         drop(file);
@@ -657,27 +676,38 @@ impl Project {
 
     /// Current state of every declared container, for `compose::status`.
     pub async fn status(&self) -> Vec<ContainerStatus> {
-        let inner = self.inner.lock().await;
         let file = self.file.read().await;
+        let inner = self.inner.try_lock().ok();
+        let stored = if inner.is_none() {
+            self.store.load().ok().flatten()
+        } else {
+            None
+        };
         file.containers
             .keys()
             .map(|key| {
-                let record = inner.state.containers.get(key);
-                let running = inner
-                    .children
-                    .get(key)
-                    .is_some_and(|c| matches!(c.poll(), crate::process::Outcome::Running));
+                let record = inner
+                    .as_ref()
+                    .and_then(|inner| inner.state.containers.get(key))
+                    .or_else(|| stored.as_ref().and_then(|state| state.containers.get(key)));
+                let running = inner.as_ref().is_some_and(|inner| {
+                    inner.children.get(key).is_some_and(|child| {
+                        matches!(child.poll(), crate::process::Outcome::Running)
+                    })
+                });
                 ContainerStatus {
                     container: key.clone(),
-                    state: match (running, record.map(|r| r.status)) {
+                    state: match (running, record.map(|record| record.status)) {
                         (true, _) => ChildStatus::Ready,
                         (false, Some(status)) => status,
                         (false, None) => ChildStatus::Stopped,
                     },
-                    pid: record.map(|r| r.pid),
-                    owned: inner.children.contains_key(key),
+                    pid: record.map(|record| record.pid),
+                    owned: inner
+                        .as_ref()
+                        .is_some_and(|inner| inner.children.contains_key(key)),
                     log_path: self.logs.path(key),
-                    last_error: record.and_then(|r| r.last_error.clone()),
+                    last_error: record.and_then(|record| record.last_error.clone()),
                 }
             })
             .collect()

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -67,6 +67,8 @@ pub struct ComposeRequest {
     /// This is the canonical `compose::add` JSON field. The singular `worker`
     /// field remains accepted for clients that used the old contract.
     pub workers: Option<Vec<String>>,
+    /// Caller-selected operation id used to bind progress before submission.
+    pub operation_id: Option<String>,
     /// Last cursor returned for each selected worker.
     pub cursors: Option<BTreeMap<String, LogCursor>>,
     /// Number of recent lines returned when no cursor is supplied.
@@ -75,6 +77,8 @@ pub struct ComposeRequest {
     pub stream: Option<LogStream>,
     /// Long-poll budget. Bounded by the daemon.
     pub wait_ms: Option<u64>,
+    /// Operation id used by operation status and cancellation calls.
+    pub progress_operation_id: Option<String>,
     /// Function or file contract requested by `compose::schema`.
     pub function_id: Option<String>,
 }
@@ -126,6 +130,8 @@ struct AddOptions {
     workers: Option<Vec<String>>,
     /// Backward-compatible form for adding one worker.
     worker: Option<String>,
+    /// Caller-selected operation id for race-free progress subscription.
+    operation_id: Option<String>,
 }
 
 /// Request fields used by single-worker compose-file edits.
@@ -259,6 +265,19 @@ struct MutationError {
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
+struct CancelOutcome {
+    operation_id: String,
+    cancelled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+struct AddAcceptedOutcome {
+    operation_id: String,
+    status: String,
+    requested: usize,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 struct SchemaEntry {
     function_id: String,
     description: String,
@@ -308,6 +327,8 @@ enum Operation {
     Restart,
     Update,
     Schema,
+    OperationStatus,
+    Cancel,
 }
 
 /// Canonical list of functions exposed by the compose daemon.
@@ -324,6 +345,8 @@ const REGISTERED_OPERATIONS: &[(&str, Operation)] = &[
     ("restart", Operation::Restart),
     ("update", Operation::Update),
     ("schema", Operation::Schema),
+    ("operation", Operation::OperationStatus),
+    ("cancel", Operation::Cancel),
 ];
 
 async fn dispatch(
@@ -371,22 +394,85 @@ async fn dispatch(
             Err(err) => Err(compose_error(&err)),
         },
         Operation::Add => {
-            let result = match request.workers.as_deref() {
-                Some(workers) => daemon.add(file.as_deref(), workers, operation_id()).await,
-                None => match request.worker.as_ref() {
-                    Some(worker) => {
-                        daemon
-                            .add(
-                                file.as_deref(),
-                                std::slice::from_ref(worker),
-                                operation_id(),
+            let workers = request
+                .workers
+                .or_else(|| request.worker.map(|worker| vec![worker]))
+                .unwrap_or_default();
+            if workers.is_empty() {
+                return daemon
+                    .add(file.as_deref(), &[], operation_id())
+                    .await
+                    .map_err(|err| compose_error(&err));
+            }
+
+            let requested = workers.len();
+            let operation = daemon
+                .operations
+                .create_with_id(
+                    request
+                        .operation_id
+                        .unwrap_or_else(|| format!("compose:{}", uuid::Uuid::new_v4())),
+                    requested,
+                )
+                .await;
+            let operation_id = operation.id().to_string();
+            operation
+                .emit(
+                    None,
+                    "accepted",
+                    format!("adding {requested} requested workers"),
+                )
+                .await;
+
+            let daemon_task = Arc::clone(&daemon);
+            let task_operation_id = operation_id.clone();
+            let cancellation = operation.cancellation();
+            tokio::spawn(async move {
+                operation
+                    .emit(None, "resolving", "resolving dependency trees")
+                    .await;
+                let result = daemon_task
+                    .add(file.as_deref(), &workers, task_operation_id)
+                    .await;
+                if *cancellation.borrow() {
+                    operation
+                        .finish(
+                            crate::operation::OperationStatus::Cancelled,
+                            "operation cancelled",
+                        )
+                        .await;
+                    return;
+                }
+                match result {
+                    Ok(value) => {
+                        let failed = value.get("status").and_then(Value::as_str) == Some("failed");
+                        operation
+                            .finish(
+                                if failed {
+                                    crate::operation::OperationStatus::Failed
+                                } else {
+                                    crate::operation::OperationStatus::Succeeded
+                                },
+                                if failed {
+                                    "one or more workers failed"
+                                } else {
+                                    "all requested workers are ready"
+                                },
                             )
+                            .await;
+                    }
+                    Err(error) => {
+                        operation
+                            .finish(crate::operation::OperationStatus::Failed, error.to_string())
                             .await
                     }
-                    None => daemon.add(file.as_deref(), &[], operation_id()).await,
-                },
-            };
-            result.map_err(|err| compose_error(&err))
+                }
+            });
+            Ok(json!({
+                "operation_id": operation_id,
+                "status": "accepted",
+                "requested": requested
+            }))
         }
         Operation::Remove => match daemon
             .remove(file.as_deref(), request.worker.as_deref(), operation_id())
@@ -488,6 +574,25 @@ async fn dispatch(
         Operation::Schema => Ok(to_value(&build_schema_response(
             request.function_id.as_deref(),
         ))),
+        Operation::OperationStatus => {
+            let id = request
+                .progress_operation_id
+                .or(request.operation_id)
+                .ok_or_else(|| Error::Handler("operation_id is required".into()))?;
+            let operation = daemon
+                .operations
+                .get(&id)
+                .await
+                .ok_or_else(|| Error::Handler(format!("unknown compose operation '{id}'")))?;
+            Ok(to_value(&operation.snapshot().await))
+        }
+        Operation::Cancel => {
+            let id = request
+                .progress_operation_id
+                .or(request.operation_id)
+                .ok_or_else(|| Error::Handler("operation_id is required".into()))?;
+            Ok(json!({ "operation_id": id, "cancelled": daemon.operations.cancel(&id).await }))
+        }
     }
 }
 
@@ -583,6 +688,10 @@ fn op_description(function_id: &str) -> &'static str {
             "JSON Schema for a worker-compose.yaml file. The response is a \
              complete small example keyed by its file name."
         }
+        "compose::operation" => {
+            "Return the latest snapshot for reconnecting to a pushed Compose operation."
+        }
+        "compose::cancel" => "Request cancellation of a running Compose operation.",
         _ => "",
     }
 }
@@ -602,6 +711,7 @@ fn op_metadata(function_id: &str) -> (u64, bool) {
         "compose::restart" => (600_000, false),
         "compose::update" => (600_000, false),
         "compose::schema" | "worker-compose.yaml" => (10_000, true),
+        "compose::operation" | "compose::cancel" => (10_000, true),
         _ => (30_000, false),
     }
 }
@@ -651,7 +761,7 @@ fn schema_table() -> &'static [SchemaTriple] {
             (
                 "compose::add",
                 add_options_schema(),
-                schema_for_value::<MutationOutcome>(),
+                schema_for_value::<AddAcceptedOutcome>(),
             ),
             (
                 "compose::remove",
@@ -672,6 +782,16 @@ fn schema_table() -> &'static [SchemaTriple] {
                 "compose::schema",
                 schema_for_value::<SchemaRequest>(),
                 schema_for_value::<SchemaResponse>(),
+            ),
+            (
+                "compose::operation",
+                schema_for_value::<ComposeRequest>(),
+                schema_for_value::<crate::operation::OperationSnapshot>(),
+            ),
+            (
+                "compose::cancel",
+                schema_for_value::<ComposeRequest>(),
+                schema_for_value::<CancelOutcome>(),
             ),
             (
                 "worker-compose.yaml",
@@ -908,7 +1028,6 @@ mod tests {
         for id in [
             "compose::up",
             "compose::down",
-            "compose::add",
             "compose::remove",
             "compose::restart",
             "compose::update",
@@ -925,5 +1044,16 @@ mod tests {
             assert!(properties.contains_key("status"));
             assert!(properties.contains_key("changed"));
         }
+    }
+
+    #[test]
+    fn add_response_is_an_observable_operation_admission() {
+        let properties = schema_entry("compose::add").2.as_ref().unwrap()["properties"]
+            .as_object()
+            .unwrap();
+        assert!(properties.contains_key("operation_id"));
+        assert!(properties.contains_key("status"));
+        assert!(properties.contains_key("requested"));
+        assert!(!properties.contains_key("containers"));
     }
 }

--- a/crates/iii-compose/src/report.rs
+++ b/crates/iii-compose/src/report.rs
@@ -320,6 +320,25 @@ pub fn failed(key: &str, code: &str, message: &str) {
     ));
 }
 
+/// Render pushed progress in the dedicated `iii compose add` client process.
+/// Remote daemon reconciliation itself uses the normal lifecycle tree above.
+pub fn progress_event(event: &crate::operation::ProgressEvent) {
+    match (event.container.as_deref(), event.phase.as_str()) {
+        (
+            Some(container),
+            "starting" | "installing" | "configuring" | "preparing" | "registering",
+        ) => starting(container, &event.detail),
+        (Some(container), "ready") => ready(container, Duration::from_millis(event.elapsed_ms)),
+        (Some(container), "failed") => failed(container, "START_FAILED", &event.detail),
+        (None, "accepted" | "resolving") => line(&format!("{} {}", RUNNING.cyan(), event.detail)),
+        (None, "complete") if event.detail.contains("ready") => {
+            line(&format!("{} {}", OK.green(), event.detail))
+        }
+        (None, "complete") => line(&format!("{} {}", FAILED.red(), event.detail)),
+        _ => {}
+    }
+}
+
 /// Already in the desired state — nothing was done to it.
 pub fn unchanged(key: &str, what: &str) {
     if set(key, RowState::Skipped(what.to_string())) {

--- a/crates/iii-compose/src/shutdown.rs
+++ b/crates/iii-compose/src/shutdown.rs
@@ -62,6 +62,11 @@ impl ShutdownSignal {
         Ok(Self { receiver })
     }
 
+    /// Adapts an existing latched cancellation source to lifecycle shutdown.
+    pub(crate) fn from_receiver(receiver: watch::Receiver<bool>) -> Self {
+        Self { receiver }
+    }
+
     pub(crate) fn requested(&self) -> bool {
         *self.receiver.borrow()
     }

--- a/crates/iii-compose/tests/process_lifecycle.rs
+++ b/crates/iii-compose/tests/process_lifecycle.rs
@@ -62,6 +62,20 @@ async fn read_pid_file(path: &Path) -> u32 {
 }
 
 #[tokio::test]
+async fn managed_workers_do_not_inherit_terminal_stdin() {
+    let tmp = tempfile::tempdir().unwrap();
+    // `read` would receive SIGTTIN when this background process group inherited
+    // Compose's controlling terminal. Null stdin makes it observe EOF and exit.
+    let child = spawn("read value", tmp.path());
+    let pid = child.pid;
+    let status = tokio::time::timeout(Duration::from_secs(2), child.wait())
+        .await
+        .expect("stdin read should not stop the managed worker");
+    assert!(!status.success());
+    assert!(wait_until_gone(pid).await);
+}
+
+#[tokio::test]
 async fn stop_takes_down_grandchildren_too() {
     let tmp = tempfile::tempdir().unwrap();
     // The worker spawns its own child, as a language runtime or build tool

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -219,6 +219,7 @@ fn cli_usage_command_path(cli: &Cli) -> String {
         Some(Commands::Compose(args)) => match &args.command {
             Some(iii_compose::ComposeSubcommand::Build(_)) => "compose build".to_string(),
             Some(iii_compose::ComposeSubcommand::Logs(_)) => "compose logs".to_string(),
+            Some(iii_compose::ComposeSubcommand::Add(_)) => "compose add".to_string(),
             None => "compose".to_string(),
         },
         Some(Commands::GenDocs { .. }) => "gen-cli-docs".to_string(),


### PR DESCRIPTION
## Summary

Make large `compose::add` requests observable, cancellable, responsive, and safer while preserving the existing dependency-tree renderer.

## Changes

### Observable asynchronous operations

- `compose::add` now admits work immediately and returns:
  - `operation_id`
  - `status`
  - requested worker count
- Added a `compose-operation` trigger type for pushed progress events.
- Added `compose::operation` for reconnect snapshots.
- Added `compose::cancel` for explicit cancellation.
- Supports caller-selected operation IDs so clients can bind progress before submission.
- Added `iii compose add` as a first-class CLI command.

### Batch execution

- Resolve requested root dependency graphs concurrently with bounded parallelism.
- Preserve request order when merging resolved graphs.
- Acquire registry artifacts concurrently before runtime reconciliation.
- Adopt and publish worker results as each worker settles instead of waiting for the entire wave.
- Keep Compose status responsive during long lifecycle operations using durable-state fallback.

### Progress reporting

- Reuse the existing dependency-tree renderer after add changes the graph.
- Emit structured phases including:
  - accepted
  - resolving
  - waiting
  - installing
  - configuring
  - preparing
  - starting
  - registering
  - ready
  - failed
  - complete
- Retain pushed progress for remote clients without duplicating daemon lifecycle rows.
- Register remote Compose functions only after initial foreground startup completes, preventing two operations from sharing the global tree renderer.

### Startup and cancellation safety

- Add a hard deadline around the entire readiness routine, including engine RPCs.
- Add a 20-minute VM preparation deadline.
- Propagate operation cancellation into the existing lifecycle shutdown path.
- Cancel active operations before daemon-wide shutdown.
- Avoid dropping reconciliation futures while they own unadopted child processes.

### Process supervision

- Managed workers receive null stdin on Unix and Windows.
- Prevent background workers from receiving `SIGTTIN` and entering stopped `T` state when reading the controlling terminal.
- Added process lifecycle regression coverage for inherited stdin.

### CLI and contracts

- Added typed operation admission, snapshot, cancellation, and progress-event schemas.
- Added top-level telemetry naming for `compose add`.
- Updated schema tests for asynchronous add admission.

## Motivation

Large worker batches previously ran as one long synchronous RPC. During the operation:

- the caller could time out while Compose continued working;
- status and shutdown could block behind lifecycle state;
- users received no remote progress;
- a worker reading inherited terminal stdin could stop indefinitely;
- stalled engine readiness calls could bypass the configured startup timeout;
- cancellation could abandon a child before it was adopted.

This change separates admission from execution, exposes pushed progress through iii triggers, and adds bounded concurrency and lifecycle failsafes.

## Validation

- Full `iii-compose` test suite
- All process lifecycle tests
- CLI parser tests
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`

## Compatibility note

`compose::add` now returns an accepted operation rather than waiting for the final mutation result. Consumers should follow the `compose-operation` trigger or query `compose::operation` when reconnecting.