### PR TITLE
(MOT-3944) fix(engine): allow namespaced queue provider registration

### DIFF
--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -72,6 +72,7 @@ const NAMESPACE_SCOPED_QUEUE_FUNCTION_IDS: &[&str] = &[
     "engine::queue::dlq_messages",
 ];
 
+/// Returns whether a function is an official namespace-scoped queue provider.
 fn is_namespace_scoped_queue_function(function_id: &str) -> bool {
     NAMESPACE_SCOPED_QUEUE_FUNCTION_IDS.contains(&function_id)
 }

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -59,6 +59,23 @@ const REATTACH_EVICT_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 /// as the durable transport boundary.
 const ENQUEUE_PROVIDER_FUNCTION_ID: &str = "engine::queue::enqueue";
 
+/// Engine-shaped functions that the standalone queue worker provides inside
+/// each project namespace. These IDs are safe exceptions to the reserved
+/// `engine::*` rule because queue dispatch resolves them in an explicit target
+/// namespace; all other `engine::*` registrations remain restricted to
+/// `default`.
+const NAMESPACE_SCOPED_QUEUE_FUNCTION_IDS: &[&str] = &[
+    ENQUEUE_PROVIDER_FUNCTION_ID,
+    "engine::queue::list_topics",
+    "engine::queue::topic_stats",
+    "engine::queue::dlq_topics",
+    "engine::queue::dlq_messages",
+];
+
+fn is_namespace_scoped_queue_function(function_id: &str) -> bool {
+    NAMESPACE_SCOPED_QUEUE_FUNCTION_IDS.contains(&function_id)
+}
+
 /// How long a freshly connected worker's registrations wait for the namespace
 /// to arrive before the engine gives up and files them under
 /// [`DEFAULT_NAMESPACE`].
@@ -2190,7 +2207,10 @@ impl Engine {
                 // builtins. In `default` the ownership conflict with the builtin
                 // already blocks the shadow; outside it there is nothing to
                 // conflict with, so reserve the prefix here.
-                if reg_id.starts_with("engine::") && namespace != DEFAULT_NAMESPACE {
+                if reg_id.starts_with("engine::")
+                    && namespace != DEFAULT_NAMESPACE
+                    && !is_namespace_scoped_queue_function(&reg_id)
+                {
                     tracing::warn!(
                         worker_id = %worker.id,
                         function_id = %reg_id,
@@ -3974,7 +3994,7 @@ mod tests {
     /// bare id. In `default` the ownership conflict with the real builtin guards
     /// it instead, so `engine::*` there is allowed.
     #[tokio::test]
-    async fn register_function_reserves_engine_prefix_outside_default() {
+    async fn register_function_reserves_non_provider_engine_prefix_outside_default() {
         ensure_default_meter();
         let engine = Engine::new();
 
@@ -3985,25 +4005,45 @@ mod tests {
         engine.begin_namespace_resolution(&worker);
         engine.resolve_connection_namespace(&worker, "orders").await;
 
-        let reserved = Message::RegisterFunction {
-            id: "engine::log::info".to_string(),
-            description: None,
-            request_format: None,
-            response_format: None,
-            metadata: None,
-            invocation: None,
-        };
-        engine
-            .dispatch_msg(&worker, &reserved)
-            .await
-            .expect("dispatch");
-        assert!(
+        for function_id in ["engine::log::info", "engine::queue::custom"] {
+            let reserved = Message::RegisterFunction {
+                id: function_id.to_string(),
+                description: None,
+                request_format: None,
+                response_format: None,
+                metadata: None,
+                invocation: None,
+            };
             engine
-                .functions
-                .get("orders", "engine::log::info")
-                .is_none(),
-            "a reserved engine::* id must not register outside default"
-        );
+                .dispatch_msg(&worker, &reserved)
+                .await
+                .expect("dispatch");
+            assert!(
+                engine.functions.get("orders", function_id).is_none(),
+                "reserved function {function_id} must not register outside default"
+            );
+        }
+
+        // Queue providers are the narrow exception: enqueue dispatch and the
+        // queue administration API resolve them in the project namespace.
+        for function_id in super::NAMESPACE_SCOPED_QUEUE_FUNCTION_IDS {
+            let queue_provider = Message::RegisterFunction {
+                id: (*function_id).to_string(),
+                description: None,
+                request_format: None,
+                response_format: None,
+                metadata: None,
+                invocation: None,
+            };
+            engine
+                .dispatch_msg(&worker, &queue_provider)
+                .await
+                .expect("dispatch queue provider");
+            assert!(
+                engine.functions.get("orders", function_id).is_some(),
+                "queue provider {function_id} must register in a project namespace"
+            );
+        }
 
         // The same-shaped id in `default` is allowed.
         let (tx2, _rx2) = mpsc::channel::<Outbound>(8);


### PR DESCRIPTION
Refs MOT-3944

## Summary

- Allow the five official standalone queue provider functions to register in project namespaces.
- Keep every other worker-provided `engine::*` function restricted to `default`.
- Add regression coverage for allowed providers and rejected arbitrary IDs.

## Problem

The namespace-aware queue worker uses one project-scoped connection. It must register `engine::queue::*` provider functions in that project namespace. The engine currently rejects all worker-provided `engine::*` registrations outside `default`, so the worker fails startup with `FUNCTION_NAMESPACE_CONFLICT`.

## Behavior

```text
project queue worker
        |
        +-- official engine::queue provider -> allowed in project namespace
        |
        +-- any other engine::* function    -> rejected outside default
```

The exception is an exact allowlist. It does not permit arbitrary `engine::queue::*` registrations.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p iii`
- `cargo test -p iii --lib` — 1,753 passed, 1 ignored
- `cargo test -p iii --lib register_function_reserves_non_provider_engine_prefix_outside_default`
- Queue durability E2E against the patched engine — 3 passed

## Clippy baseline

`cargo clippy -p iii --lib -- -D warnings` still reports existing warnings outside `engine/src/engine/mod.rs`. This change introduces no Clippy finding in the modified code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue-provider functions can now be registered within project namespaces.
  * Supported queue operations include enqueueing, topic listing and statistics, and dead-letter queue access.
  * Queue operations continue to resolve against their explicitly selected project namespace.

* **Bug Fixes**
  * Preserved restrictions on other reserved `engine::*` function identifiers outside the default namespace.
  * Prevented unauthorized engine-prefixed functions from being registered in project namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->