### PR TITLE
docs(install): default namespace + one compose::add per recipe

### DIFF
--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -162,16 +162,10 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-cmd">
       <span className="iii-qs-prompt">$</span>
-      <span>iii --config config.yaml</span>
+      <span>iii compose --up</span>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
     <div className="iii-qs-comment"># New terminal, same folder</div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>iii compose --engine ws://127.0.0.1:49134</span>
-    </div>
-    <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># Third terminal, same folder</div>
     <div className="iii-qs-slot" data-qs="none">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -249,7 +243,7 @@ agents within your iii system. You can add a provider worker later at any time.
   </div>
 </div>
 
-{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init iii-app && cd iii-app`, start `iii --config config.yaml`, and in a second terminal start `iii compose --engine ws://127.0.0.1:49134`. In a third terminal, add `harness`, `console`, and `provider-<name>` one at a time with `iii trigger compose::add worker=<name>`, then open http://localhost:3113. Export the provider credential in the terminal that runs the engine before starting it. Without an llm, add only `console`. */}
+{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init iii-app && cd iii-app`, start `iii compose --up` (it starts and manages the engine), and in a second terminal add `harness`, `console`, and `provider-<name>` in one `iii trigger compose::add worker=harness worker=console worker=provider-<name>` command, then open http://localhost:3113. Export the provider credential in the terminal that runs `iii compose --up` before starting it. Without an llm, add only `console`. */}
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -143,7 +143,7 @@ agents within your iii system. You can add a provider worker later at any time.
     <div className="iii-qs-slot" data-qs="llamacpp">
       <div className="iii-qs-comment"># Set up your llm provider</div>
       <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default.</div>
-      <div className="iii-qs-comment"># A key is only needed when llama-server runs with --api-key:</div>
+      <div className="iii-qs-comment">{'# A key is only needed when llama-server runs with --api-key:'}</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export LLAMACPP_API_KEY=yourkey</span>
@@ -162,7 +162,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-cmd">
       <span className="iii-qs-prompt">$</span>
-      <span>iii compose --up</span>
+      <span>{'iii compose --up'}</span>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
     <div className="iii-qs-comment"># New terminal, same folder</div>

--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -168,68 +168,68 @@ agents within your iii system. You can add a provider worker later at any time.
     <div className="iii-qs-comment"># New terminal, same folder</div>
     <div className="iii-qs-cmd">
       <span className="iii-qs-prompt">$</span>
-      <span>iii compose --namespace dev --engine ws://127.0.0.1:49134</span>
+      <span>iii compose --engine ws://127.0.0.1:49134</span>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
     <div className="iii-qs-comment"># Third terminal, same folder</div>
     <div className="iii-qs-slot" data-qs="none">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=console</span>
+        <span>iii trigger compose::add worker=console</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openai">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-openai</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-openai</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openai-codex">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-openai-codex</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-openai-codex</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="anthropic">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-anthropic</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-anthropic</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="deepseek">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-deepseek</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-deepseek</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="kimi">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-kimi</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-kimi</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openrouter">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-openrouter</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-openrouter</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="xai">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-xai</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-xai</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="zai">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-zai</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-zai</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-github-copilot</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-github-copilot</span>
       </div>
       <div className="iii-qs-comment"># Sign in once the provider worker is up:</div>
       <div className="iii-qs-cmd">
@@ -240,7 +240,7 @@ agents within your iii system. You can add a provider worker later at any time.
     <div className="iii-qs-slot" data-qs="llamacpp">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-llamacpp</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-llamacpp</span>
       </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
@@ -249,7 +249,7 @@ agents within your iii system. You can add a provider worker later at any time.
   </div>
 </div>
 
-{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init iii-app && cd iii-app`, start `iii --config config.yaml`, and in a second terminal start `iii compose --namespace dev --engine ws://127.0.0.1:49134`. In a third terminal, add `harness`, `console`, and `provider-<name>` one at a time with `iii trigger -n dev compose::add worker=<name>`, then open http://localhost:3113. Export the provider credential in the terminal that runs the engine before starting it. Without an llm, add only `console`. */}
+{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init iii-app && cd iii-app`, start `iii --config config.yaml`, and in a second terminal start `iii compose --engine ws://127.0.0.1:49134`. In a third terminal, add `harness`, `console`, and `provider-<name>` one at a time with `iii trigger compose::add worker=<name>`, then open http://localhost:3113. Export the provider credential in the terminal that runs the engine before starting it. Without an llm, add only `console`. */}
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -166,68 +166,68 @@ agents within your iii system. You can add a provider worker later at any time.
     <div className="iii-qs-comment"># New terminal, same folder</div>
     <div className="iii-qs-cmd">
       <span className="iii-qs-prompt">$</span>
-      <span>iii compose --namespace dev --engine ws://127.0.0.1:49134</span>
+      <span>iii compose --engine ws://127.0.0.1:49134</span>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
     <div className="iii-qs-comment"># Third terminal, same folder</div>
     <div className="iii-qs-slot" data-qs="none">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=console</span>
+        <span>iii trigger compose::add worker=console</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openai">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-openai</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-openai</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openai-codex">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-openai-codex</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-openai-codex</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="anthropic">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-anthropic</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-anthropic</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="deepseek">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-deepseek</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-deepseek</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="kimi">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-kimi</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-kimi</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openrouter">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-openrouter</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-openrouter</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="xai">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-xai</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-xai</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="zai">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-zai</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-zai</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-github-copilot</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-github-copilot</span>
       </div>
       <div className="iii-qs-comment"># Sign in once the provider worker is up:</div>
       <div className="iii-qs-cmd">
@@ -238,7 +238,7 @@ agents within your iii system. You can add a provider worker later at any time.
     <div className="iii-qs-slot" data-qs="llamacpp">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger -n dev compose::add worker=harness && iii trigger -n dev compose::add worker=console && iii trigger -n dev compose::add worker=provider-llamacpp</span>
+        <span>iii trigger compose::add worker=harness worker=console worker=provider-llamacpp</span>
       </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
@@ -247,7 +247,7 @@ agents within your iii system. You can add a provider worker later at any time.
   </div>
 </div>
 
-The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init iii-app && cd iii-app`, start `iii --config config.yaml`, and in a second terminal start `iii compose --namespace dev --engine ws://127.0.0.1:49134`. In a third terminal, add `harness`, `console`, and `provider-<name>` one at a time with `iii trigger -n dev compose::add worker=<name>`, then open http://localhost:3113. Export the provider credential in the terminal that runs the engine before starting it. Without an llm, add only `console`.
+The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init iii-app && cd iii-app`, start `iii --config config.yaml`, and in a second terminal start `iii compose --engine ws://127.0.0.1:49134`. In a third terminal, add `harness`, `console`, and `provider-<name>` one at a time with `iii trigger compose::add worker=<name>`, then open http://localhost:3113. Export the provider credential in the terminal that runs the engine before starting it. Without an llm, add only `console`.
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -160,16 +160,10 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-cmd">
       <span className="iii-qs-prompt">$</span>
-      <span>iii --config config.yaml</span>
+      <span>iii compose --up</span>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
     <div className="iii-qs-comment"># New terminal, same folder</div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>iii compose --engine ws://127.0.0.1:49134</span>
-    </div>
-    <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># Third terminal, same folder</div>
     <div className="iii-qs-slot" data-qs="none">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -247,7 +241,7 @@ agents within your iii system. You can add a provider worker later at any time.
   </div>
 </div>
 
-The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init iii-app && cd iii-app`, start `iii --config config.yaml`, and in a second terminal start `iii compose --engine ws://127.0.0.1:49134`. In a third terminal, add `harness`, `console`, and `provider-<name>` one at a time with `iii trigger compose::add worker=<name>`, then open http://localhost:3113. Export the provider credential in the terminal that runs the engine before starting it. Without an llm, add only `console`.
+The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init iii-app && cd iii-app`, start `iii compose --up` (it starts and manages the engine), and in a second terminal add `harness`, `console`, and `provider-<name>` in one `iii trigger compose::add worker=harness worker=console worker=provider-<name>` command, then open http://localhost:3113. Export the provider credential in the terminal that runs `iii compose --up` before starting it. Without an llm, add only `console`.
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -141,7 +141,7 @@ agents within your iii system. You can add a provider worker later at any time.
     <div className="iii-qs-slot" data-qs="llamacpp">
       <div className="iii-qs-comment"># Set up your llm provider</div>
       <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default.</div>
-      <div className="iii-qs-comment"># A key is only needed when llama-server runs with --api-key:</div>
+      <div className="iii-qs-comment">{'# A key is only needed when llama-server runs with --api-key:'}</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span> export LLAMACPP_API_KEY=yourkey</span>
@@ -160,7 +160,7 @@ agents within your iii system. You can add a provider worker later at any time.
     </div>
     <div className="iii-qs-cmd">
       <span className="iii-qs-prompt">$</span>
-      <span>iii compose --up</span>
+      <span>{'iii compose --up'}</span>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
     <div className="iii-qs-comment"># New terminal, same folder</div>


### PR DESCRIPTION
## What

- Drop the `-n dev` / `--namespace dev` flags from the install recipe. The CLI resolves to the `default` namespace when none is given.
- Collapse each provider recipe's three chained triggers into one `compose::add`:
  ```
  iii trigger compose::add worker=harness worker=console worker=provider-<name>
  ```

## Why

`compose::add` collects repeated `worker=` tokens into its `workers` list (`cli_trigger/mod.rs` → `parse_collecting(&args.kv, ..., "worker", "workers")`), so the three `&&`-chained calls are one call. And with the default namespace there is no reason to spell `-n dev` on every line.

## Notes

- Both `docs/next/install.mdx` and its `.skill.md` twin updated in lockstep.
- The `worker=a worker=b` collapse is specific to `compose::add`; every other trigger keeps last-value-wins for repeated keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)