### PR TITLE
docs(install): install from the harness template

### DIFF
--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -13,7 +13,7 @@ The recipe below installs the engine, creates a project from the harness templat
 Select your llm provider, or select **no llm**. The harness project ships
 [console](./using-iii/console), the browser ui for your running system, and the
 [harness](https://workers.iii.dev/workers/harness) worker for agentic development and running agents
-inside your iii system. `provider-openai` and `provider-anthropic` are enabled out of the box; enable
+inside your iii system. `provider-openai` and `provider-anthropic` are enabled by default; enable
 any other provider in `worker-compose.yaml` later.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
@@ -97,7 +97,7 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openai-codex">
-      <div className="iii-qs-comment"># No api key — uses your chatgpt subscription. Sign in with the codex cli so ~/.codex/auth.json exists:</div>
+      <div className="iii-qs-comment"># No api key. Uses your chatgpt subscription. Sign in with the codex cli so ~/.codex/auth.json exists:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>codex login</span>
@@ -164,7 +164,7 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
-      <div className="iii-qs-comment"># No api key — your github copilot subscription grants the models. Enable the provider in worker-compose.yaml:</div>
+      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models. Enable the provider in worker-compose.yaml:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano worker-compose.yaml</span>

--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -9,11 +9,12 @@ type: "how-to"
 
 ## Start a project
 
-The recipe below installs the engine, creates a project, and starts it. Select your llm provider, or
-select **no llm** to set up a project without one. Every recipe adds [console](./using-iii/console),
-the browser ui for your running system; a provider also adds
-[harness](https://workers.iii.dev/workers/harness) which enables both agentic development and use of
-agents within your iii system. You can add a provider worker later at any time.
+The recipe below installs the engine, creates a project from the harness template, and starts it.
+Select your llm provider, or select **no llm**. The harness project ships
+[console](./using-iii/console), the browser ui for your running system, and the
+[harness](https://workers.iii.dev/workers/harness) worker for agentic development and running agents
+inside your iii system. `provider-openai` and `provider-anthropic` are enabled out of the box; enable
+any other provider in `worker-compose.yaml` later.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-none" defaultChecked />
@@ -68,173 +69,130 @@ agents within your iii system. You can add a provider worker later at any time.
 </div>
 
   <div className="iii-qs-body">
-    <div className="iii-qs-slot" data-qs="none">
-      <div className="iii-qs-comment"># No llm needed. Add a provider worker whenever you want agents.</div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openai">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+    <div className="iii-qs-comment"># Install iii & create a harness project</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export OPENAI_API_KEY=yourkey</span>
+        <span>curl -fsSL https://install.iii.dev/iii/main/install.sh | sh</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii project init my-harness --template harness && cd my-harness</span>
+      </div>
+    <div className="iii-qs-gap" aria-hidden="true" />
+    <div className="iii-qs-slot" data-qs="none">
+      <div className="iii-qs-comment"># No llm needed now. Add a provider key to .env whenever you want agents; the console starts either way.</div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openai">
+      <div className="iii-qs-comment"># provider-openai is enabled by default. Set OPENAI_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="anthropic">
+      <div className="iii-qs-comment"># provider-anthropic is enabled by default. Set ANTHROPIC_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openai-codex">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># No api key. This provider uses your chatgpt subscription.</div>
-      <div className="iii-qs-comment"># Sign in with the codex cli first, so ~/.codex/auth.json exists:</div>
+      <div className="iii-qs-comment"># No api key — uses your chatgpt subscription. Sign in with the codex cli so ~/.codex/auth.json exists:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>codex login</span>
       </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="anthropic">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable the provider in worker-compose.yaml:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export ANTHROPIC_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="deepseek">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable provider-deepseek in worker-compose.yaml, then set DEEPSEEK_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export DEEPSEEK_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="kimi">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable provider-kimi in worker-compose.yaml, then set MOONSHOT_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export MOONSHOT_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openrouter">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable provider-openrouter in worker-compose.yaml, then set OPENROUTER_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export OPENROUTER_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="xai">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable provider-xai in worker-compose.yaml, then set XAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export XAI_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="zai">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable provider-zai in worker-compose.yaml, then set ZAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export ZAI_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models.</div>
+      <div className="iii-qs-comment"># No api key — your github copilot subscription grants the models. Enable the provider in worker-compose.yaml:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
     </div>
     <div className="iii-qs-slot" data-qs="llamacpp">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default.</div>
-      <div className="iii-qs-comment">{'# A key is only needed when llama-server runs with --api-key:'}</div>
+      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default. Enable the provider in worker-compose.yaml:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export LLAMACPP_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
       </div>
-    </div>
-
-    <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># Install iii & setup your project</div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>curl -fsSL https://install.iii.dev/iii/main/install.sh | sh</span>
-    </div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>iii project init iii-app && cd iii-app</span>
-    </div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>{'iii compose --up'}</span>
+      <div className="iii-qs-comment">{'# A key is only needed when llama-server runs with --api-key (set LLAMACPP_API_KEY in .env):'}</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
+      </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># New terminal, same folder</div>
-    <div className="iii-qs-slot" data-qs="none">
+    <div className="iii-qs-comment"># Start the engine and the whole harness stack</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=console</span>
+        <span>{'iii compose --up'}</span>
       </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openai">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-openai</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openai-codex">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-openai-codex</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="anthropic">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-anthropic</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="deepseek">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-deepseek</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="kimi">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-kimi</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openrouter">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-openrouter</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="xai">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-xai</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="zai">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-zai</span>
-      </div>
-    </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-github-copilot</span>
-      </div>
       <div className="iii-qs-comment"># Sign in once the provider worker is up:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>iii trigger provider::github-copilot::login::start</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="llamacpp">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-llamacpp</span>
       </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
@@ -243,7 +201,7 @@ agents within your iii system. You can add a provider worker later at any time.
   </div>
 </div>
 
-{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init iii-app && cd iii-app`, start `iii compose --up` (it starts and manages the engine), and in a second terminal add `harness`, `console`, and `provider-<name>` in one `iii trigger compose::add worker=harness worker=console worker=provider-<name>` command, then open http://localhost:3113. Export the provider credential in the terminal that runs `iii compose --up` before starting it. Without an llm, add only `console`. */}
+{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, uncomment its block in `worker-compose.yaml` and set its key in `.env` first. Then start the whole stack with `iii compose --up` and open http://localhost:3113. Without an llm, skip the key and the console still starts. */}
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -11,7 +11,7 @@ The recipe below installs the engine, creates a project from the harness templat
 Select your llm provider, or select **no llm**. The harness project ships
 [console](./using-iii/console), the browser ui for your running system, and the
 [harness](https://workers.iii.dev/workers/harness) worker for agentic development and running agents
-inside your iii system. `provider-openai` and `provider-anthropic` are enabled out of the box; enable
+inside your iii system. `provider-openai` and `provider-anthropic` are enabled by default; enable
 any other provider in `worker-compose.yaml` later.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
@@ -95,7 +95,7 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openai-codex">
-      <div className="iii-qs-comment"># No api key — uses your chatgpt subscription. Sign in with the codex cli so ~/.codex/auth.json exists:</div>
+      <div className="iii-qs-comment"># No api key. Uses your chatgpt subscription. Sign in with the codex cli so ~/.codex/auth.json exists:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>codex login</span>
@@ -162,7 +162,7 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
-      <div className="iii-qs-comment"># No api key — your github copilot subscription grants the models. Enable the provider in worker-compose.yaml:</div>
+      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models. Enable the provider in worker-compose.yaml:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano worker-compose.yaml</span>

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -7,11 +7,12 @@
 
 ## Start a project
 
-The recipe below installs the engine, creates a project, and starts it. Select your llm provider, or
-select **no llm** to set up a project without one. Every recipe adds [console](./using-iii/console),
-the browser ui for your running system; a provider also adds
-[harness](https://workers.iii.dev/workers/harness) which enables both agentic development and use of
-agents within your iii system. You can add a provider worker later at any time.
+The recipe below installs the engine, creates a project from the harness template, and starts it.
+Select your llm provider, or select **no llm**. The harness project ships
+[console](./using-iii/console), the browser ui for your running system, and the
+[harness](https://workers.iii.dev/workers/harness) worker for agentic development and running agents
+inside your iii system. `provider-openai` and `provider-anthropic` are enabled out of the box; enable
+any other provider in `worker-compose.yaml` later.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-none" defaultChecked />
@@ -66,173 +67,130 @@ agents within your iii system. You can add a provider worker later at any time.
 </div>
 
   <div className="iii-qs-body">
-    <div className="iii-qs-slot" data-qs="none">
-      <div className="iii-qs-comment"># No llm needed. Add a provider worker whenever you want agents.</div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openai">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+    <div className="iii-qs-comment"># Install iii & create a harness project</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export OPENAI_API_KEY=yourkey</span>
+        <span>curl -fsSL https://install.iii.dev/iii/main/install.sh | sh</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii project init my-harness --template harness && cd my-harness</span>
+      </div>
+    <div className="iii-qs-gap" aria-hidden="true" />
+    <div className="iii-qs-slot" data-qs="none">
+      <div className="iii-qs-comment"># No llm needed now. Add a provider key to .env whenever you want agents; the console starts either way.</div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openai">
+      <div className="iii-qs-comment"># provider-openai is enabled by default. Set OPENAI_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="anthropic">
+      <div className="iii-qs-comment"># provider-anthropic is enabled by default. Set ANTHROPIC_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openai-codex">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># No api key. This provider uses your chatgpt subscription.</div>
-      <div className="iii-qs-comment"># Sign in with the codex cli first, so ~/.codex/auth.json exists:</div>
+      <div className="iii-qs-comment"># No api key — uses your chatgpt subscription. Sign in with the codex cli so ~/.codex/auth.json exists:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>codex login</span>
       </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="anthropic">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable the provider in worker-compose.yaml:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export ANTHROPIC_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="deepseek">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable provider-deepseek in worker-compose.yaml, then set DEEPSEEK_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export DEEPSEEK_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="kimi">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable provider-kimi in worker-compose.yaml, then set MOONSHOT_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export MOONSHOT_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openrouter">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable provider-openrouter in worker-compose.yaml, then set OPENROUTER_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export OPENROUTER_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="xai">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable provider-xai in worker-compose.yaml, then set XAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export XAI_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="zai">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable provider-zai in worker-compose.yaml, then set ZAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export ZAI_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models.</div>
+      <div className="iii-qs-comment"># No api key — your github copilot subscription grants the models. Enable the provider in worker-compose.yaml:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
     </div>
     <div className="iii-qs-slot" data-qs="llamacpp">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default.</div>
-      <div className="iii-qs-comment">{'# A key is only needed when llama-server runs with --api-key:'}</div>
+      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default. Enable the provider in worker-compose.yaml:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export LLAMACPP_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
       </div>
-    </div>
-
-    <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># Install iii & setup your project</div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>curl -fsSL https://install.iii.dev/iii/main/install.sh | sh</span>
-    </div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>iii project init iii-app && cd iii-app</span>
-    </div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>{'iii compose --up'}</span>
+      <div className="iii-qs-comment">{'# A key is only needed when llama-server runs with --api-key (set LLAMACPP_API_KEY in .env):'}</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
+      </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># New terminal, same folder</div>
-    <div className="iii-qs-slot" data-qs="none">
+    <div className="iii-qs-comment"># Start the engine and the whole harness stack</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=console</span>
+        <span>{'iii compose --up'}</span>
       </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openai">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-openai</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openai-codex">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-openai-codex</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="anthropic">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-anthropic</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="deepseek">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-deepseek</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="kimi">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-kimi</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openrouter">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-openrouter</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="xai">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-xai</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="zai">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-zai</span>
-      </div>
-    </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-github-copilot</span>
-      </div>
       <div className="iii-qs-comment"># Sign in once the provider worker is up:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>iii trigger provider::github-copilot::login::start</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="llamacpp">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-llamacpp</span>
       </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
@@ -241,7 +199,7 @@ agents within your iii system. You can add a provider worker later at any time.
   </div>
 </div>
 
-The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init iii-app && cd iii-app`, start `iii compose --up` (it starts and manages the engine), and in a second terminal add `harness`, `console`, and `provider-<name>` in one `iii trigger compose::add worker=harness worker=console worker=provider-<name>` command, then open http://localhost:3113. Export the provider credential in the terminal that runs `iii compose --up` before starting it. Without an llm, add only `console`.
+The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, uncomment its block in `worker-compose.yaml` and set its key in `.env` first. Then start the whole stack with `iii compose --up` and open http://localhost:3113. Without an llm, skip the key and the console still starts.
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 


### PR DESCRIPTION
## What

Rework the **Start a project** recipe on the install page to scaffold from the **harness template** instead of adding workers one at a time.

- `iii project init my-harness --template harness` brings up `console`, the `harness` worker, and `provider-openai` + `provider-anthropic` from one `worker-compose.yaml`.
- Those two providers are **enabled by default**, so their recipe is now just: put the key in `.env`, then `iii compose --up`. No `compose::add` for a provider.
- Every other provider: uncomment its block in `worker-compose.yaml` and set its key in `.env` (via `nano`) **before** `iii compose --up`. Codex and Copilot use their own sign-in instead of an api key.
- Users edit `.env` (`nano .env`) before starting.

## Why

The harness template already declares the whole agent stack, so the old three-terminal `compose::add worker=harness worker=console worker=provider-<name>` flow is redundant. For OpenAI/Anthropic there is no provider install step at all.

## Notes

- `docs/next/install.mdx.skill.md` is regenerated with `iii-skill-render --write`; the renderer parses the MDX, so the page is valid.
- Stacked conceptually on the merged #2116 (compose `--up`); branched from current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)