### PR TITLE
docs(install): no-llm base template, wrap --flags, bring to docs/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,22 @@ scripts/                         Build and CI scripts
 
 **Workspaces:** `Cargo.toml` (Rust), `pnpm-workspace.yaml` (JS/TS), `turbo.json` (build orchestration).
 
+## Docs (Mintlify/MDX)
+
+- **`--` renders as an em dash.** Mintlify's smart typography turns a double
+  hyphen into `—` in rendered text. Any command with a `--flag` (`--up`,
+  `--template`, `--api-key`) shown outside a Markdown code span — for example in
+  a JSX `<span>` — must be wrapped in a JSX string expression so it renders
+  verbatim: `<span>{'iii compose --up'}</span>`. Inside plain Markdown backticks
+  it is already safe.
+- Vale bans em dashes (`Terminology.EmDash`) and phrases like "out of the box"
+  (`Terminology.SlopMagic`) in prose. Rewrite with commas, parentheses, periods,
+  or colons, and name the explicit default.
+- After editing a `docs/next/*.mdx`, regenerate its skill artifact with
+  `iii-skill-render --write docs/next/<page>.mdx`. Versioned copies under
+  `docs/<version>/` are out of skill-render scope, so bring changes forward to
+  them (and their `.skill.md`) by hand.
+
 ## Boundaries
 
 ### Always

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -9,11 +9,12 @@ type: "how-to"
 
 ## Start a project
 
-The recipe below installs the engine, creates a project, and starts it. Select your llm provider, or
-select **no llm** to set up a project without one. Every recipe adds [console](./using-iii/console),
-the browser ui for your running system; a provider also adds
-[harness](https://workers.iii.dev/workers/harness) which enables both agentic development and use of
-agents within your iii system. You can add a provider worker later at any time.
+The recipe below installs the engine, creates a project from the harness template, and starts it.
+Select your llm provider, or select **no llm**. The harness project ships
+[console](./using-iii/console), the browser ui for your running system, and the
+[harness](https://workers.iii.dev/workers/harness) worker for agentic development and running agents
+inside your iii system. `provider-openai` and `provider-anthropic` are enabled by default; enable
+any other provider in `worker-compose.yaml` later.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-none" defaultChecked />
@@ -68,182 +69,178 @@ agents within your iii system. You can add a provider worker later at any time.
 </div>
 
   <div className="iii-qs-body">
-    <div className="iii-qs-slot" data-qs="none">
-      <div className="iii-qs-comment"># No llm needed. Add a provider worker whenever you want agents.</div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openai">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+    <div className="iii-qs-comment"># Install iii</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export OPENAI_API_KEY=yourkey</span>
+        <span>curl -fsSL https://install.iii.dev/iii/main/install.sh | sh</span>
+      </div>
+    <div className="iii-qs-gap" aria-hidden="true" />
+    <div className="iii-qs-slot" data-qs="none">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii project init my-app && cd my-app</span>
+      </div>
+      <div className="iii-qs-comment"># No llm. The base template starts just the console.</div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># provider-openai is enabled by default. Set OPENAI_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="anthropic">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># provider-anthropic is enabled by default. Set ANTHROPIC_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openai-codex">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># No api key. This provider uses your chatgpt subscription.</div>
-      <div className="iii-qs-comment"># Sign in with the codex cli first, so ~/.codex/auth.json exists:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># No api key. Uses your chatgpt subscription. Sign in with the codex cli so ~/.codex/auth.json exists:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>codex login</span>
       </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="anthropic">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable the provider in worker-compose.yaml:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export ANTHROPIC_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="deepseek">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export DEEPSEEK_API_KEY=yourkey</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># Enable provider-deepseek in worker-compose.yaml, then set DEEPSEEK_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="kimi">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export MOONSHOT_API_KEY=yourkey</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># Enable provider-kimi in worker-compose.yaml, then set MOONSHOT_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openrouter">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export OPENROUTER_API_KEY=yourkey</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># Enable provider-openrouter in worker-compose.yaml, then set OPENROUTER_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="xai">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export XAI_API_KEY=yourkey</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># Enable provider-xai in worker-compose.yaml, then set XAI_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="zai">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export ZAI_API_KEY=yourkey</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># Enable provider-zai in worker-compose.yaml, then set ZAI_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models.</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models. Enable the provider in worker-compose.yaml:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
     </div>
     <div className="iii-qs-slot" data-qs="llamacpp">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default.</div>
-      <div className="iii-qs-comment">{'# A key is only needed when llama-server runs with --api-key:'}</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export LLAMACPP_API_KEY=yourkey</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-    </div>
-
-    <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># Install iii & setup your project</div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>curl -fsSL https://install.iii.dev/iii/main/install.sh | sh</span>
-    </div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>iii project init iii-app && cd iii-app</span>
-    </div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>{'iii compose --up'}</span>
+      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default. Enable the provider in worker-compose.yaml:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-comment">{'# A key is only needed when llama-server runs with --api-key (set LLAMACPP_API_KEY in .env):'}</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
+      </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># New terminal, same folder</div>
-    <div className="iii-qs-slot" data-qs="none">
+    <div className="iii-qs-comment"># Start the engine and your project</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=console</span>
+        <span>{'iii compose --up'}</span>
       </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openai">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-openai</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openai-codex">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-openai-codex</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="anthropic">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-anthropic</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="deepseek">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-deepseek</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="kimi">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-kimi</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openrouter">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-openrouter</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="xai">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-xai</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="zai">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-zai</span>
-      </div>
-    </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-github-copilot</span>
-      </div>
       <div className="iii-qs-comment"># Sign in once the provider worker is up:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>iii trigger provider::github-copilot::login::start</span>
       </div>
     </div>
-    <div className="iii-qs-slot" data-qs="llamacpp">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-llamacpp</span>
-      </div>
-    </div>
     <div className="iii-qs-gap" aria-hidden="true" />
     <div className="iii-qs-comment"># Open your browser to http://localhost:3113</div>
-
   </div>
 </div>
 
-{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init iii-app && cd iii-app`, start `iii compose --up` (it starts and manages the engine), and in a second terminal add `harness`, `console`, and `provider-<name>` in one `iii trigger compose::add worker=harness worker=console worker=provider-<name>` command, then open http://localhost:3113. Export the provider credential in the terminal that runs `iii compose --up` before starting it. Without an llm, add only `console`. */}
+{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, uncomment its block in `worker-compose.yaml` and set its key in `.env` first. Then start the whole stack with `iii compose --up` and open http://localhost:3113. Without an llm, skip the key and the console still starts. */}
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/install.mdx.skill.md
+++ b/docs/install.mdx.skill.md
@@ -7,11 +7,12 @@
 
 ## Start a project
 
-The recipe below installs the engine, creates a project, and starts it. Select your llm provider, or
-select **no llm** to set up a project without one. Every recipe adds [console](./using-iii/console),
-the browser ui for your running system; a provider also adds
-[harness](https://workers.iii.dev/workers/harness) which enables both agentic development and use of
-agents within your iii system. You can add a provider worker later at any time.
+The recipe below installs the engine, creates a project from the harness template, and starts it.
+Select your llm provider, or select **no llm**. The harness project ships
+[console](./using-iii/console), the browser ui for your running system, and the
+[harness](https://workers.iii.dev/workers/harness) worker for agentic development and running agents
+inside your iii system. `provider-openai` and `provider-anthropic` are enabled by default; enable
+any other provider in `worker-compose.yaml` later.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-none" defaultChecked />
@@ -66,182 +67,178 @@ agents within your iii system. You can add a provider worker later at any time.
 </div>
 
   <div className="iii-qs-body">
-    <div className="iii-qs-slot" data-qs="none">
-      <div className="iii-qs-comment"># No llm needed. Add a provider worker whenever you want agents.</div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openai">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+    <div className="iii-qs-comment"># Install iii</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export OPENAI_API_KEY=yourkey</span>
+        <span>curl -fsSL https://install.iii.dev/iii/main/install.sh | sh</span>
+      </div>
+    <div className="iii-qs-gap" aria-hidden="true" />
+    <div className="iii-qs-slot" data-qs="none">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii project init my-app && cd my-app</span>
+      </div>
+      <div className="iii-qs-comment"># No llm. The base template starts just the console.</div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># provider-openai is enabled by default. Set OPENAI_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="anthropic">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># provider-anthropic is enabled by default. Set ANTHROPIC_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openai-codex">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># No api key. This provider uses your chatgpt subscription.</div>
-      <div className="iii-qs-comment"># Sign in with the codex cli first, so ~/.codex/auth.json exists:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># No api key. Uses your chatgpt subscription. Sign in with the codex cli so ~/.codex/auth.json exists:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>codex login</span>
       </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="anthropic">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
+      <div className="iii-qs-comment"># Enable the provider in worker-compose.yaml:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export ANTHROPIC_API_KEY=yourkey</span>
+        <span>nano worker-compose.yaml</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="deepseek">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export DEEPSEEK_API_KEY=yourkey</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># Enable provider-deepseek in worker-compose.yaml, then set DEEPSEEK_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="kimi">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export MOONSHOT_API_KEY=yourkey</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># Enable provider-kimi in worker-compose.yaml, then set MOONSHOT_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openrouter">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export OPENROUTER_API_KEY=yourkey</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># Enable provider-openrouter in worker-compose.yaml, then set OPENROUTER_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="xai">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export XAI_API_KEY=yourkey</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># Enable provider-xai in worker-compose.yaml, then set XAI_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="zai">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># The leading space keeps the export out of bash/zsh history (if you have history control enabled)</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export ZAI_API_KEY=yourkey</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># Enable provider-zai in worker-compose.yaml, then set ZAI_API_KEY in .env:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models.</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
+      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models. Enable the provider in worker-compose.yaml:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
     </div>
     <div className="iii-qs-slot" data-qs="llamacpp">
-      <div className="iii-qs-comment"># Set up your llm provider</div>
-      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default.</div>
-      <div className="iii-qs-comment">{'# A key is only needed when llama-server runs with --api-key:'}</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span> export LLAMACPP_API_KEY=yourkey</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-    </div>
-
-    <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># Install iii & setup your project</div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>curl -fsSL https://install.iii.dev/iii/main/install.sh | sh</span>
-    </div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>iii project init iii-app && cd iii-app</span>
-    </div>
-    <div className="iii-qs-cmd">
-      <span className="iii-qs-prompt">$</span>
-      <span>{'iii compose --up'}</span>
+      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default. Enable the provider in worker-compose.yaml:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano worker-compose.yaml</span>
+      </div>
+      <div className="iii-qs-comment">{'# A key is only needed when llama-server runs with --api-key (set LLAMACPP_API_KEY in .env):'}</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>nano .env</span>
+      </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># New terminal, same folder</div>
-    <div className="iii-qs-slot" data-qs="none">
+    <div className="iii-qs-comment"># Start the engine and your project</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=console</span>
+        <span>{'iii compose --up'}</span>
       </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openai">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-openai</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openai-codex">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-openai-codex</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="anthropic">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-anthropic</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="deepseek">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-deepseek</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="kimi">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-kimi</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="openrouter">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-openrouter</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="xai">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-xai</span>
-      </div>
-    </div>
-    <div className="iii-qs-slot" data-qs="zai">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-zai</span>
-      </div>
-    </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-github-copilot</span>
-      </div>
       <div className="iii-qs-comment"># Sign in once the provider worker is up:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>iii trigger provider::github-copilot::login::start</span>
       </div>
     </div>
-    <div className="iii-qs-slot" data-qs="llamacpp">
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii trigger compose::add worker=harness worker=console worker=provider-llamacpp</span>
-      </div>
-    </div>
     <div className="iii-qs-gap" aria-hidden="true" />
     <div className="iii-qs-comment"># Open your browser to http://localhost:3113</div>
-
   </div>
 </div>
 
-The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init iii-app && cd iii-app`, start `iii compose --up` (it starts and manages the engine), and in a second terminal add `harness`, `console`, and `provider-<name>` in one `iii trigger compose::add worker=harness worker=console worker=provider-<name>` command, then open http://localhost:3113. Export the provider credential in the terminal that runs `iii compose --up` before starting it. Without an llm, add only `console`.
+The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, uncomment its block in `worker-compose.yaml` and set its key in `.env` first. Then start the whole stack with `iii compose --up` and open http://localhost:3113. Without an llm, skip the key and the console still starts.
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -69,20 +69,24 @@ any other provider in `worker-compose.yaml` later.
 </div>
 
   <div className="iii-qs-body">
-    <div className="iii-qs-comment"># Install iii & create a harness project</div>
+    <div className="iii-qs-comment"># Install iii</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>curl -fsSL https://install.iii.dev/iii/main/install.sh | sh</span>
       </div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii project init my-harness --template harness && cd my-harness</span>
-      </div>
     <div className="iii-qs-gap" aria-hidden="true" />
     <div className="iii-qs-slot" data-qs="none">
-      <div className="iii-qs-comment"># No llm needed now. Add a provider key to .env whenever you want agents; the console starts either way.</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii project init my-app && cd my-app</span>
+      </div>
+      <div className="iii-qs-comment"># No llm. The base template starts just the console.</div>
     </div>
     <div className="iii-qs-slot" data-qs="openai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># provider-openai is enabled by default. Set OPENAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -90,6 +94,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="anthropic">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># provider-anthropic is enabled by default. Set ANTHROPIC_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -97,6 +105,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openai-codex">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># No api key. Uses your chatgpt subscription. Sign in with the codex cli so ~/.codex/auth.json exists:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -109,6 +121,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="deepseek">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># Enable provider-deepseek in worker-compose.yaml, then set DEEPSEEK_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -120,6 +136,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="kimi">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># Enable provider-kimi in worker-compose.yaml, then set MOONSHOT_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -131,6 +151,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openrouter">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># Enable provider-openrouter in worker-compose.yaml, then set OPENROUTER_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -142,6 +166,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="xai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># Enable provider-xai in worker-compose.yaml, then set XAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -153,6 +181,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="zai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># Enable provider-zai in worker-compose.yaml, then set ZAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -164,6 +196,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models. Enable the provider in worker-compose.yaml:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -171,6 +207,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="llamacpp">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default. Enable the provider in worker-compose.yaml:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -183,7 +223,7 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># Start the engine and the whole harness stack</div>
+    <div className="iii-qs-comment"># Start the engine and your project</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>{'iii compose --up'}</span>
@@ -197,7 +237,6 @@ any other provider in `worker-compose.yaml` later.
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
     <div className="iii-qs-comment"># Open your browser to http://localhost:3113</div>
-
   </div>
 </div>
 

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -67,20 +67,24 @@ any other provider in `worker-compose.yaml` later.
 </div>
 
   <div className="iii-qs-body">
-    <div className="iii-qs-comment"># Install iii & create a harness project</div>
+    <div className="iii-qs-comment"># Install iii</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>curl -fsSL https://install.iii.dev/iii/main/install.sh | sh</span>
       </div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>iii project init my-harness --template harness && cd my-harness</span>
-      </div>
     <div className="iii-qs-gap" aria-hidden="true" />
     <div className="iii-qs-slot" data-qs="none">
-      <div className="iii-qs-comment"># No llm needed now. Add a provider key to .env whenever you want agents; the console starts either way.</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii project init my-app && cd my-app</span>
+      </div>
+      <div className="iii-qs-comment"># No llm. The base template starts just the console.</div>
     </div>
     <div className="iii-qs-slot" data-qs="openai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># provider-openai is enabled by default. Set OPENAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -88,6 +92,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="anthropic">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># provider-anthropic is enabled by default. Set ANTHROPIC_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -95,6 +103,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openai-codex">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># No api key. Uses your chatgpt subscription. Sign in with the codex cli so ~/.codex/auth.json exists:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -107,6 +119,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="deepseek">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># Enable provider-deepseek in worker-compose.yaml, then set DEEPSEEK_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -118,6 +134,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="kimi">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># Enable provider-kimi in worker-compose.yaml, then set MOONSHOT_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -129,6 +149,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="openrouter">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># Enable provider-openrouter in worker-compose.yaml, then set OPENROUTER_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -140,6 +164,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="xai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># Enable provider-xai in worker-compose.yaml, then set XAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -151,6 +179,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="zai">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># Enable provider-zai in worker-compose.yaml, then set ZAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -162,6 +194,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models. Enable the provider in worker-compose.yaml:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -169,6 +205,10 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-slot" data-qs="llamacpp">
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
+      </div>
       <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default. Enable the provider in worker-compose.yaml:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -181,7 +221,7 @@ any other provider in `worker-compose.yaml` later.
       </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># Start the engine and the whole harness stack</div>
+    <div className="iii-qs-comment"># Start the engine and your project</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>{'iii compose --up'}</span>
@@ -195,7 +235,6 @@ any other provider in `worker-compose.yaml` later.
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
     <div className="iii-qs-comment"># Open your browser to http://localhost:3113</div>
-
   </div>
 </div>
 


### PR DESCRIPTION
Follow-up to #2117 (harness-template install page, already merged).

## What

- **No-llm → base template.** The `no llm` recipe now scaffolds `iii project init my-app` (no `-t`) instead of the harness template, so it does not pull the agent stack.
- **`--` no longer renders as an em dash.** Mintlify smart typography turns `--` into `—` in the terminal spans. Every command span with a `--flag` (`--template`, `--up`, `--api-key`) is wrapped in a JSX string expression (`{'...'}`) so it renders verbatim. `iii project init` moves into each provider slot to make room for the per-provider init.
- **Brought forward to `docs/`.** The released `docs/install.mdx` gets the same harness-template recipe as `docs/next`; both `.skill.md` regenerated/mirrored.
- **AGENTS.md** gains a "Docs (Mintlify/MDX)" section documenting the `--` gotcha, the Vale em-dash/"out of the box" bans, and `iii-skill-render`.

## Test plan

- `pnpm dev` in `docs/` renders `/install` and `/next/install` with no MDX parse errors; the `--flag` spans show literal double hyphens; the `no llm` pill shows `iii project init my-app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)