### PR TITLE
docs(upgrading): add a coding-agent prompt for the Compose migration

### DIFF
--- a/docs/next/upgrading/workers-to-compose.mdx
+++ b/docs/next/upgrading/workers-to-compose.mdx
@@ -24,7 +24,7 @@ Migrate this iii project from config.yaml worker declarations to worker-compose.
 
 Before changing anything:
 1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/, preserving each source's relative path so two files with the same name never collide, and stop if a destination already exists. Do not delete the originals.
-2. Work out whether the engine will be managed by Compose or supervised separately (systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
+2. Make sure this project is not already supervised separately (ex. systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
 
 Write worker-compose.yaml:
 - Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into the engine.workers map. The map value is the worker config itself; drop the old nested config: key. Multiple instances use a #instance suffix.

--- a/docs/next/upgrading/workers-to-compose.mdx
+++ b/docs/next/upgrading/workers-to-compose.mdx
@@ -13,6 +13,61 @@ A managed project now has one `worker-compose.yaml`. Its `engine:` section confi
 `containers:` declares project workers. If a direct `config.yaml` still declares a project worker,
 startup and reload stop with `UNSUPPORTED_CONFIG_WORKERS` and list every entry to migrate.
 
+## Hand the migration to a coding agent
+
+The steps below are mechanical, so a coding agent with shell access to the project can carry them
+out. Copy this prompt into the agent, then review the resulting `worker-compose.yaml` before
+starting it.
+
+```text Prompt
+Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23).
+Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
+
+Before changing anything:
+1. Locate every config.yaml (including any path passed with --config), any existing
+   worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by
+   default), and the state, queue, and stream data paths. Copy all of them into
+   ./backup-pre-compose/ and do not delete the originals.
+2. Work out whether the engine will be managed by Compose or supervised separately (systemd,
+   Kubernetes). If the repository does not make this clear, ask me before writing the file.
+
+Write worker-compose.yaml:
+- Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into
+  the engine.workers map. The map value is the worker config itself; drop the old nested config:
+  key. Multiple instances use a #instance suffix.
+- Do not declare iii-engine-functions, iii-telemetry, or iii-observability. The engine injects
+  them.
+- Move every other worker under containers:. Rename it per the table on the page (iii-state or
+  state becomes state, iii-http or http becomes http, and so on). Registry workers use
+  package://api.workers.iii.dev/<name> with an explicit version; local workers use path://. Copy
+  each old config: value to config_override and keep every storage path unchanged.
+- Translate iii-exec commands into scripts.pre_run, scripts.run, and scripts.post_run.
+- Pin versions from iii.lock or the registry. Never invent a version number.
+- For a separately supervised engine, keep only the five engine-owned workers in the list-shaped
+  config.yaml and omit engine: from the Compose file.
+
+Stored configuration: for every worker whose configuration id changed (for example iii-state to
+state), read the old value with configuration::get, put it under config_override or write it to
+the new id with configuration::set, and verify the new worker before removing the old entry. Do
+not rename YAML files as a shortcut.
+
+Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
+
+Finish by running these and showing me the output:
+  iii compose --namespace dev --up --file worker-compose.yaml
+  (or the --engine ws://... form for a separately supervised engine)
+  iii trigger -n dev compose::status file=worker-compose.yaml
+  iii trigger engine::workers::list
+  iii trigger engine::triggers::list
+
+If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER,
+ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the
+cause and rerun. Do not work around an error by deleting a worker.
+
+Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored
+configuration ids you migrated, and anything you could not migrate.
+```
+
 ## Back up the project
 
 Keep a copy of:

--- a/docs/next/upgrading/workers-to-compose.mdx
+++ b/docs/next/upgrading/workers-to-compose.mdx
@@ -19,37 +19,22 @@ The steps below are mechanical, so a coding agent with shell access to the proje
 out. Copy this prompt into the agent, then review the resulting `worker-compose.yaml` before
 starting it.
 
-```text Prompt
-Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23).
-Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
+```text Prompt wrap
+Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23). Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
 
 Before changing anything:
-1. Locate every config.yaml (including any path passed with --config), any existing
-   worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by
-   default), and the state, queue, and stream data paths. Copy all of them into
-   ./backup-pre-compose/ and do not delete the originals.
-2. Work out whether the engine will be managed by Compose or supervised separately (systemd,
-   Kubernetes). If the repository does not make this clear, ask me before writing the file.
+1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/ and do not delete the originals.
+2. Work out whether the engine will be managed by Compose or supervised separately (systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
 
 Write worker-compose.yaml:
-- Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into
-  the engine.workers map. The map value is the worker config itself; drop the old nested config:
-  key. Multiple instances use a #instance suffix.
-- Do not declare iii-engine-functions, iii-telemetry, or iii-observability. The engine injects
-  them.
-- Move every other worker under containers:. Rename it per the table on the page (iii-state or
-  state becomes state, iii-http or http becomes http, and so on). Registry workers use
-  package://api.workers.iii.dev/<name> with an explicit version; local workers use path://. Copy
-  each old config: value to config_override and keep every storage path unchanged.
+- Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into the engine.workers map. The map value is the worker config itself; drop the old nested config: key. Multiple instances use a #instance suffix.
+- Do not declare iii-engine-functions, iii-telemetry, or iii-observability. The engine injects them.
+- Move every other worker under containers:. Rename it per the table on the page (iii-state or state becomes state, iii-http or http becomes http, and so on). Registry workers use package://api.workers.iii.dev/<name> with an explicit version; local workers use path://. Copy each old config: value to config_override and keep every storage path unchanged.
 - Translate iii-exec commands into scripts.pre_run, scripts.run, and scripts.post_run.
 - Pin versions from iii.lock or the registry. Never invent a version number.
-- For a separately supervised engine, keep only the five engine-owned workers in the list-shaped
-  config.yaml and omit engine: from the Compose file.
+- For a separately supervised engine, keep only the five engine-owned workers in the list-shaped config.yaml and omit engine: from the Compose file.
 
-Stored configuration: for every worker whose configuration id changed (for example iii-state to
-state), read the old value with configuration::get, put it under config_override or write it to
-the new id with configuration::set, and verify the new worker before removing the old entry. Do
-not rename YAML files as a shortcut.
+Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
 Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
@@ -60,12 +45,9 @@ Finish by running these and showing me the output:
   iii trigger engine::workers::list
   iii trigger engine::triggers::list
 
-If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER,
-ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the
-cause and rerun. Do not work around an error by deleting a worker.
+If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER, ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the cause and rerun. Do not work around an error by deleting a worker.
 
-Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored
-configuration ids you migrated, and anything you could not migrate.
+Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored configuration ids you migrated, and anything you could not migrate.
 ```
 
 ## Back up the project

--- a/docs/next/upgrading/workers-to-compose.mdx
+++ b/docs/next/upgrading/workers-to-compose.mdx
@@ -40,7 +40,7 @@ Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
 Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
-  (for a separately supervised engine: start the engine with iii --config config.yaml under its own supervisor, then iii compose --namespace dev --engine ws://127.0.0.1:49134 --up --file worker-compose.yaml)
+  (for a separately supervised engine: start the engine with iii --config config.yaml under its own supervisor, then iii compose --namespace dev --engine <that engine's ws:// URL> --up --file worker-compose.yaml)
 
 With the daemon running, show me the output of:
   iii trigger -n dev compose::status file=worker-compose.yaml

--- a/docs/next/upgrading/workers-to-compose.mdx
+++ b/docs/next/upgrading/workers-to-compose.mdx
@@ -23,7 +23,7 @@ starting it.
 Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23). Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
 
 Before changing anything:
-1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/ and do not delete the originals.
+1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/, preserving each source's relative path so two files with the same name never collide, and stop if a destination already exists. Do not delete the originals.
 2. Work out whether the engine will be managed by Compose or supervised separately (systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
 
 Write worker-compose.yaml:
@@ -34,20 +34,23 @@ Write worker-compose.yaml:
 - Pin versions from iii.lock or the registry. Never invent a version number.
 - For a separately supervised engine, keep only the five engine-owned workers in the list-shaped config.yaml and omit engine: from the Compose file.
 
-Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
+Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get and raw: true so ${VAR} templates are copied as templates rather than expanded values, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
 Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
-Finish by running these and showing me the output:
+Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
-  (or the --engine ws://... form for a separately supervised engine)
+  (for a separately supervised engine: start the engine with iii --config config.yaml under its own supervisor, then iii compose --namespace dev --engine ws://127.0.0.1:49134 --up --file worker-compose.yaml)
+
+With the daemon running, show me the output of:
   iii trigger -n dev compose::status file=worker-compose.yaml
   iii trigger engine::workers::list
   iii trigger engine::triggers::list
+If the engine is not on localhost port 49134, add --address <host> and --port <port> to each iii trigger command.
 
 If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER, ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the cause and rerun. Do not work around an error by deleting a worker.
 
-Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored configuration ids you migrated, and anything you could not migrate.
+Report back: the resolved path and diff of every configuration file you changed, including any passed with --config, the full new worker-compose.yaml, which stored configuration ids you migrated, and anything you could not migrate.
 ```
 
 ## Back up the project

--- a/docs/next/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/next/upgrading/workers-to-compose.mdx.skill.md
@@ -20,7 +20,7 @@ Migrate this iii project from config.yaml worker declarations to worker-compose.
 
 Before changing anything:
 1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/, preserving each source's relative path so two files with the same name never collide, and stop if a destination already exists. Do not delete the originals.
-2. Work out whether the engine will be managed by Compose or supervised separately (systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
+2. Make sure this project is not already supervised separately (ex. systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
 
 Write worker-compose.yaml:
 - Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into the engine.workers map. The map value is the worker config itself; drop the old nested config: key. Multiple instances use a #instance suffix.

--- a/docs/next/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/next/upgrading/workers-to-compose.mdx.skill.md
@@ -15,37 +15,22 @@ The steps below are mechanical, so a coding agent with shell access to the proje
 out. Copy this prompt into the agent, then review the resulting `worker-compose.yaml` before
 starting it.
 
-```text Prompt
-Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23).
-Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
+```text Prompt wrap
+Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23). Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
 
 Before changing anything:
-1. Locate every config.yaml (including any path passed with --config), any existing
-   worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by
-   default), and the state, queue, and stream data paths. Copy all of them into
-   ./backup-pre-compose/ and do not delete the originals.
-2. Work out whether the engine will be managed by Compose or supervised separately (systemd,
-   Kubernetes). If the repository does not make this clear, ask me before writing the file.
+1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/ and do not delete the originals.
+2. Work out whether the engine will be managed by Compose or supervised separately (systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
 
 Write worker-compose.yaml:
-- Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into
-  the engine.workers map. The map value is the worker config itself; drop the old nested config:
-  key. Multiple instances use a #instance suffix.
-- Do not declare iii-engine-functions, iii-telemetry, or iii-observability. The engine injects
-  them.
-- Move every other worker under containers:. Rename it per the table on the page (iii-state or
-  state becomes state, iii-http or http becomes http, and so on). Registry workers use
-  package://api.workers.iii.dev/<name> with an explicit version; local workers use path://. Copy
-  each old config: value to config_override and keep every storage path unchanged.
+- Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into the engine.workers map. The map value is the worker config itself; drop the old nested config: key. Multiple instances use a #instance suffix.
+- Do not declare iii-engine-functions, iii-telemetry, or iii-observability. The engine injects them.
+- Move every other worker under containers:. Rename it per the table on the page (iii-state or state becomes state, iii-http or http becomes http, and so on). Registry workers use package://api.workers.iii.dev/<name> with an explicit version; local workers use path://. Copy each old config: value to config_override and keep every storage path unchanged.
 - Translate iii-exec commands into scripts.pre_run, scripts.run, and scripts.post_run.
 - Pin versions from iii.lock or the registry. Never invent a version number.
-- For a separately supervised engine, keep only the five engine-owned workers in the list-shaped
-  config.yaml and omit engine: from the Compose file.
+- For a separately supervised engine, keep only the five engine-owned workers in the list-shaped config.yaml and omit engine: from the Compose file.
 
-Stored configuration: for every worker whose configuration id changed (for example iii-state to
-state), read the old value with configuration::get, put it under config_override or write it to
-the new id with configuration::set, and verify the new worker before removing the old entry. Do
-not rename YAML files as a shortcut.
+Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
 Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
@@ -56,12 +41,9 @@ Finish by running these and showing me the output:
   iii trigger engine::workers::list
   iii trigger engine::triggers::list
 
-If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER,
-ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the
-cause and rerun. Do not work around an error by deleting a worker.
+If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER, ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the cause and rerun. Do not work around an error by deleting a worker.
 
-Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored
-configuration ids you migrated, and anything you could not migrate.
+Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored configuration ids you migrated, and anything you could not migrate.
 ```
 
 ## Back up the project

--- a/docs/next/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/next/upgrading/workers-to-compose.mdx.skill.md
@@ -36,7 +36,7 @@ Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
 Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
-  (for a separately supervised engine: start the engine with iii --config config.yaml under its own supervisor, then iii compose --namespace dev --engine ws://127.0.0.1:49134 --up --file worker-compose.yaml)
+  (for a separately supervised engine: start the engine with iii --config config.yaml under its own supervisor, then iii compose --namespace dev --engine <that engine's ws:// URL> --up --file worker-compose.yaml)
 
 With the daemon running, show me the output of:
   iii trigger -n dev compose::status file=worker-compose.yaml

--- a/docs/next/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/next/upgrading/workers-to-compose.mdx.skill.md
@@ -9,6 +9,61 @@ A managed project now has one `worker-compose.yaml`. Its `engine:` section confi
 `containers:` declares project workers. If a direct `config.yaml` still declares a project worker,
 startup and reload stop with `UNSUPPORTED_CONFIG_WORKERS` and list every entry to migrate.
 
+## Hand the migration to a coding agent
+
+The steps below are mechanical, so a coding agent with shell access to the project can carry them
+out. Copy this prompt into the agent, then review the resulting `worker-compose.yaml` before
+starting it.
+
+```text Prompt
+Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23).
+Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
+
+Before changing anything:
+1. Locate every config.yaml (including any path passed with --config), any existing
+   worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by
+   default), and the state, queue, and stream data paths. Copy all of them into
+   ./backup-pre-compose/ and do not delete the originals.
+2. Work out whether the engine will be managed by Compose or supervised separately (systemd,
+   Kubernetes). If the repository does not make this clear, ask me before writing the file.
+
+Write worker-compose.yaml:
+- Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into
+  the engine.workers map. The map value is the worker config itself; drop the old nested config:
+  key. Multiple instances use a #instance suffix.
+- Do not declare iii-engine-functions, iii-telemetry, or iii-observability. The engine injects
+  them.
+- Move every other worker under containers:. Rename it per the table on the page (iii-state or
+  state becomes state, iii-http or http becomes http, and so on). Registry workers use
+  package://api.workers.iii.dev/<name> with an explicit version; local workers use path://. Copy
+  each old config: value to config_override and keep every storage path unchanged.
+- Translate iii-exec commands into scripts.pre_run, scripts.run, and scripts.post_run.
+- Pin versions from iii.lock or the registry. Never invent a version number.
+- For a separately supervised engine, keep only the five engine-owned workers in the list-shaped
+  config.yaml and omit engine: from the Compose file.
+
+Stored configuration: for every worker whose configuration id changed (for example iii-state to
+state), read the old value with configuration::get, put it under config_override or write it to
+the new id with configuration::set, and verify the new worker before removing the old entry. Do
+not rename YAML files as a shortcut.
+
+Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
+
+Finish by running these and showing me the output:
+  iii compose --namespace dev --up --file worker-compose.yaml
+  (or the --engine ws://... form for a separately supervised engine)
+  iii trigger -n dev compose::status file=worker-compose.yaml
+  iii trigger engine::workers::list
+  iii trigger engine::triggers::list
+
+If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER,
+ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the
+cause and rerun. Do not work around an error by deleting a worker.
+
+Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored
+configuration ids you migrated, and anything you could not migrate.
+```
+
 ## Back up the project
 
 Keep a copy of:

--- a/docs/next/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/next/upgrading/workers-to-compose.mdx.skill.md
@@ -19,7 +19,7 @@ starting it.
 Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23). Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
 
 Before changing anything:
-1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/ and do not delete the originals.
+1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/, preserving each source's relative path so two files with the same name never collide, and stop if a destination already exists. Do not delete the originals.
 2. Work out whether the engine will be managed by Compose or supervised separately (systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
 
 Write worker-compose.yaml:
@@ -30,20 +30,23 @@ Write worker-compose.yaml:
 - Pin versions from iii.lock or the registry. Never invent a version number.
 - For a separately supervised engine, keep only the five engine-owned workers in the list-shaped config.yaml and omit engine: from the Compose file.
 
-Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
+Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get and raw: true so ${VAR} templates are copied as templates rather than expanded values, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
 Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
-Finish by running these and showing me the output:
+Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
-  (or the --engine ws://... form for a separately supervised engine)
+  (for a separately supervised engine: start the engine with iii --config config.yaml under its own supervisor, then iii compose --namespace dev --engine ws://127.0.0.1:49134 --up --file worker-compose.yaml)
+
+With the daemon running, show me the output of:
   iii trigger -n dev compose::status file=worker-compose.yaml
   iii trigger engine::workers::list
   iii trigger engine::triggers::list
+If the engine is not on localhost port 49134, add --address <host> and --port <port> to each iii trigger command.
 
 If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER, ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the cause and rerun. Do not work around an error by deleting a worker.
 
-Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored configuration ids you migrated, and anything you could not migrate.
+Report back: the resolved path and diff of every configuration file you changed, including any passed with --config, the full new worker-compose.yaml, which stored configuration ids you migrated, and anything you could not migrate.
 ```
 
 ## Back up the project

--- a/docs/upgrading/workers-to-compose.mdx
+++ b/docs/upgrading/workers-to-compose.mdx
@@ -24,7 +24,7 @@ Migrate this iii project from config.yaml worker declarations to worker-compose.
 
 Before changing anything:
 1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/, preserving each source's relative path so two files with the same name never collide, and stop if a destination already exists. Do not delete the originals.
-2. Work out whether the engine will be managed by Compose or supervised separately (systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
+2. Make sure this project is not already supervised separately (ex. systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
 
 Write worker-compose.yaml:
 - Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into the engine.workers map. The map value is the worker config itself; drop the old nested config: key. Multiple instances use a #instance suffix.

--- a/docs/upgrading/workers-to-compose.mdx
+++ b/docs/upgrading/workers-to-compose.mdx
@@ -13,6 +13,61 @@ A managed project now has one `worker-compose.yaml`. Its `engine:` section confi
 `containers:` declares project workers. If a direct `config.yaml` still declares a project worker,
 startup and reload stop with `UNSUPPORTED_CONFIG_WORKERS` and list every entry to migrate.
 
+## Hand the migration to a coding agent
+
+The steps below are mechanical, so a coding agent with shell access to the project can carry them
+out. Copy this prompt into the agent, then review the resulting `worker-compose.yaml` before
+starting it.
+
+```text Prompt
+Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23).
+Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
+
+Before changing anything:
+1. Locate every config.yaml (including any path passed with --config), any existing
+   worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by
+   default), and the state, queue, and stream data paths. Copy all of them into
+   ./backup-pre-compose/ and do not delete the originals.
+2. Work out whether the engine will be managed by Compose or supervised separately (systemd,
+   Kubernetes). If the repository does not make this clear, ask me before writing the file.
+
+Write worker-compose.yaml:
+- Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into
+  the engine.workers map. The map value is the worker config itself; drop the old nested config:
+  key. Multiple instances use a #instance suffix.
+- Do not declare iii-engine-functions, iii-telemetry, or iii-observability. The engine injects
+  them.
+- Move every other worker under containers:. Rename it per the table on the page (iii-state or
+  state becomes state, iii-http or http becomes http, and so on). Registry workers use
+  package://api.workers.iii.dev/<name> with an explicit version; local workers use path://. Copy
+  each old config: value to config_override and keep every storage path unchanged.
+- Translate iii-exec commands into scripts.pre_run, scripts.run, and scripts.post_run.
+- Pin versions from iii.lock or the registry. Never invent a version number.
+- For a separately supervised engine, keep only the five engine-owned workers in the list-shaped
+  config.yaml and omit engine: from the Compose file.
+
+Stored configuration: for every worker whose configuration id changed (for example iii-state to
+state), read the old value with configuration::get, put it under config_override or write it to
+the new id with configuration::set, and verify the new worker before removing the old entry. Do
+not rename YAML files as a shortcut.
+
+Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
+
+Finish by running these and showing me the output:
+  iii compose --namespace dev --up --file worker-compose.yaml
+  (or the --engine ws://... form for a separately supervised engine)
+  iii trigger -n dev compose::status file=worker-compose.yaml
+  iii trigger engine::workers::list
+  iii trigger engine::triggers::list
+
+If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER,
+ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the
+cause and rerun. Do not work around an error by deleting a worker.
+
+Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored
+configuration ids you migrated, and anything you could not migrate.
+```
+
 ## Back up the project
 
 Keep a copy of:

--- a/docs/upgrading/workers-to-compose.mdx
+++ b/docs/upgrading/workers-to-compose.mdx
@@ -19,37 +19,22 @@ The steps below are mechanical, so a coding agent with shell access to the proje
 out. Copy this prompt into the agent, then review the resulting `worker-compose.yaml` before
 starting it.
 
-```text Prompt
-Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23).
-Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
+```text Prompt wrap
+Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23). Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
 
 Before changing anything:
-1. Locate every config.yaml (including any path passed with --config), any existing
-   worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by
-   default), and the state, queue, and stream data paths. Copy all of them into
-   ./backup-pre-compose/ and do not delete the originals.
-2. Work out whether the engine will be managed by Compose or supervised separately (systemd,
-   Kubernetes). If the repository does not make this clear, ask me before writing the file.
+1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/ and do not delete the originals.
+2. Work out whether the engine will be managed by Compose or supervised separately (systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
 
 Write worker-compose.yaml:
-- Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into
-  the engine.workers map. The map value is the worker config itself; drop the old nested config:
-  key. Multiple instances use a #instance suffix.
-- Do not declare iii-engine-functions, iii-telemetry, or iii-observability. The engine injects
-  them.
-- Move every other worker under containers:. Rename it per the table on the page (iii-state or
-  state becomes state, iii-http or http becomes http, and so on). Registry workers use
-  package://api.workers.iii.dev/<name> with an explicit version; local workers use path://. Copy
-  each old config: value to config_override and keep every storage path unchanged.
+- Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into the engine.workers map. The map value is the worker config itself; drop the old nested config: key. Multiple instances use a #instance suffix.
+- Do not declare iii-engine-functions, iii-telemetry, or iii-observability. The engine injects them.
+- Move every other worker under containers:. Rename it per the table on the page (iii-state or state becomes state, iii-http or http becomes http, and so on). Registry workers use package://api.workers.iii.dev/<name> with an explicit version; local workers use path://. Copy each old config: value to config_override and keep every storage path unchanged.
 - Translate iii-exec commands into scripts.pre_run, scripts.run, and scripts.post_run.
 - Pin versions from iii.lock or the registry. Never invent a version number.
-- For a separately supervised engine, keep only the five engine-owned workers in the list-shaped
-  config.yaml and omit engine: from the Compose file.
+- For a separately supervised engine, keep only the five engine-owned workers in the list-shaped config.yaml and omit engine: from the Compose file.
 
-Stored configuration: for every worker whose configuration id changed (for example iii-state to
-state), read the old value with configuration::get, put it under config_override or write it to
-the new id with configuration::set, and verify the new worker before removing the old entry. Do
-not rename YAML files as a shortcut.
+Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
 Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
@@ -60,12 +45,9 @@ Finish by running these and showing me the output:
   iii trigger engine::workers::list
   iii trigger engine::triggers::list
 
-If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER,
-ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the
-cause and rerun. Do not work around an error by deleting a worker.
+If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER, ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the cause and rerun. Do not work around an error by deleting a worker.
 
-Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored
-configuration ids you migrated, and anything you could not migrate.
+Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored configuration ids you migrated, and anything you could not migrate.
 ```
 
 ## Back up the project

--- a/docs/upgrading/workers-to-compose.mdx
+++ b/docs/upgrading/workers-to-compose.mdx
@@ -40,7 +40,7 @@ Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
 Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
-  (for a separately supervised engine: start the engine with iii --config config.yaml under its own supervisor, then iii compose --namespace dev --engine ws://127.0.0.1:49134 --up --file worker-compose.yaml)
+  (for a separately supervised engine: start the engine with iii --config config.yaml under its own supervisor, then iii compose --namespace dev --engine <that engine's ws:// URL> --up --file worker-compose.yaml)
 
 With the daemon running, show me the output of:
   iii trigger -n dev compose::status file=worker-compose.yaml

--- a/docs/upgrading/workers-to-compose.mdx
+++ b/docs/upgrading/workers-to-compose.mdx
@@ -23,7 +23,7 @@ starting it.
 Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23). Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
 
 Before changing anything:
-1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/ and do not delete the originals.
+1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/, preserving each source's relative path so two files with the same name never collide, and stop if a destination already exists. Do not delete the originals.
 2. Work out whether the engine will be managed by Compose or supervised separately (systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
 
 Write worker-compose.yaml:
@@ -34,20 +34,23 @@ Write worker-compose.yaml:
 - Pin versions from iii.lock or the registry. Never invent a version number.
 - For a separately supervised engine, keep only the five engine-owned workers in the list-shaped config.yaml and omit engine: from the Compose file.
 
-Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
+Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get and raw: true so ${VAR} templates are copied as templates rather than expanded values, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
 Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
-Finish by running these and showing me the output:
+Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
-  (or the --engine ws://... form for a separately supervised engine)
+  (for a separately supervised engine: start the engine with iii --config config.yaml under its own supervisor, then iii compose --namespace dev --engine ws://127.0.0.1:49134 --up --file worker-compose.yaml)
+
+With the daemon running, show me the output of:
   iii trigger -n dev compose::status file=worker-compose.yaml
   iii trigger engine::workers::list
   iii trigger engine::triggers::list
+If the engine is not on localhost port 49134, add --address <host> and --port <port> to each iii trigger command.
 
 If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER, ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the cause and rerun. Do not work around an error by deleting a worker.
 
-Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored configuration ids you migrated, and anything you could not migrate.
+Report back: the resolved path and diff of every configuration file you changed, including any passed with --config, the full new worker-compose.yaml, which stored configuration ids you migrated, and anything you could not migrate.
 ```
 
 ## Back up the project

--- a/docs/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/upgrading/workers-to-compose.mdx.skill.md
@@ -20,7 +20,7 @@ Migrate this iii project from config.yaml worker declarations to worker-compose.
 
 Before changing anything:
 1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/, preserving each source's relative path so two files with the same name never collide, and stop if a destination already exists. Do not delete the originals.
-2. Work out whether the engine will be managed by Compose or supervised separately (systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
+2. Make sure this project is not already supervised separately (ex. systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
 
 Write worker-compose.yaml:
 - Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into the engine.workers map. The map value is the worker config itself; drop the old nested config: key. Multiple instances use a #instance suffix.

--- a/docs/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/upgrading/workers-to-compose.mdx.skill.md
@@ -15,37 +15,22 @@ The steps below are mechanical, so a coding agent with shell access to the proje
 out. Copy this prompt into the agent, then review the resulting `worker-compose.yaml` before
 starting it.
 
-```text Prompt
-Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23).
-Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
+```text Prompt wrap
+Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23). Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
 
 Before changing anything:
-1. Locate every config.yaml (including any path passed with --config), any existing
-   worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by
-   default), and the state, queue, and stream data paths. Copy all of them into
-   ./backup-pre-compose/ and do not delete the originals.
-2. Work out whether the engine will be managed by Compose or supervised separately (systemd,
-   Kubernetes). If the repository does not make this clear, ask me before writing the file.
+1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/ and do not delete the originals.
+2. Work out whether the engine will be managed by Compose or supervised separately (systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
 
 Write worker-compose.yaml:
-- Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into
-  the engine.workers map. The map value is the worker config itself; drop the old nested config:
-  key. Multiple instances use a #instance suffix.
-- Do not declare iii-engine-functions, iii-telemetry, or iii-observability. The engine injects
-  them.
-- Move every other worker under containers:. Rename it per the table on the page (iii-state or
-  state becomes state, iii-http or http becomes http, and so on). Registry workers use
-  package://api.workers.iii.dev/<name> with an explicit version; local workers use path://. Copy
-  each old config: value to config_override and keep every storage path unchanged.
+- Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into the engine.workers map. The map value is the worker config itself; drop the old nested config: key. Multiple instances use a #instance suffix.
+- Do not declare iii-engine-functions, iii-telemetry, or iii-observability. The engine injects them.
+- Move every other worker under containers:. Rename it per the table on the page (iii-state or state becomes state, iii-http or http becomes http, and so on). Registry workers use package://api.workers.iii.dev/<name> with an explicit version; local workers use path://. Copy each old config: value to config_override and keep every storage path unchanged.
 - Translate iii-exec commands into scripts.pre_run, scripts.run, and scripts.post_run.
 - Pin versions from iii.lock or the registry. Never invent a version number.
-- For a separately supervised engine, keep only the five engine-owned workers in the list-shaped
-  config.yaml and omit engine: from the Compose file.
+- For a separately supervised engine, keep only the five engine-owned workers in the list-shaped config.yaml and omit engine: from the Compose file.
 
-Stored configuration: for every worker whose configuration id changed (for example iii-state to
-state), read the old value with configuration::get, put it under config_override or write it to
-the new id with configuration::set, and verify the new worker before removing the old entry. Do
-not rename YAML files as a shortcut.
+Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
 Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
@@ -56,12 +41,9 @@ Finish by running these and showing me the output:
   iii trigger engine::workers::list
   iii trigger engine::triggers::list
 
-If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER,
-ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the
-cause and rerun. Do not work around an error by deleting a worker.
+If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER, ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the cause and rerun. Do not work around an error by deleting a worker.
 
-Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored
-configuration ids you migrated, and anything you could not migrate.
+Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored configuration ids you migrated, and anything you could not migrate.
 ```
 
 ## Back up the project

--- a/docs/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/upgrading/workers-to-compose.mdx.skill.md
@@ -36,7 +36,7 @@ Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
 Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
-  (for a separately supervised engine: start the engine with iii --config config.yaml under its own supervisor, then iii compose --namespace dev --engine ws://127.0.0.1:49134 --up --file worker-compose.yaml)
+  (for a separately supervised engine: start the engine with iii --config config.yaml under its own supervisor, then iii compose --namespace dev --engine <that engine's ws:// URL> --up --file worker-compose.yaml)
 
 With the daemon running, show me the output of:
   iii trigger -n dev compose::status file=worker-compose.yaml

--- a/docs/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/upgrading/workers-to-compose.mdx.skill.md
@@ -9,6 +9,61 @@ A managed project now has one `worker-compose.yaml`. Its `engine:` section confi
 `containers:` declares project workers. If a direct `config.yaml` still declares a project worker,
 startup and reload stop with `UNSUPPORTED_CONFIG_WORKERS` and list every entry to migrate.
 
+## Hand the migration to a coding agent
+
+The steps below are mechanical, so a coding agent with shell access to the project can carry them
+out. Copy this prompt into the agent, then review the resulting `worker-compose.yaml` before
+starting it.
+
+```text Prompt
+Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23).
+Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
+
+Before changing anything:
+1. Locate every config.yaml (including any path passed with --config), any existing
+   worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by
+   default), and the state, queue, and stream data paths. Copy all of them into
+   ./backup-pre-compose/ and do not delete the originals.
+2. Work out whether the engine will be managed by Compose or supervised separately (systemd,
+   Kubernetes). If the repository does not make this clear, ask me before writing the file.
+
+Write worker-compose.yaml:
+- Move configuration, iii-worker-manager, iii-http-functions, iii-stream, and iii-sandbox into
+  the engine.workers map. The map value is the worker config itself; drop the old nested config:
+  key. Multiple instances use a #instance suffix.
+- Do not declare iii-engine-functions, iii-telemetry, or iii-observability. The engine injects
+  them.
+- Move every other worker under containers:. Rename it per the table on the page (iii-state or
+  state becomes state, iii-http or http becomes http, and so on). Registry workers use
+  package://api.workers.iii.dev/<name> with an explicit version; local workers use path://. Copy
+  each old config: value to config_override and keep every storage path unchanged.
+- Translate iii-exec commands into scripts.pre_run, scripts.run, and scripts.post_run.
+- Pin versions from iii.lock or the registry. Never invent a version number.
+- For a separately supervised engine, keep only the five engine-owned workers in the list-shaped
+  config.yaml and omit engine: from the Compose file.
+
+Stored configuration: for every worker whose configuration id changed (for example iii-state to
+state), read the old value with configuration::get, put it under config_override or write it to
+the new id with configuration::set, and verify the new worker before removing the old entry. Do
+not rename YAML files as a shortcut.
+
+Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
+
+Finish by running these and showing me the output:
+  iii compose --namespace dev --up --file worker-compose.yaml
+  (or the --engine ws://... form for a separately supervised engine)
+  iii trigger -n dev compose::status file=worker-compose.yaml
+  iii trigger engine::workers::list
+  iii trigger engine::triggers::list
+
+If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER,
+ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the
+cause and rerun. Do not work around an error by deleting a worker.
+
+Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored
+configuration ids you migrated, and anything you could not migrate.
+```
+
 ## Back up the project
 
 Keep a copy of:

--- a/docs/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/upgrading/workers-to-compose.mdx.skill.md
@@ -19,7 +19,7 @@ starting it.
 Migrate this iii project from config.yaml worker declarations to worker-compose.yaml (iii 0.23). Read https://iii.dev/docs/upgrading/workers-to-compose.md first and follow it exactly.
 
 Before changing anything:
-1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/ and do not delete the originals.
+1. Locate every config.yaml (including any path passed with --config), any existing worker-compose.yaml, iii.lock, the configuration worker's storage directory (./config by default), and the state, queue, and stream data paths. Copy all of them into ./backup-pre-compose/, preserving each source's relative path so two files with the same name never collide, and stop if a destination already exists. Do not delete the originals.
 2. Work out whether the engine will be managed by Compose or supervised separately (systemd, Kubernetes). If the repository does not make this clear, ask me before writing the file.
 
 Write worker-compose.yaml:
@@ -30,20 +30,23 @@ Write worker-compose.yaml:
 - Pin versions from iii.lock or the registry. Never invent a version number.
 - For a separately supervised engine, keep only the five engine-owned workers in the list-shaped config.yaml and omit engine: from the Compose file.
 
-Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
+Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get and raw: true so ${VAR} templates are copied as templates rather than expanded values, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
 Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
-Finish by running these and showing me the output:
+Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
-  (or the --engine ws://... form for a separately supervised engine)
+  (for a separately supervised engine: start the engine with iii --config config.yaml under its own supervisor, then iii compose --namespace dev --engine ws://127.0.0.1:49134 --up --file worker-compose.yaml)
+
+With the daemon running, show me the output of:
   iii trigger -n dev compose::status file=worker-compose.yaml
   iii trigger engine::workers::list
   iii trigger engine::triggers::list
+If the engine is not on localhost port 49134, add --address <host> and --port <port> to each iii trigger command.
 
 If startup reports UNSUPPORTED_CONFIG_WORKERS, UNSUPPORTED_ENGINE_WORKER, ENGINE_WORKER_IS_INJECTED, or any other error from the Common errors list on the page, fix the cause and rerun. Do not work around an error by deleting a worker.
 
-Report back: the diff of config.yaml, the full new worker-compose.yaml, which stored configuration ids you migrated, and anything you could not migrate.
+Report back: the resolved path and diff of every configuration file you changed, including any passed with --config, the full new worker-compose.yaml, which stored configuration ids you migrated, and anything you could not migrate.
 ```
 
 ## Back up the project


### PR DESCRIPTION
## What

Adds a "Hand the migration to a coding agent" section near the top of `upgrading/workers-to-compose`, with a copyable prompt a reader can paste into Claude Code, Codex, Cursor, or any agent with shell access to their project.

The prompt tells the agent to read the page, back up `config.yaml`, storage directories, and `iii.lock`, ask whether the engine is Compose-managed or supervised separately, build `engine.workers` and `containers:` per the page's rules, pin versions from `iii.lock` or the registry instead of inventing them, migrate stored configuration ids with `configuration::get` and `configuration::set`, leave the generated `engine-config.yaml` alone, and finish with the same `compose::status`, `engine::workers::list`, and `engine::triggers::list` checks the page already recommends.

Applied to `docs/next/upgrading/workers-to-compose.mdx` (source), its `.skill.md` artifact regenerated with `iii-skill-render`, and both brought forward by hand to the `docs/upgrading/` 0.23.x copy as AGENTS.md describes.

## Why

The migration is manual and breaking with no automatic migrator, and every step is a mechanical transform of one YAML shape into another. Readers will hand it to an agent regardless. The site's "Copy page" menu gives the agent the reference but not the task: what to back up, what not to guess, which engine mode applies, and how to verify. A task prompt carries those guardrails.

## Notes

- Prose only, no code or config changes.
- The code block uses the `wrap` option with one logical line per paragraph or list item, so the browser wraps it to the content column and a copy yields clean unwrapped text. Hard-wrapping at 100 columns clipped at about 55 characters in the preview and forced horizontal scrolling.
- Uses the `dev` namespace to stay consistent with the commands already on the page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the worker-to-Compose migration guide with a copy-paste coding-agent workflow for backups, configuration migration, startup, verification, and reporting.
  - Added safer collision-free backups that preserve relative paths and stop when destinations already exist.
  - Preserved `${VAR}` templates during configuration reads.
  - Clarified foreground Compose startup, separately supervised engine execution, and custom trigger addresses and ports.
  - Expanded reporting requirements to include resolved paths and diffs for changed configuration files.
  - Updated the corresponding coding-agent skill guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->