### PR TITLE
docs(install): add providers with compose::add, not worker-compose edits

### DIFF
--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -13,8 +13,8 @@ The recipe below installs the engine, creates a project from the harness templat
 Select your llm provider, or select **no llm**. The harness project ships
 [console](./using-iii/console), the browser ui for your running system, and the
 [harness](https://workers.iii.dev/workers/harness) worker for agentic development and running agents
-inside your iii system. `provider-openai` and `provider-anthropic` are enabled by default; enable
-any other provider in `worker-compose.yaml` later.
+inside your iii system. `provider-openai` and `provider-anthropic` are enabled by default; add
+any other provider with `iii trigger compose::add` once the project is running.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-none" defaultChecked />
@@ -114,22 +114,13 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>codex login</span>
       </div>
-      <div className="iii-qs-comment"># Enable the provider in worker-compose.yaml:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
     </div>
     <div className="iii-qs-slot" data-qs="deepseek">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-deepseek in worker-compose.yaml, then set DEEPSEEK_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set DEEPSEEK_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -140,11 +131,7 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-kimi in worker-compose.yaml, then set MOONSHOT_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set MOONSHOT_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -155,11 +142,7 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-openrouter in worker-compose.yaml, then set OPENROUTER_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set OPENROUTER_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -170,11 +153,7 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-xai in worker-compose.yaml, then set XAI_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set XAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -185,11 +164,7 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-zai in worker-compose.yaml, then set ZAI_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set ZAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -200,22 +175,14 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models. Enable the provider in worker-compose.yaml:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models.</div>
     </div>
     <div className="iii-qs-slot" data-qs="llamacpp">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default. Enable the provider in worker-compose.yaml:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default.</div>
       <div className="iii-qs-comment">{'# A key is only needed when llama-server runs with --api-key (set LLAMACPP_API_KEY in .env):'}</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -228,11 +195,65 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii compose --up'}</span>
       </div>
+    <div className="iii-qs-slot" data-qs="openai-codex">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-openai-codex</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="deepseek">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-deepseek</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="kimi">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-kimi</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openrouter">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-openrouter</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="xai">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-xai</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="zai">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-zai</span>
+      </div>
+    </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-github-copilot</span>
+      </div>
       <div className="iii-qs-comment"># Sign in once the provider worker is up:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>iii trigger provider::github-copilot::login::start</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="llamacpp">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-llamacpp</span>
       </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
@@ -240,7 +261,7 @@ any other provider in `worker-compose.yaml` later.
   </div>
 </div>
 
-{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, uncomment its block in `worker-compose.yaml` and set its key in `.env` first. Then start the whole stack with `iii compose --up` and open http://localhost:3113. Without an llm, skip the key and the console still starts. */}
+{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, set its key in `.env` first, then start the whole stack with `iii compose --up` and add the provider with `iii trigger compose::add worker=provider-<name>`. Open http://localhost:3113. Without an llm, skip the key and the console still starts. */}
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -9,7 +9,8 @@ type: "how-to"
 
 ## Start a project
 
-The recipe below installs the engine, creates a project from the harness template, and starts it.
+The recipe below installs the engine, creates a project from our templates, and starts it. Once
+started you can explore the project via https://127.0.0.1:3113.
 Select your llm provider, or select **no llm**.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
@@ -253,11 +254,11 @@ Select your llm provider, or select **no llm**.
       </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># Open your browser to http://localhost:3113</div>
+    <div className="iii-qs-comment"># Open your browser to http://127.0.0.1:3113</div>
   </div>
 </div>
 
-{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, set its key in `.env` first, then start the whole stack with `iii compose --up` and add the provider with `iii trigger compose::add worker=provider-<name>`. Open http://localhost:3113. Without an llm, skip the key and the console still starts. */}
+{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, set its key in `.env` first, then start the whole stack with `iii compose --up` and add the provider with `iii trigger compose::add worker=provider-<name>`. Open http://127.0.0.1:3113. Without an llm, skip the key and the console still starts. */}
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -10,11 +10,7 @@ type: "how-to"
 ## Start a project
 
 The recipe below installs the engine, creates a project from the harness template, and starts it.
-Select your llm provider, or select **no llm**. The harness project ships
-[console](./using-iii/console), the browser ui for your running system, and the
-[harness](https://workers.iii.dev/workers/harness) worker for agentic development and running agents
-inside your iii system. `provider-openai` and `provider-anthropic` are enabled by default; add
-any other provider with `iii trigger compose::add` once the project is running.
+Select your llm provider, or select **no llm**.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-none" defaultChecked />

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -80,7 +80,7 @@ any other provider with `iii trigger compose::add` once the project is running.
         <span className="iii-qs-prompt">$</span>
         <span>iii project init my-app && cd my-app</span>
       </div>
-      <div className="iii-qs-comment"># No llm. The base template starts just the console.</div>
+      <div className="iii-qs-comment"># No llm. The base template starts only the console.</div>
     </div>
     <div className="iii-qs-slot" data-qs="openai">
       <div className="iii-qs-cmd">

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -11,6 +11,7 @@ type: "how-to"
 
 The recipe below installs the engine, creates a project from our templates, and starts it. Once
 started you can explore the project via https://127.0.0.1:3113.
+
 Select your llm provider, or select **no llm**.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
@@ -27,7 +28,6 @@ Select your llm provider, or select **no llm**.
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-llamacpp" />
 
 <div className="iii-qs-head">
-  <span className="iii-qs-title">select your llm provider</span>
   <div className="iii-qs-picker">
     <label className="iii-qs-pill" htmlFor="qs-none">
       no llm

--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -13,8 +13,8 @@ The recipe below installs the engine, creates a project from the harness templat
 Select your llm provider, or select **no llm**. The harness project ships
 [console](./using-iii/console), the browser ui for your running system, and the
 [harness](https://workers.iii.dev/workers/harness) worker for agentic development and running agents
-inside your iii system. `provider-openai` and `provider-anthropic` are enabled by default; enable
-any other provider in `worker-compose.yaml` later.
+inside your iii system. `provider-openai` and `provider-anthropic` are enabled by default; add
+any other provider with `iii trigger compose::add` once the project is running.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-none" defaultChecked />
@@ -114,22 +114,13 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>codex login</span>
       </div>
-      <div className="iii-qs-comment"># Enable the provider in worker-compose.yaml:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
     </div>
     <div className="iii-qs-slot" data-qs="deepseek">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-deepseek in worker-compose.yaml, then set DEEPSEEK_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set DEEPSEEK_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -140,11 +131,7 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-kimi in worker-compose.yaml, then set MOONSHOT_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set MOONSHOT_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -155,11 +142,7 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-openrouter in worker-compose.yaml, then set OPENROUTER_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set OPENROUTER_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -170,11 +153,7 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-xai in worker-compose.yaml, then set XAI_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set XAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -185,11 +164,7 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-zai in worker-compose.yaml, then set ZAI_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set ZAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -200,22 +175,14 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models. Enable the provider in worker-compose.yaml:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models.</div>
     </div>
     <div className="iii-qs-slot" data-qs="llamacpp">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default. Enable the provider in worker-compose.yaml:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default.</div>
       <div className="iii-qs-comment">{'# A key is only needed when llama-server runs with --api-key (set LLAMACPP_API_KEY in .env):'}</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -228,11 +195,65 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii compose --up'}</span>
       </div>
+    <div className="iii-qs-slot" data-qs="openai-codex">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-openai-codex</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="deepseek">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-deepseek</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="kimi">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-kimi</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openrouter">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-openrouter</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="xai">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-xai</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="zai">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-zai</span>
+      </div>
+    </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-github-copilot</span>
+      </div>
       <div className="iii-qs-comment"># Sign in once the provider worker is up:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>iii trigger provider::github-copilot::login::start</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="llamacpp">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-llamacpp</span>
       </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
@@ -240,7 +261,7 @@ any other provider in `worker-compose.yaml` later.
   </div>
 </div>
 
-{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, uncomment its block in `worker-compose.yaml` and set its key in `.env` first. Then start the whole stack with `iii compose --up` and open http://localhost:3113. Without an llm, skip the key and the console still starts. */}
+{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, set its key in `.env` first, then start the whole stack with `iii compose --up` and add the provider with `iii trigger compose::add worker=provider-<name>`. Open http://localhost:3113. Without an llm, skip the key and the console still starts. */}
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -9,7 +9,8 @@ type: "how-to"
 
 ## Start a project
 
-The recipe below installs the engine, creates a project from the harness template, and starts it.
+The recipe below installs the engine, creates a project from our templates, and starts it. Once
+started you can explore the project via https://127.0.0.1:3113.
 Select your llm provider, or select **no llm**.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
@@ -253,11 +254,11 @@ Select your llm provider, or select **no llm**.
       </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># Open your browser to http://localhost:3113</div>
+    <div className="iii-qs-comment"># Open your browser to http://127.0.0.1:3113</div>
   </div>
 </div>
 
-{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, set its key in `.env` first, then start the whole stack with `iii compose --up` and add the provider with `iii trigger compose::add worker=provider-<name>`. Open http://localhost:3113. Without an llm, skip the key and the console still starts. */}
+{/* llm-only: The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, set its key in `.env` first, then start the whole stack with `iii compose --up` and add the provider with `iii trigger compose::add worker=provider-<name>`. Open http://127.0.0.1:3113. Without an llm, skip the key and the console still starts. */}
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -10,11 +10,7 @@ type: "how-to"
 ## Start a project
 
 The recipe below installs the engine, creates a project from the harness template, and starts it.
-Select your llm provider, or select **no llm**. The harness project ships
-[console](./using-iii/console), the browser ui for your running system, and the
-[harness](https://workers.iii.dev/workers/harness) worker for agentic development and running agents
-inside your iii system. `provider-openai` and `provider-anthropic` are enabled by default; add
-any other provider with `iii trigger compose::add` once the project is running.
+Select your llm provider, or select **no llm**.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-none" defaultChecked />

--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -80,7 +80,7 @@ any other provider with `iii trigger compose::add` once the project is running.
         <span className="iii-qs-prompt">$</span>
         <span>iii project init my-app && cd my-app</span>
       </div>
-      <div className="iii-qs-comment"># No llm. The base template starts just the console.</div>
+      <div className="iii-qs-comment"># No llm. The base template starts only the console.</div>
     </div>
     <div className="iii-qs-slot" data-qs="openai">
       <div className="iii-qs-cmd">

--- a/docs/next/install.mdx
+++ b/docs/next/install.mdx
@@ -11,6 +11,7 @@ type: "how-to"
 
 The recipe below installs the engine, creates a project from our templates, and starts it. Once
 started you can explore the project via https://127.0.0.1:3113.
+
 Select your llm provider, or select **no llm**.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
@@ -27,7 +28,6 @@ Select your llm provider, or select **no llm**.
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-llamacpp" />
 
 <div className="iii-qs-head">
-  <span className="iii-qs-title">select your llm provider</span>
   <div className="iii-qs-picker">
     <label className="iii-qs-pill" htmlFor="qs-none">
       no llm

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -7,7 +7,8 @@
 
 ## Start a project
 
-The recipe below installs the engine, creates a project from the harness template, and starts it.
+The recipe below installs the engine, creates a project from our templates, and starts it. Once
+started you can explore the project via https://127.0.0.1:3113.
 Select your llm provider, or select **no llm**.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
@@ -251,11 +252,11 @@ Select your llm provider, or select **no llm**.
       </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
-    <div className="iii-qs-comment"># Open your browser to http://localhost:3113</div>
+    <div className="iii-qs-comment"># Open your browser to http://127.0.0.1:3113</div>
   </div>
 </div>
 
-The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, set its key in `.env` first, then start the whole stack with `iii compose --up` and add the provider with `iii trigger compose::add worker=provider-<name>`. Open http://localhost:3113. Without an llm, skip the key and the console still starts.
+The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, set its key in `.env` first, then start the whole stack with `iii compose --up` and add the provider with `iii trigger compose::add worker=provider-<name>`. Open http://127.0.0.1:3113. Without an llm, skip the key and the console still starts.
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -8,11 +8,7 @@
 ## Start a project
 
 The recipe below installs the engine, creates a project from the harness template, and starts it.
-Select your llm provider, or select **no llm**. The harness project ships
-[console](./using-iii/console), the browser ui for your running system, and the
-[harness](https://workers.iii.dev/workers/harness) worker for agentic development and running agents
-inside your iii system. `provider-openai` and `provider-anthropic` are enabled by default; add
-any other provider with `iii trigger compose::add` once the project is running.
+Select your llm provider, or select **no llm**.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-none" defaultChecked />

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -11,8 +11,8 @@ The recipe below installs the engine, creates a project from the harness templat
 Select your llm provider, or select **no llm**. The harness project ships
 [console](./using-iii/console), the browser ui for your running system, and the
 [harness](https://workers.iii.dev/workers/harness) worker for agentic development and running agents
-inside your iii system. `provider-openai` and `provider-anthropic` are enabled by default; enable
-any other provider in `worker-compose.yaml` later.
+inside your iii system. `provider-openai` and `provider-anthropic` are enabled by default; add
+any other provider with `iii trigger compose::add` once the project is running.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-none" defaultChecked />
@@ -112,22 +112,13 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>codex login</span>
       </div>
-      <div className="iii-qs-comment"># Enable the provider in worker-compose.yaml:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
     </div>
     <div className="iii-qs-slot" data-qs="deepseek">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-deepseek in worker-compose.yaml, then set DEEPSEEK_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set DEEPSEEK_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -138,11 +129,7 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-kimi in worker-compose.yaml, then set MOONSHOT_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set MOONSHOT_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -153,11 +140,7 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-openrouter in worker-compose.yaml, then set OPENROUTER_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set OPENROUTER_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -168,11 +151,7 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-xai in worker-compose.yaml, then set XAI_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set XAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -183,11 +162,7 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Enable provider-zai in worker-compose.yaml, then set ZAI_API_KEY in .env:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Set ZAI_API_KEY in .env:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>nano .env</span>
@@ -198,22 +173,14 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models. Enable the provider in worker-compose.yaml:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># No api key. Your github copilot subscription grants the models.</div>
     </div>
     <div className="iii-qs-slot" data-qs="llamacpp">
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>{'iii project init my-harness --template harness && cd my-harness'}</span>
       </div>
-      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default. Enable the provider in worker-compose.yaml:</div>
-      <div className="iii-qs-cmd">
-        <span className="iii-qs-prompt">$</span>
-        <span>nano worker-compose.yaml</span>
-      </div>
+      <div className="iii-qs-comment"># Runs against your own llama-server, http://127.0.0.1:8080 by default.</div>
       <div className="iii-qs-comment">{'# A key is only needed when llama-server runs with --api-key (set LLAMACPP_API_KEY in .env):'}</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
@@ -226,11 +193,65 @@ any other provider in `worker-compose.yaml` later.
         <span className="iii-qs-prompt">$</span>
         <span>{'iii compose --up'}</span>
       </div>
+    <div className="iii-qs-slot" data-qs="openai-codex">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-openai-codex</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="deepseek">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-deepseek</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="kimi">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-kimi</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="openrouter">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-openrouter</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="xai">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-xai</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="zai">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-zai</span>
+      </div>
+    </div>
     <div className="iii-qs-slot" data-qs="github-copilot">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-github-copilot</span>
+      </div>
       <div className="iii-qs-comment"># Sign in once the provider worker is up:</div>
       <div className="iii-qs-cmd">
         <span className="iii-qs-prompt">$</span>
         <span>iii trigger provider::github-copilot::login::start</span>
+      </div>
+    </div>
+    <div className="iii-qs-slot" data-qs="llamacpp">
+      <div className="iii-qs-comment"># Add the provider to your running project:</div>
+      <div className="iii-qs-cmd">
+        <span className="iii-qs-prompt">$</span>
+        <span>iii trigger compose::add worker=provider-llamacpp</span>
       </div>
     </div>
     <div className="iii-qs-gap" aria-hidden="true" />
@@ -238,7 +259,7 @@ any other provider in `worker-compose.yaml` later.
   </div>
 </div>
 
-The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, uncomment its block in `worker-compose.yaml` and set its key in `.env` first. Then start the whole stack with `iii compose --up` and open http://localhost:3113. Without an llm, skip the key and the console still starts.
+The panel above is one recipe with a provider picker. Plain form: install iii, run `iii project init my-harness --template harness && cd my-harness`. The harness template ships console, the harness worker, and provider-openai and provider-anthropic enabled by default. Put your provider key in `.env` (edit with `nano .env`); for any other provider, set its key in `.env` first, then start the whole stack with `iii compose --up` and add the provider with `iii trigger compose::add worker=provider-<name>`. Open http://localhost:3113. Without an llm, skip the key and the console still starts.
 
 {/* TODO: re-enable the "## 3. Install the VS Code Extension (Optional)" section once the iii-lsp extension is more thoroughly tested across VS Code, Cursor, Windsurf, and VSCodium. The Frame demo also needs `/images/lsp.mp4` to be captured and committed before the section is re-added. Before re-enabling, move the capability description (what completions/hover/diagnostics the extension provides) to an overview/explanation page for the extension and link to it from a single-sentence description here. ## 3. Install the VS Code Extension (Optional) The iii Language Server extension adds iii-aware editor support. See the extension overview for details. <Frame> <video autoPlay loop muted playsInline src="/images/lsp.mp4" alt="iii Language Server extension" /> </Frame> Open the Extensions panel and search for `iii-lsp`, or install from the terminal: <Tabs> <Tab title="VS Code"> code --install-extension iii-hq.iii-lsp </Tab> <Tab title="Cursor"> cursor --install-extension iii-hq.iii-lsp </Tab> <Tab title="Windsurf"> windsurf --install-extension iii-hq.iii-lsp </Tab> <Tab title="VSCodium"> codium --install-extension iii-hq.iii-lsp </Tab> </Tabs> */}
 

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -78,7 +78,7 @@ any other provider with `iii trigger compose::add` once the project is running.
         <span className="iii-qs-prompt">$</span>
         <span>iii project init my-app && cd my-app</span>
       </div>
-      <div className="iii-qs-comment"># No llm. The base template starts just the console.</div>
+      <div className="iii-qs-comment"># No llm. The base template starts only the console.</div>
     </div>
     <div className="iii-qs-slot" data-qs="openai">
       <div className="iii-qs-cmd">

--- a/docs/next/install.mdx.skill.md
+++ b/docs/next/install.mdx.skill.md
@@ -9,6 +9,7 @@
 
 The recipe below installs the engine, creates a project from our templates, and starts it. Once
 started you can explore the project via https://127.0.0.1:3113.
+
 Select your llm provider, or select **no llm**.
 
 <div className="iii-qs" role="group" aria-label="quickstart recipe">
@@ -25,7 +26,6 @@ Select your llm provider, or select **no llm**.
   <input className="iii-qs-radio" type="radio" name="iii-qs" id="qs-llamacpp" />
 
 <div className="iii-qs-head">
-  <span className="iii-qs-title">select your llm provider</span>
   <div className="iii-qs-picker">
     <label className="iii-qs-pill" htmlFor="qs-none">
       no llm


### PR DESCRIPTION
## What

Non-default provider tabs on the install page (openai-codex, deepseek, kimi, openrouter, xai, zai, github-copilot, llamacpp) now add the provider worker with `iii trigger compose::add worker=provider-<name>` after `iii compose --up`, instead of telling the reader to hand-edit `worker-compose.yaml`.

`provider-openai` and `provider-anthropic` stay enabled by default (no compose::add). Key setup (`.env`) is unchanged.

## Why

`compose::add` is the one-command way to add a worker to a running project; hand-editing YAML was an extra manual step the engine already automates.

## Slugs

All verified live on workers.iii.dev: `provider-openai-codex`, `provider-deepseek`, `provider-kimi`, `provider-openrouter`, `provider-xai`, `provider-zai`, `provider-github-copilot`, `provider-llamacpp`.

## Scope

Applied to `docs/next/install.mdx` and current `docs/install.mdx` (per request). Rendered `.skill.md` regenerated; `iii-skill-check verify-rendered` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation quickstarts for configuring non-default LLM providers.
  * Provider API keys are now set in `.env` before adding provider workers.
  * Added instructions for adding provider workers to a running project with `iii trigger compose::add`.
  * Removed instructions to edit `worker-compose.yaml` for supported providers.
  * Clarified setup options for projects using no LLM provider.
  * Simplified quickstart wording and updated the local project URL to `http://127.0.0.1:3113`.
  * Added a link for exploring the started project at `https://127.0.0.1:3113`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->