### PR TITLE
docs(quickstart): remove intro video

### DIFF
--- a/docs/next/quickstart.mdx
+++ b/docs/next/quickstart.mdx
@@ -9,15 +9,6 @@ type: "tutorial"
 
 In this tutorial you will learn how iii makes it unreasonably simple to build and extend systems.
 
-<Frame>
-  <video
-    controls
-    playsInline
-    preload="metadata"
-    src="https://assets.motia.dev/videos/mp4/site/v1/iii-intro.mp4"
-  />
-</Frame>
-
 <Tip title="Install iii before proceeding">
   Make sure you have installed iii before proceeding. If you haven't then visit the
   [Install](./install) guide first. There you can also learn how to [set up iii for agentic

--- a/docs/next/quickstart.mdx.skill.md
+++ b/docs/next/quickstart.mdx.skill.md
@@ -5,15 +5,6 @@
 
 In this tutorial you will learn how iii makes it unreasonably simple to build and extend systems.
 
-<Frame>
-  <video
-    controls
-    playsInline
-    preload="metadata"
-    src="https://assets.motia.dev/videos/mp4/site/v1/iii-intro.mp4"
-  />
-</Frame>
-
 <Tip title="Install iii before proceeding">
   Make sure you have installed iii before proceeding. If you haven't then visit the
   [Install](./install) guide first. There you can also learn how to [set up iii for agentic

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -9,15 +9,6 @@ type: "tutorial"
 
 In this tutorial you will learn how iii makes it unreasonably simple to build and extend systems.
 
-<Frame>
-  <video
-    controls
-    playsInline
-    preload="metadata"
-    src="https://assets.motia.dev/videos/mp4/site/v1/iii-intro.mp4"
-  />
-</Frame>
-
 <Tip title="Install iii before proceeding">
   Make sure you have installed iii before proceeding. If you haven't then visit the
   [Install](./install) guide first. There you can also learn how to [set up iii for agentic


### PR DESCRIPTION
Removes the intro `<Frame><video>` block (iii-intro.mp4) from the Quickstart page in both `docs/next/quickstart.mdx` and current `docs/quickstart.mdx`. Rendered `.skill.md` regenerated; `verify-rendered` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the introductory video from the Quickstart tutorial pages.
  * The surrounding Quickstart instructions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->