### PR TITLE
docs(welcome): remove intro video

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -9,15 +9,6 @@ type: "explanation"
 
 {/* <Tip> The tabs above split the site into Docs (start here), Tutorials, How-tos, Patterns, SDK & Engine Reference, and Changelog. Read this page and the Docs tab in order first. The other tabs make more sense once you have the model. </Tip> */}
 
-<Frame>
-  <video
-    controls
-    playsInline
-    preload="metadata"
-    src="https://assets.motia.dev/videos/mp4/site/v1/iii-intro.mp4"
-  />
-</Frame>
-
 ## The Problem
 
 Each service in a modern system arrives with its own internals, its own lifecycle, its own

--- a/docs/next/index.mdx
+++ b/docs/next/index.mdx
@@ -9,15 +9,6 @@ type: "explanation"
 
 {/* <Tip> The tabs above split the site into Docs (start here), Tutorials, How-tos, Patterns, SDK & Engine Reference, and Changelog. Read this page and the Docs tab in order first. The other tabs make more sense once you have the model. </Tip> */}
 
-<Frame>
-  <video
-    controls
-    playsInline
-    preload="metadata"
-    src="https://assets.motia.dev/videos/mp4/site/v1/iii-intro.mp4"
-  />
-</Frame>
-
 ## The Problem
 
 Each service in a modern system arrives with its own internals, its own lifecycle, its own

--- a/docs/next/index.mdx.skill.md
+++ b/docs/next/index.mdx.skill.md
@@ -5,15 +5,6 @@
 
 {/* <Tip> The tabs above split the site into Docs (start here), Tutorials, How-tos, Patterns, SDK & Engine Reference, and Changelog. Read this page and the Docs tab in order first. The other tabs make more sense once you have the model. </Tip> */}
 
-<Frame>
-  <video
-    controls
-    playsInline
-    preload="metadata"
-    src="https://assets.motia.dev/videos/mp4/site/v1/iii-intro.mp4"
-  />
-</Frame>
-
 ## The Problem
 
 Each service in a modern system arrives with its own internals, its own lifecycle, its own


### PR DESCRIPTION
Removes the intro `<Frame><video>` block (iii-intro.mp4) from the Welcome page in both `docs/next/index.mdx` and current `docs/index.mdx`. Rendered `.skill.md` regenerated; `verify-rendered` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the introductory video from the main documentation landing page.
  - Removed the introductory video from the next-version documentation landing page.
  - Both pages now begin directly with the “The Problem” section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->