### PR TITLE
docs(changelog): add 0.23 release notes

### DIFF
--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -5,10 +5,114 @@ owner: "devrel"
 type: "reference"
 ---
 
-<Update label="0.23.0" description="Upcoming">
-  ## Breaking: Compose startup uses `--up`
+<Update label="0.23.0" description="September 2026">
+  ## Breaking: project workers move to Worker Compose
 
-  `iii compose up` is replaced by `iii compose --up`. The positional `up` form is rejected, and `--file` is valid only with `--up`; bare `iii compose` starts the daemon without starting a project. Migrate explicit files to `iii compose --up --file worker-compose.yaml`.
+  iii no longer manages project workers from `config.yaml`. The `iii worker` commands, the `worker::*`
+  functions, the `iii.toml` fallback, and the engine-managed project worker lifecycle are removed. A
+  direct project worker entry in `config.yaml` now stops startup with `UNSUPPORTED_CONFIG_WORKERS`.
+
+  Declare project workers under `containers:` in `worker-compose.yaml`. The `engine.workers` map is
+  only for `configuration`, `iii-worker-manager`, `iii-http-functions`, `iii-stream`, and
+  `iii-sandbox`. The engine adds its internal functions, telemetry, and observability workers
+  automatically. HTTP, cron, queue, state, pubsub, and bridge providers now run as standalone Compose
+  packages.
+
+  Stored provider configuration is not renamed or copied automatically. Preserve each storage path and
+  move prefixed configuration ids, such as `iii-queue`, to the standalone package id, such as `queue`.
+
+  <Callout type="warning">
+    Existing projects must follow [Move workers from config.yaml to
+    Compose](/upgrading/workers-to-compose) before their first 0.23 start.
+  </Callout>
+
+  ## Worker Compose is the project control plane
+
+  The new Compose daemon reads one `worker-compose.yaml`, resolves local and registry workers, starts
+  them in dependency order, and stops them in reverse order. It supplies project namespaces,
+  configuration overrides, environment files, and `pre_run`, `run`, and `post_run` scripts. A failed
+  start rolls back the workers that it started. If a running worker exits, Compose stops its dependent
+  workers and reports the failure.
+
+  Project operations are regular iii functions. The `compose::*` surface can validate, start, stop,
+  inspect, add, remove, restart, and update workers. It also provides bounded, rotating stdout and
+  stderr logs. Mutation calls return concise operation results that show the affected workers.
+
+  `iii compose --up` starts the Compose daemon, its managed engine, and the declared project. Bare
+  `iii compose` starts only the daemon. The old positional `iii compose up` form is rejected, and
+  `--file` is valid only with `--up`. Use `iii compose --up --file worker-compose.yaml` when you
+  specify a file.
+
+  Local workers that declare `runtime.base_image` now run in a VM. Source changes are forwarded into
+  the guest before restart, so the VM runs the current local files. A Compose file can also omit
+  `containers:` or use an empty map when it only owns an engine.
+
+  ## Namespaces isolate workers on a shared engine
+
+  Namespace is now a runtime routing value for functions, workers, trigger providers, and project
+  daemons. The same worker name and function id can exist in several namespaces without a naming
+  convention or an id prefix. This lets several tenants, projects, or agents share one engine.
+
+  Node, browser, Python, Rust, and Go SDKs can set a worker namespace and route a call to a namespace.
+  The CLI adds `--namespace`. Calls without an explicit namespace inherit the caller's namespace;
+  workers that declare no namespace use `default`, which keeps the prior behavior. Calls are strict
+  and do not search another namespace after a miss. SDK calls to `engine::*` continue to target the
+  default namespace.
+
+  Triggers now distinguish the target function namespace from `trigger_namespace`, which selects the
+  trigger type provider. A project-local provider takes priority over the default provider,
+  independent of startup order. Function and worker discovery, ownership conflicts, queue providers,
+  RBAC rules, the Console, and live trace updates are also namespace-aware.
+
+  A registration grace period holds early function and trigger messages until the worker namespace is
+  known. It defaults to 5000 ms and can be changed with `registration_namespace_grace_ms` or
+  `III_NAMESPACE_GRACE_MS`.
+
+  ## Breaking: RabbitMQ durable subscriber queues use the namespace
+
+  RabbitMQ subscriber and dead-letter queue names now include the subscriber namespace. This keeps two
+  namespaced subscribers from consuming from the same durable queue.
+
+  | Version | Subscriber queue                              | Dead-letter queue                           |
+  | ------- | --------------------------------------------- | ------------------------------------------- |
+  | 0.22.x  | `iii.{topic}.{function_id}.queue`             | `iii.{topic}.{function_id}.dlq`             |
+  | 0.23.x  | `iii.{topic}.{function_id}@{namespace}.queue` | `iii.{topic}.{function_id}@{namespace}.dlq` |
+
+  The RabbitMQ adapter does not move messages from the old queue. Stop publishers, drain the old
+  subscriber and dead-letter queues, upgrade, and then remove the old queues. Also review RBAC rules
+  before a worker moves out of `default`: unscoped `expose_functions` and `allowed_functions` grants
+  now apply to `default` only. Custom workers outside `default` cannot register the reserved
+  `engine::*` prefix. See [Upgrade from 0.22.x](/upgrading/from-0-22-x) for the full checklist.
+
+  ## Traces persist and update live
+
+  New observability configurations persist completed spans in a bounded SQLite archive under
+  `./data/observability/traces`. Traces survive an engine restart and remain available after they
+  leave the hot memory cache. The default archive has a 1 GiB disk limit and 30-day retention, and
+  eviction now reclaims database disk space. Existing stored configurations without `trace_storage`
+  keep their previous memory-only behavior.
+
+  Observability settings now have a dedicated Console view for trace storage, sampling, metrics, and
+  logs. The Console trace view reacts to coalesced trace events instead of polling once per second.
+  The event feed refreshes when a pending engine span starts and when its final span replaces it.
+  Namespaced trace providers update the correct Console view.
+
+  **Breaking API change:** `engine::traces::list` now returns one compact summary per trace, including
+  aggregate status, span count, error count, tags, and optional projected attributes. Consumers that
+  need complete span records must use the new `engine::traces::spans` function. Summary filtering and
+  pagination are stable across traces, including data read from the archive.
+
+  ## Additional reliability and telemetry fixes
+
+  - Queue provider registration and routing are scoped by namespace, including providers that register
+    after startup.
+  - Compose supports empty container declarations and gives local base-image workers the correct VM
+    execution path.
+  - The engine aggregates CLI command counts into heartbeat telemetry instead of sending a network
+    event for every command. A project stamp also prevents restarts from sending duplicate heartbeats
+    within the configured interval.
+  - Telemetry sends explicitly configured worker names as readable heartbeat labels. It replaces
+    generated `hostname:pid` names with generic values.
 </Update>
 
 <Update label="0.22.1" description="August 2026">

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -6,114 +6,40 @@ type: "reference"
 ---
 
 <Update label="0.23.0" description="September 2026">
-  ## Breaking: project workers move to Worker Compose
+  ## Worker Compose
 
-  iii no longer manages project workers from `config.yaml`. The `iii worker` commands, the `worker::*`
-  functions, the `iii.toml` fallback, and the engine-managed project worker lifecycle are removed. A
-  direct project worker entry in `config.yaml` now stops startup with `UNSUPPORTED_CONFIG_WORKERS`.
-
-  Declare project workers under `containers:` in `worker-compose.yaml`. The `engine.workers` map is
-  only for `configuration`, `iii-worker-manager`, `iii-http-functions`, `iii-stream`, and
-  `iii-sandbox`. The engine adds its internal functions, telemetry, and observability workers
-  automatically. HTTP, cron, queue, state, pubsub, and bridge providers now run as standalone Compose
-  packages.
-
-  Stored provider configuration is not renamed or copied automatically. Preserve each storage path and
-  move prefixed configuration ids, such as `iii-queue`, to the standalone package id, such as `queue`.
+  - Project workers now run through Compose and are declared in `worker-compose.yaml`.
+  - Compose manages dependency order, lifecycle, configuration, scripts, status, and logs.
+  - The legacy `iii worker`, `worker::*`, and engine-managed project worker lifecycle are removed.
+  - Workers with `runtime.base_image` run in VMs, with source changes forwarded before restart.
 
   <Callout type="warning">
     Existing projects must follow [Move workers from config.yaml to
     Compose](/upgrading/workers-to-compose) before their first 0.23 start.
   </Callout>
 
-  ## Worker Compose is the project control plane
+  ## Namespaces
 
-  The new Compose daemon reads one `worker-compose.yaml`, resolves local and registry workers, starts
-  them in dependency order, and stops them in reverse order. It supplies project namespaces,
-  configuration overrides, environment files, and `pre_run`, `run`, and `post_run` scripts. A failed
-  start rolls back the workers that it started. If a running worker exits, Compose stops its dependent
-  workers and reports the failure.
+  - Namespaces isolate projects, workers, functions, and triggers on a shared engine.
+  - Namespace support is available in the CLI, Console, and Node, browser, Python, Rust, and Go SDKs.
+  - Workers without a namespace continue to use `default`.
+  - RabbitMQ durable subscriptions now use namespace-aware queue names.
 
-  Project operations are regular iii functions. The `compose::*` surface can validate, start, stop,
-  inspect, add, remove, restart, and update workers. It also provides bounded, rotating stdout and
-  stderr logs. Mutation calls return concise operation results that show the affected workers.
+  See [Upgrade from 0.22.x](/upgrading/from-0-22-x) for the queue and authorization migration
+  checklist.
 
-  `iii compose --up` starts the Compose daemon and the declared project. It also starts the managed
-  engine when the Compose file has an `engine:` section and `--engine` does not select an existing
-  engine. Bare `iii compose` starts only the daemon. The old positional `iii compose up` form is
-  rejected, and `--file` is valid only with `--up`. Use
-  `iii compose --up --file worker-compose.yaml` when you specify a file.
+  ## Observability
 
-  Local workers that declare `runtime.base_image` now run in a VM. Source changes are forwarded into
-  the guest before restart, so the VM runs the current local files. A Compose file can also omit
-  `containers:` or use an empty map when it only owns an engine.
+  - Traces can persist across engine restarts.
+  - The Console adds observability configuration and live trace updates.
+  - `engine::traces::list` now returns compact trace summaries. Use `engine::traces::spans` for full
+    span details.
 
-  ## Namespaces isolate workers on a shared engine
+  ## Reliability
 
-  Namespace is now a runtime routing value for functions, workers, trigger providers, and project
-  daemons. The same worker name and function id can exist in several namespaces without a naming
-  convention or an id prefix. This lets several tenants, projects, or agents share one engine.
-
-  Node, browser, Python, Rust, and Go SDKs can set a worker namespace and route a call to a namespace.
-  The CLI adds `--namespace`. Calls without an explicit namespace inherit the caller's namespace;
-  workers that declare no namespace use `default`, which keeps the prior behavior. Calls are strict
-  and do not search another namespace after a miss. SDK calls to `engine::*` continue to target the
-  default namespace.
-
-  Triggers now distinguish the target function namespace from `trigger_namespace`, which selects the
-  trigger type provider. A project-local provider takes priority over the default provider,
-  independent of startup order. Function and worker discovery, ownership conflicts, queue providers,
-  RBAC rules, the Console, and live trace updates are also namespace-aware.
-
-  A registration grace period holds early function and trigger messages until the worker namespace is
-  known. It defaults to 5000 ms and can be changed with `registration_namespace_grace_ms` or
-  `III_NAMESPACE_GRACE_MS`.
-
-  ## Breaking: RabbitMQ durable subscriber queues use the namespace
-
-  RabbitMQ subscriber and dead-letter queue names now include the subscriber namespace. This keeps two
-  namespaced subscribers from consuming from the same durable queue.
-
-  | Version | Subscriber queue                              | Dead-letter queue                           |
-  | ------- | --------------------------------------------- | ------------------------------------------- |
-  | 0.22.x  | `iii.{topic}.{function_id}.queue`             | `iii.{topic}.{function_id}.dlq`             |
-  | 0.23.x  | `iii.{topic}.{function_id}@{namespace}.queue` | `iii.{topic}.{function_id}@{namespace}.dlq` |
-
-  The RabbitMQ adapter does not move messages from the old queue. Stop publishers, drain the old
-  subscriber and dead-letter queues, upgrade, and then remove the old queues. Also review RBAC rules
-  before a worker moves out of `default`: unscoped `expose_functions` and `allowed_functions` grants
-  now apply to `default` only. Custom workers outside `default` cannot register the reserved
-  `engine::*` prefix. See [Upgrade from 0.22.x](/upgrading/from-0-22-x) for the full checklist.
-
-  ## Traces persist and update live
-
-  New observability configurations persist completed spans in a bounded SQLite archive under
-  `./data/observability/traces`. Traces survive an engine restart and remain available after they
-  leave the hot memory cache. The default archive has a 1 GiB disk limit and 30-day retention, and
-  eviction now reclaims database disk space. Existing stored configurations without `trace_storage`
-  keep their previous memory-only behavior.
-
-  Observability settings now have a dedicated Console view for trace storage, sampling, metrics, and
-  logs. The Console trace view reacts to coalesced trace events instead of polling once per second.
-  The event feed refreshes when a pending engine span starts and when its final span replaces it.
-  Namespaced trace providers update the correct Console view.
-
-  **Breaking API change:** `engine::traces::list` now returns one compact summary per trace, including
-  aggregate status, span count, error count, tags, and optional projected attributes. Consumers that
-  need complete span records must use the new `engine::traces::spans` function. Summary filtering and
-  pagination are stable across traces, including data read from the archive.
-
-  ## Additional reliability and telemetry fixes
-
-  - Queue provider registration and routing are scoped by namespace, including providers that register
-    after startup.
-  - Compose supports empty container declarations and gives local base-image workers the correct VM
-    execution path.
-  - The engine aggregates CLI command counts into heartbeat telemetry instead of sending a network
-    event for every command. A project stamp also prevents restarts from sending duplicate heartbeats
-    within the configured interval.
-  - Telemetry sends explicitly configured worker names as readable heartbeat labels. It replaces
-    generated `hostname:pid` names with generic values.
+  - Improved queue routing across namespaces.
+  - Improved trace archive cleanup and summary pagination.
+  - Reduced CLI telemetry traffic.
 </Update>
 
 <Update label="0.22.1" description="August 2026">

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -38,10 +38,11 @@ type: "reference"
   inspect, add, remove, restart, and update workers. It also provides bounded, rotating stdout and
   stderr logs. Mutation calls return concise operation results that show the affected workers.
 
-  `iii compose --up` starts the Compose daemon, its managed engine, and the declared project. Bare
-  `iii compose` starts only the daemon. The old positional `iii compose up` form is rejected, and
-  `--file` is valid only with `--up`. Use `iii compose --up --file worker-compose.yaml` when you
-  specify a file.
+  `iii compose --up` starts the Compose daemon and the declared project. It also starts the managed
+  engine when the Compose file has an `engine:` section and `--engine` does not select an existing
+  engine. Bare `iii compose` starts only the daemon. The old positional `iii compose up` form is
+  rejected, and `--file` is valid only with `--up`. Use
+  `iii compose --up --file worker-compose.yaml` when you specify a file.
 
   Local workers that declare `runtime.base_image` now run in a VM. Source changes are forwarded into
   the guest before restart, so the VM runs the current local files. A Compose file can also omit


### PR DESCRIPTION
## What

- replace the 0.23 placeholder with complete September 2026 release notes
- document Worker Compose, namespaces, RabbitMQ queue migration, persistent traces, and reliability fixes
- link the existing 0.22 to 0.23 migration guides

## Why

The published 0.23 entry only documented the `iii compose --up` CLI change. The release also introduced Worker Compose, namespace routing, persistent trace storage, and required migration steps that users need before upgrading.

## Notes

- documents breaking removal of the legacy worker lifecycle
- documents RabbitMQ durable queue renaming and the trace list API change
- no runtime or API implementation changes are included

## Validation

- `git diff --check`
- compiled `docs/changelog/index.mdx` with `@mdx-js/mdx` 3.1.1 in a read-only container
- verified release details against `iii/v0.22.1..iii/v0.23.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Condensed the 0.23.0 changelog into concise bullet lists.
  * Organized release information under Worker Compose, Namespaces, Observability, and Reliability headings.
  * Retained summaries of Compose control, namespace routing, queue naming, trace archives, and telemetry updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->