### PR TITLE
feat(compose): required: false contains a failed start

### DIFF
--- a/crates/iii-compose/src/config.rs
+++ b/crates/iii-compose/src/config.rs
@@ -123,6 +123,19 @@ pub struct Container {
     pub env_file: Vec<PathBuf>,
     /// Readiness budget for this container: its own override, else the file's.
     pub startup_timeout: Duration,
+    /// Whether a failed start fails the operation that started it.
+    ///
+    /// `true` is the default and the rule everything else is written against:
+    /// an `up` that cannot start a declared container refuses and undoes
+    /// itself. `false` says the project would rather run without this one, so
+    /// the failure is reported against the container and the operation carries
+    /// on.
+    ///
+    /// Dependents carry on too. `start_after` is a start order, not a claim
+    /// that the dependent cannot run without the dependency, so a container
+    /// that waited on a non-required one starts as if it had come up. A
+    /// dependent that genuinely needs it says so by failing on its own.
+    pub required: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -428,6 +441,7 @@ fn validate_container(
             .map(|path| resolve_relative(base_dir, path))
             .collect(),
         startup_timeout,
+        required: raw.required,
     })
 }
 
@@ -730,6 +744,15 @@ struct RawContainer {
     env_file: Vec<PathBuf>,
     #[serde(default)]
     startup_timeout: Option<String>,
+    /// Absent means `true`: the default is the strict rule, so a file written
+    /// before this field existed keeps the behaviour it was written against.
+    #[serde(default = "required_by_default")]
+    #[schemars(default = "required_by_default")]
+    required: bool,
+}
+
+fn required_by_default() -> bool {
+    true
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -1026,6 +1026,14 @@ pub struct MutationOutcome {
     /// Concise failure for the first worker that could not reach its target state.
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<MutationError>,
+    /// Workers that failed while the operation still succeeded, which is only
+    /// possible for a container declaring `required: false`.
+    ///
+    /// `status: ok` used to mean every planned container is up. It now means
+    /// every *required* one is, so the return has to name the rest rather than
+    /// leave a caller to compare the plan against a later status call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    not_required_failures: Option<Vec<String>>,
 }
 
 impl MutationOutcome {
@@ -1046,15 +1054,25 @@ impl MutationOutcome {
             .collect();
         let mut affected_workers = std::collections::BTreeSet::new();
         let mut error = None;
+        let mut failed = Vec::new();
 
         for result in operations.flat_map(|operation| &operation.containers) {
             if result.changed && !requested.contains(result.container.as_str()) {
                 affected_workers.insert(result.container.clone());
             }
+            if result.error.is_some() {
+                failed.push(result.container.clone());
+            }
             if error.is_none() {
                 error = result.error.as_ref().map(MutationError::from);
             }
         }
+
+        // A succeeding operation with a failed container is the `required:
+        // false` case and nothing else: a required failure is what makes the
+        // status `failed` in the first place.
+        let not_required_failures =
+            (status == OpStatus::Ok && !failed.is_empty()).then_some(failed);
 
         Self {
             status,
@@ -1067,6 +1085,7 @@ impl MutationOutcome {
             affected_workers: (!affected_workers.is_empty())
                 .then(|| affected_workers.into_iter().collect()),
             error,
+            not_required_failures,
         }
     }
 

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -177,6 +177,10 @@ async fn up_inner(
     let mut results: Vec<ContainerResult> = Vec::new();
     // Only what *this* operation started may be rolled back.
     let mut started: Vec<String> = Vec::new();
+    // Containers that failed and said their failure does not fail the
+    // operation. Counted so the closing line reports a partial project as
+    // partial rather than reading like a clean start.
+    let mut not_required_failures = 0usize;
     let max_parallel_workers = crate::parallelism::max_parallel_workers();
 
     // Everything this operation will touch, drawn before any of it moves, so an
@@ -281,8 +285,17 @@ async fn up_inner(
                     if let Some(operation) = crate::operation::active(&operation_id) {
                         operation.emit(Some(key), "failed", error.to_string()).await;
                     }
-                    if failure.is_none() {
-                        failure = Some((key.clone(), error));
+                    if is_required(ctx.file, key) {
+                        if failure.is_none() {
+                            failure = Some((key.clone(), error));
+                        }
+                    } else {
+                        // The plan counted it, so the progress has to account
+                        // for it however it settled.
+                        if let Some(operation) = crate::operation::active(&operation_id) {
+                            operation.completed_one().await;
+                        }
+                        not_required_failures += 1;
                     }
                 }
                 StartAttempt::Interrupted => interrupted = true,
@@ -321,6 +334,9 @@ async fn up_inner(
 
     report::plan_done();
     let changed = results.iter().filter(|result| result.changed).count();
+    if not_required_failures > 0 {
+        report::not_required_failed(not_required_failures);
+    }
     report::summary_ok("up", changed, results.len(), began.elapsed());
     Some(OpResult {
         operation_id,
@@ -328,6 +344,15 @@ async fn up_inner(
         changed: changed > 0,
         containers: results,
     })
+}
+
+/// Whether this container's failure fails the operation. A container the file
+/// no longer declares is treated as required: the strict rule is the one that
+/// refuses rather than the one that carries on.
+fn is_required(file: &ComposeFile, key: &str) -> bool {
+    file.containers
+        .get(key)
+        .is_none_or(|container| container.required)
 }
 
 /// Drops a leading `container '<name>': ` from a message that is already being

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -652,7 +652,9 @@ fn op_description(function_id: &str) -> &'static str {
     match function_id {
         "compose::up" => {
             "Start a compose project, or one container and its dependencies. \
-             Repeated calls leave ready containers running."
+             Repeated calls leave ready containers running. A container \
+             declaring 'required: false' is named in not_required_failures \
+             when it fails, and the operation still returns ok."
         }
         "compose::down" => {
             "Stop a compose project, or one container and its dependents, in \

--- a/crates/iii-compose/src/report.rs
+++ b/crates/iii-compose/src/report.rs
@@ -352,6 +352,17 @@ pub fn rolled_back(key: &str) {
     ));
 }
 
+/// Containers that failed and declared `required: false`. Printed before the
+/// closing line so a partial project does not read as a clean start.
+pub fn not_required_failed(count: usize) {
+    let body = if count == 1 {
+        "1 container failed and is not required: the project is up without it".to_string()
+    } else {
+        format!("{count} containers failed and are not required: the project is up without them")
+    };
+    line(&body.yellow().to_string());
+}
+
 /// Closing line of an operation.
 pub fn summary_ok(action: &str, changed: usize, total: usize, elapsed: Duration) {
     let body = if changed == 0 {

--- a/crates/iii-compose/tests/config_validation.rs
+++ b/crates/iii-compose/tests/config_validation.rs
@@ -562,6 +562,46 @@ containers:
     );
 }
 
+/// A file written before the field existed keeps the strict rule, and a
+/// container opts out one at a time rather than for the project.
+#[test]
+fn required_defaults_to_true_and_is_declared_per_container() {
+    let file = parse(
+        r#"
+namespace: orders
+containers:
+  api:
+    worker: path://./workers/api
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+"#,
+    )
+    .expect("required is part of the container schema");
+
+    assert!(
+        file.containers["api"].required,
+        "a container that says nothing is required"
+    );
+    assert!(!file.containers["mailer"].required);
+}
+
+#[test]
+fn rejects_a_non_boolean_required() {
+    assert_eq!(
+        code(
+            r#"
+namespace: orders
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: "no"
+"#
+        ),
+        "INVALID_COMPOSE_FILE"
+    );
+}
+
 #[test]
 fn rejects_a_user_environment_that_shadows_the_reserved_contract() {
     // Silently dropping it would look like it took effect.

--- a/docs/next/understanding-iii/compose.mdx
+++ b/docs/next/understanding-iii/compose.mdx
@@ -163,21 +163,45 @@ started is rolled back, and everything after it in the start order is never atte
 containers that have nothing to do with it. Once a container is ready, the supervisor is narrower:
 it takes that container's transitive dependents down and leaves the rest alone.
 
-So a `mailer` that nothing depends on ends the whole start if it fails during `up`, and is contained
-if it fails a minute later. The same declaration, the same container, two blast radii separated only
-by timing.
+So a `mailer` that nothing depends on would end the whole start if it failed during `up`, and be
+contained if it failed a minute later. The same declaration, the same container, two blast radii
+separated only by timing.
 
 Each rule is defensible where it stands. An `up` that reported success over a half-started project
 would be worse than one that refuses, and a supervisor that tore down a whole project because one
-leaf died would be worse than one that contains it. What is missing is a way for the compose file to
-say which it wants, so the choice is compose's rather than the operator's. That is a v1 limitation
-rather than a decision: a project cannot mark a container as non-essential, and it cannot ask for a
-dead one to be restarted, because there is no restart policy at all.
+leaf died would be worse than one that contains it. What was missing was a way for the compose file
+to say which it wants, so the choice was compose's rather than the operator's.
 
-Both belong in the file rather than in compose's judgement, and they are two separate questions:
-whether a container's failure fails the operation, and what happens when a ready container exits.
-Whatever those grow into, the property worth keeping is that the answer reads the same at start time
-and at run time.
+### Saying it in the file
+
+A container declares whether its failure fails the operation:
+
+```yaml
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+```
+
+`required: true` is the default and the strict rule above, so a file written before this field
+existed keeps the behavior it was written against. `required: false` narrows the start-time blast
+radius to the one container that declared it: the failure is reported against `mailer`, nothing is
+rolled back, and the operation carries on.
+
+Its dependents carry on too. A container that names `mailer` in `start_after` starts as if it had
+come up, because `start_after` is a start order rather than a claim that the dependent cannot run
+without it. A dependent that genuinely cannot run without `mailer` says so by failing on its own.
+
+That moves what `status: ok` means. It used to say every planned container is up; it now says every
+required one is, so the return names the rest in `not_required_failures` rather than leaving a
+caller to compare the plan against a later status call.
+
+The field answers the start-time question and only that one. Once a container is ready, the
+supervisor still takes its transitive dependents down when it exits, whatever the container
+declared, and a project still cannot ask for a dead container to be restarted, because there is no
+restart policy at all. So the two blast radii have narrowed rather than met. The property worth
+keeping is that the answer reads the same at start time and at run time, and the run-time half is
+the restart policy that does not exist yet.
 
 ## Related
 

--- a/docs/next/understanding-iii/compose.mdx.skill.md
+++ b/docs/next/understanding-iii/compose.mdx.skill.md
@@ -159,21 +159,45 @@ started is rolled back, and everything after it in the start order is never atte
 containers that have nothing to do with it. Once a container is ready, the supervisor is narrower:
 it takes that container's transitive dependents down and leaves the rest alone.
 
-So a `mailer` that nothing depends on ends the whole start if it fails during `up`, and is contained
-if it fails a minute later. The same declaration, the same container, two blast radii separated only
-by timing.
+So a `mailer` that nothing depends on would end the whole start if it failed during `up`, and be
+contained if it failed a minute later. The same declaration, the same container, two blast radii
+separated only by timing.
 
 Each rule is defensible where it stands. An `up` that reported success over a half-started project
 would be worse than one that refuses, and a supervisor that tore down a whole project because one
-leaf died would be worse than one that contains it. What is missing is a way for the compose file to
-say which it wants, so the choice is compose's rather than the operator's. That is a v1 limitation
-rather than a decision: a project cannot mark a container as non-essential, and it cannot ask for a
-dead one to be restarted, because there is no restart policy at all.
+leaf died would be worse than one that contains it. What was missing was a way for the compose file
+to say which it wants, so the choice was compose's rather than the operator's.
 
-Both belong in the file rather than in compose's judgement, and they are two separate questions:
-whether a container's failure fails the operation, and what happens when a ready container exits.
-Whatever those grow into, the property worth keeping is that the answer reads the same at start time
-and at run time.
+### Saying it in the file
+
+A container declares whether its failure fails the operation:
+
+```yaml
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+```
+
+`required: true` is the default and the strict rule above, so a file written before this field
+existed keeps the behavior it was written against. `required: false` narrows the start-time blast
+radius to the one container that declared it: the failure is reported against `mailer`, nothing is
+rolled back, and the operation carries on.
+
+Its dependents carry on too. A container that names `mailer` in `start_after` starts as if it had
+come up, because `start_after` is a start order rather than a claim that the dependent cannot run
+without it. A dependent that genuinely cannot run without `mailer` says so by failing on its own.
+
+That moves what `status: ok` means. It used to say every planned container is up; it now says every
+required one is, so the return names the rest in `not_required_failures` rather than leaving a
+caller to compare the plan against a later status call.
+
+The field answers the start-time question and only that one. Once a container is ready, the
+supervisor still takes its transitive dependents down when it exits, whatever the container
+declared, and a project still cannot ask for a dead container to be restarted, because there is no
+restart policy at all. So the two blast radii have narrowed rather than met. The property worth
+keeping is that the answer reads the same at start time and at run time, and the run-time half is
+the restart policy that does not exist yet.
 
 ## Related
 

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -162,6 +162,21 @@ ready stay as they are.
 A project that fails to start due to a project-related issue ends the command with
 `PROJECT_DID_NOT_START`. Partial starts are rolled back in reverse dependency order.
 
+A worker that declares `required: false` is the exception:
+
+```yaml
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+```
+
+Its failure is reported against that worker, nothing is rolled back, and the operation still returns
+`ok`. Workers that name it in `start_after` start anyway, because `start_after` is a start order and
+not a claim that the dependent cannot run without it. The response lists every worker that failed
+this way in `not_required_failures`, so an `ok` still says which workers are down, and `error`
+carries the first reason.
+
 ### Stopping a project
 
 `compose::down` stops the project in reverse dependency order.
@@ -452,6 +467,7 @@ Each key under `containers` is the name the worker registers under.
 | `environment`     | map            | empty                | Environment variables for this worker.                                                                     |
 | `env_file`        | array of paths | empty                | Read at start time, in declaration order. A later file wins on conflicting entries.                        |
 | `startup_timeout` | string         | the file's value     | Readiness budget for this worker.                                                                          |
+| `required`        | boolean        | `true`               | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
 | `scripts`         | mapping        | absent               | See below.                                                                                                 |
 
 `path://` directories resolve against the compose file's directory. A missing directory fails with

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -156,6 +156,21 @@ ready stay as they are.
 A project that fails to start due to a project-related issue ends the command with
 `PROJECT_DID_NOT_START`. Partial starts are rolled back in reverse dependency order.
 
+A worker that declares `required: false` is the exception:
+
+```yaml
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+```
+
+Its failure is reported against that worker, nothing is rolled back, and the operation still returns
+`ok`. Workers that name it in `start_after` start anyway, because `start_after` is a start order and
+not a claim that the dependent cannot run without it. The response lists every worker that failed
+this way in `not_required_failures`, so an `ok` still says which workers are down, and `error`
+carries the first reason.
+
 ### Stopping a project
 
 `compose::down` stops the project in reverse dependency order.
@@ -446,6 +461,7 @@ Each key under `containers` is the name the worker registers under.
 | `environment`     | map            | empty                | Environment variables for this worker.                                                                     |
 | `env_file`        | array of paths | empty                | Read at start time, in declaration order. A later file wins on conflicting entries.                        |
 | `startup_timeout` | string         | the file's value     | Readiness budget for this worker.                                                                          |
+| `required`        | boolean        | `true`               | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
 | `scripts`         | mapping        | absent               | See below.                                                                                                 |
 
 `path://` directories resolve against the compose file's directory. A missing directory fails with

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -927,6 +927,97 @@ async fn a_child_that_never_registers_times_out_and_rolls_back() {
     daemon.shutdown().await;
 }
 
+/// `required: false` moves the blast radius of a failed start from the whole
+/// operation to the one container that declared it, and a dependent starts on
+/// the same declaration: `start_after` is a start order, not a claim that the
+/// dependent cannot run without it.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_container_that_is_not_required_fails_alone_and_its_dependent_still_starts() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let api_started = tmp.path().join("workers/api/started");
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: optional
+startup_timeout: 2s
+stop_timeout: 100ms
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+    scripts:
+      run: "sleep 30"
+  api:
+    worker: path://./workers/api
+    start_after: [mailer]
+    scripts:
+      run: "touch started && sleep 30"
+"#,
+        &["mailer", "api"],
+    );
+
+    // `mailer` never registers, so it times out. `api` waits behind it and is
+    // started anyway once that failure is recorded.
+    let up = call(
+        port,
+        "compose::up",
+        json!({ "file": file.to_str().unwrap() }),
+    );
+    let ready = async {
+        wait_for_start_markers(&[api_started.as_path()]).await;
+        let api = register_test_worker(port, "optional", "api");
+        wait_for_worker_state(&daemon, "optional", "api", true).await;
+        api
+    };
+    let (up, api) = tokio::join!(up, ready);
+    let up = up.expect("compose::up should answer");
+
+    assert_eq!(
+        up["status"], "ok",
+        "a container that is not required must not fail the operation: {up}"
+    );
+    assert_eq!(
+        up["not_required_failures"],
+        json!(["mailer"]),
+        "the return has to name what is down under an ok: {up}"
+    );
+    assert_eq!(
+        up["error"]["code"], "STARTUP_TIMEOUT",
+        "the reason for the contained failure is still reported: {up}"
+    );
+
+    // Rollback is what `required: true` buys, so nothing may have been undone.
+    let status = call(
+        port,
+        "compose::status",
+        json!({ "file": file.to_str().unwrap() }),
+    )
+    .await
+    .expect("status after a contained failure");
+    let state = |key: &str| {
+        status["containers"]
+            .as_array()
+            .expect("containers")
+            .iter()
+            .find(|container| container["container"] == key)
+            .unwrap_or_else(|| panic!("missing {key}: {status}"))["state"]
+            .clone()
+    };
+    assert_eq!(state("api"), "ready", "dependent was rolled back: {status}");
+    assert_ne!(
+        state("mailer"),
+        "ready",
+        "the failed container must not report ready: {status}"
+    );
+
+    api.shutdown_async().await;
+    daemon.shutdown().await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn logs_continue_from_a_cursor_after_the_worker_is_ready() {
     isolate_state();


### PR DESCRIPTION
A container's blast radius depended on the clock: a failure during `up` ended the operation and rolled back everything it had started, while the same failure a minute later took only that container's dependents. Same declaration, two blast radii separated by timing, and no way for the file to say which it wanted.

`required: false` says it. The failure is reported against that container, nothing is rolled back, and the operation carries on. Dependents carry on too: `start_after` is a start order, not a claim that the dependent cannot run without the dependency, so a container that waited on a non-required one starts as if it had come up. A dependent that genuinely needs it fails on its own.

`required: true` is the default, so a file written before this field keeps the behaviour it was written against.

That moves what `status: ok` means. It used to say every planned container is up; it now says every required one is, so the mutation return names the rest in `not_required_failures` rather than leaving a caller to compare the plan against a later status call.

Start time only. A ready container that exits still cascades into its dependents whatever it declared: that is the restart-policy half of the same question, and it does not exist yet. The docs say so.

Closes #2051

## What

A new container field, and the operation rule that follows from it:

```yaml
containers:
  mailer:
    worker: path://./workers/mailer
    required: false
```

- config.rs: required: bool, defaulting to true. Strict as everything else in the file, so a non-boolean is INVALID_COMPOSE_FILE.
- lifecycle.rs: a failed non-required container no longer ends the wave. It is recorded, the plan's progress advances for it, and the following waves start.
- daemon.rs: not_required_failures on the mutation return. Derived rather than plumbed, because a container result carrying an error under status: ok can only be a non-required one: a required failure is what makes the status failed. error still carries the first reason.
- report.rs: a line before the summary, so a partial project does not read as a clean start.

✗ mailer STARTUP_TIMEOUT container 'mailer' was not ready after 2s
✓ api ready (215ms)
1 container failed and is not required: the project is up without it
up: 1 of 2 changed in 2.2s

Tests: config_validation covers the default, the per-container declaration, and the rejection. compose_daemon_e2e runs the case the field exists for: mailer never registers and times
out, api declares start_after: [mailer] and still reaches ready, up returns oks: ["mailer"], and a status call confirms api was not rolled back.

Docs: the field row and the compose::up exception in using-iii/compose; in undhe blast radius depends on the clock" stops calling this a v1 limitation andgains a subsection for what the field settles and what it leaves open.

## Why

Each rule was defensible on its own. An up that reported success over a half-started project would be worse than one that refuses, and a supervisor that tore down a whole project because one leaf died would be worse than one that contains it. What was missise file to say which it wants, so the choice was compose's rather than theoperator's.

Split out of the review of #2034 (comment), and documented as a v1 limitation in understanding-iii/compose until now.

## Notes

- Not a breaking change. required: true is the default and is today's behaviour exactly. not_required_failures is omitted unless something failed under an ok.
- compose::restart is unchanged. A named container that fails still fails the ared: the operator named one container and asked for it.
- The .skill.md twins were edited by hand, because iii-skill-render was not available locally. Worth regenerating before merge.
- The 05-failure-rollback smoke case is not in this repository, so the non-reqded to it.
- One pre-existing test failure on macOS. add_starts_a_managed_project_declared_with_null_containers asserts on a /private tmpdir symlink path and fails identically on a clean checkout of main. Everything else in compose_daemon_e2e and all of cargo test -p iii-compose is green.

- [x] I license my contributions to this repository under Apache 2.0, and I have all necessary rights over the code I am contributing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional containers with `required: false`, allowing their startup failures without failing or rolling back the overall operation.
  * Dependent containers can still start when a non-required container fails.
  * Results now report non-required container failures while retaining a successful status.
  * The `required` setting defaults to `true`.

* **Documentation**
  * Updated compose configuration and lifecycle documentation with the new behavior and response details.

* **Tests**
  * Added validation and end-to-end coverage for optional container failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -→

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional containers that can fail without failing the overall startup operation.
  * Startup responses identify non-required containers that failed.
  * Dependents can still start when a non-required container fails.
  * The `required` setting defaults to `true`.

* **Bug Fixes**
  * Prevented unnecessary rollback when non-required containers fail.

* **Documentation**
  * Documented the `required` setting and partial-start behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->