### PR TITLE
Remove inaccurate 'worker mesh' framing of iii

### DIFF
--- a/docs/next/using-iii/workers.mdx
+++ b/docs/next/using-iii/workers.mdx
@@ -123,7 +123,7 @@ To configure the RBAC listener for untrusted workers, declare `iii-worker-manage
 
 Compose is optional for a process managed by Kubernetes, systemd, another host, or an SDK-driven
 development command. Give it the engine URL and a worker name; once connected it participates in
-the same function and trigger mesh. Compose only owns processes declared in its file.
+the same function and trigger registry. Compose only owns processes declared in its file.
 
 ## Migrating an existing project
 

--- a/docs/next/using-iii/workers.mdx.skill.md
+++ b/docs/next/using-iii/workers.mdx.skill.md
@@ -119,7 +119,7 @@ To configure the RBAC listener for untrusted workers, declare `iii-worker-manage
 
 Compose is optional for a process managed by Kubernetes, systemd, another host, or an SDK-driven
 development command. Give it the engine URL and a worker name; once connected it participates in
-the same function and trigger mesh. Compose only owns processes declared in its file.
+the same function and trigger registry. Compose only owns processes declared in its file.
 
 ## Migrating an existing project
 

--- a/engine/src/workers/engine_fn/README.md
+++ b/engine/src/workers/engine_fn/README.md
@@ -1,6 +1,6 @@
 # iii
 
-iii is a WebSocket-routed worker mesh. One engine process (default port `49134`) holds a live registry of every connected worker, every function those workers expose, and every trigger bound to them. Workers are independent processes that open a WebSocket to the engine and register **Functions** (`service::name` handlers) and **Triggers** (events that invoke those functions). There is no direct worker-to-worker traffic — every call routes through the engine.
+iii is a language-agnostic runtime where services, agents, and tools are composed of the same things: workers, triggers, and functions. One engine process (default port `49134`) holds a live registry of every connected worker, every function those workers expose, and every trigger bound to them. Workers are independent processes that open a WebSocket to the engine and register **Functions** (`service::name` handlers) and **Triggers** (events that invoke those functions). There is no direct worker-to-worker traffic — every call routes through the engine.
 
 This registry worker documents the in-process **`engine::*`** introspection surface. It is always present in the engine and is not configured in `config.yaml`.
 

--- a/engine/src/workers/engine_fn/skills/SKILL.md
+++ b/engine/src/workers/engine_fn/skills/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: iii
-description: WebSocket-routed worker mesh — the engine's Function/Trigger/Worker model and the iii-sdk surface for authoring them. Teaches the ordered way to gain a capability before writing code — (1) check functions already registered in the engine, (2) search the public registry via iii-directory, (3) build a worker. Single self-contained skill — meant for system-prompt injection; do not re-fetch.
+description: How iii works and the iii-sdk surface for authoring workers, triggers, and functions. Teaches the ordered way to gain a capability before writing code — (1) check functions already registered in the engine, (2) search the public registry via iii-directory, (3) build a worker. Single self-contained skill — meant for system-prompt injection; do not re-fetch.
 ---
 
 # iii
 
-iii is a WebSocket-routed worker mesh. One engine process (default port `49134`) holds a live registry of every connected worker, every function those workers expose, and every trigger bound to them. Workers are independent OS processes that open a WebSocket to the engine and register **Functions** (`service::name` handlers) and **Triggers** (the events that invoke those Functions). There is no direct worker-to-worker traffic — every call routes through the engine, which makes the language, runtime, and physical location of any worker invisible to its callers.
+iii is a language-agnostic runtime where services, agents, and tools are composed of the same things: workers, triggers, and functions. One engine process (default port `49134`) holds a live registry of every connected worker, every function those workers expose, and every trigger bound to them. Workers are independent OS processes that open a WebSocket to the engine and register **Functions** (`service::name` handlers) and **Triggers** (the events that invoke those Functions). There is no direct worker-to-worker traffic — every call routes through the engine, which makes the language, runtime, and physical location of any worker invisible to its callers.
 
 ## When to Use
 


### PR DESCRIPTION
## What

Remove "worker mesh" mentions that describe iii as a mesh, across the files the closed #2086 did not land in.

- `engine/src/workers/engine_fn/README.md` and `skills/SKILL.md` — "WebSocket-routed worker mesh" reworded to "a language-agnostic runtime where services, agents, and tools are composed of the same things: workers, triggers, and functions".
- `docs/next/using-iii/workers.mdx` — "the same function and trigger mesh" -> "the same function and trigger registry"; skill artifact re-rendered with `iii-skill-render`.

## Why

iii is not a mesh. Same rewording as the closed #2086.

## Notes

- Only `docs/next/` touched (next-only doc policy).
- Contrast mentions (iii is *not* a service mesh) left in place on purpose.
- The `iii-hq/workers` repo already dropped every mesh reference on `main`; no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to describe the runtime as language-agnostic and composed of workers, triggers, and functions.
  * Clarified that connected workers participate in the same function and trigger registry, including when operating outside Compose.
  * Replaced “WebSocket-routed worker mesh” and “trigger mesh” terminology with clearer runtime and registry descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->