### PR TITLE
feat(compose): publish reliable mutation completion events

### DIFF
--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -718,24 +718,37 @@ impl Daemon {
         ))
     }
 
-    /// Removes one declared worker and reconciles the running project.
+    /// Removes declared workers and reconciles the running project once.
     ///
-    /// Dependency edges pointing at the removed worker are deleted with it.
+    /// Dependency edges pointing at removed workers are deleted with them.
     /// The edited declaration is fully validated before the file or any
-    /// process changes. Only the removed container stops; normal idempotent
+    /// process changes. Only the removed containers stop; normal idempotent
     /// `up` then starts anything else that was already missing.
     pub async fn remove(
         &self,
         file: Option<&Path>,
-        worker: Option<&str>,
+        workers: &[String],
         operation_id: String,
     ) -> Result<MutationOutcome> {
-        let Some(worker) = worker.map(str::trim).filter(|worker| !worker.is_empty()) else {
+        if workers.is_empty() {
             return Err(ComposeError::InvalidWorkerSpec {
                 spec: String::new(),
-                reason: "no worker was named. Pass worker=<name>".to_string(),
+                reason: "no worker was named. Pass one or more worker=<name> arguments".to_string(),
             });
-        };
+        }
+        let workers = workers
+            .iter()
+            .map(|worker| {
+                let worker = worker.trim();
+                if worker.is_empty() {
+                    return Err(ComposeError::InvalidWorkerSpec {
+                        spec: worker.to_string(),
+                        reason: "worker names cannot be blank".to_string(),
+                    });
+                }
+                Ok(worker.to_string())
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         let path = self.resolve_file(file)?;
         let _mutation = self.lock_mutation(path).await;
@@ -744,11 +757,22 @@ impl Daemon {
             source,
         })?;
         self.validate_engine_policy_text(path, &text)?;
-        let Some(edited) = crate::edit::remove_container(&text, worker)? else {
-            return Err(ComposeError::UnknownContainer {
-                container: worker.to_string(),
-            });
-        };
+        let requested = workers.iter().map(String::as_str).collect::<BTreeSet<_>>();
+        let removal_order = crate::ComposeFile::parse(&text, path)?
+            .start_order()?
+            .into_iter()
+            .rev()
+            .filter(|worker| requested.contains(worker.as_str()))
+            .collect::<Vec<_>>();
+        let mut edited = text;
+        for worker in &workers {
+            let Some(next) = crate::edit::remove_container(&edited, worker)? else {
+                return Err(ComposeError::UnknownContainer {
+                    container: worker.to_string(),
+                });
+            };
+            edited = next;
+        }
 
         let current = crate::ComposeFile::parse(&edited, path)?;
         self.engine_policy.validate_project(&current)?;
@@ -760,16 +784,26 @@ impl Daemon {
         let project = self.project(path).await?;
         write_atomically(path, &edited)?;
 
-        let (down, up) = project
-            .reconcile_removal(current, worker, operation_id)
+        let (stopped, up) = project
+            .reconcile_removals(current, &removal_order, operation_id)
             .await;
+        let status = if up.status == OpStatus::Failed
+            || stopped
+                .iter()
+                .any(|result| result.status == OpStatus::Failed)
+        {
+            OpStatus::Failed
+        } else {
+            OpStatus::Ok
+        };
+        let operations = stopped.iter().chain(std::iter::once(&up));
         Ok(MutationOutcome::from_operations(
-            up.status,
+            status,
             true,
-            Some(worker),
+            workers.first().map(String::as_str),
+            Some(&workers),
             None,
-            None,
-            [&down, &up].into_iter(),
+            operations,
         ))
     }
 

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -122,20 +122,19 @@ impl EnginePolicy {
     }
 }
 
-/// Keeps one declaration for a dependency shared by several requested workers.
+/// Keeps one declaration for each container in a mutation batch.
 ///
-/// Registry graphs are resolved per requested root. Two roots may therefore
-/// return the same container. Identical declarations are one shared
-/// dependency; different declarations mean the roots resolved incompatible
-/// versions, sources, or dependency edges. Reject that batch before the file
-/// is read or edited, so argument order cannot select the winning declaration.
-fn coalesce_expanded(
-    expanded: Vec<crate::edit::NewContainer>,
+/// Registry graphs and direct request lists can contain the same container
+/// more than once. Identical declarations collapse into one edit. Conflicting
+/// declarations reject the batch before the file is read or edited, so
+/// argument order cannot select the winning declaration.
+fn coalesce_containers(
+    containers: Vec<crate::edit::NewContainer>,
 ) -> Result<Vec<crate::edit::NewContainer>> {
     let mut positions = BTreeMap::new();
-    let mut unique: Vec<crate::edit::NewContainer> = Vec::with_capacity(expanded.len());
+    let mut unique: Vec<crate::edit::NewContainer> = Vec::with_capacity(containers.len());
 
-    for container in expanded {
+    for container in containers {
         if let Some(&position) = positions.get(&container.key) {
             if unique[position] != container {
                 return Err(ComposeError::InvalidWorkerSpec {
@@ -430,7 +429,7 @@ impl Daemon {
         for (_, graph) in expanded {
             wanted.extend(graph?);
         }
-        let wanted = coalesce_expanded(wanted)?;
+        let wanted = coalesce_containers(wanted)?;
 
         // Acquire registry artifacts before taking either the file mutation lock
         // or the project's runtime lock. `lifecycle::start_one` calls install
@@ -607,39 +606,41 @@ impl Daemon {
         expand_graph(asked, reference, graph, path_workers)
     }
 
-    /// Moves one declared container to another version of the same package.
+    /// Moves declared containers to other versions of the same packages.
     ///
-    /// `worker=state` takes whatever the registry calls latest; `worker=state@1.2.3`
-    /// takes that one, which is how a downgrade is spelled. The container has to
-    /// be declared already — this edits a line, it does not add one, and
-    /// `compose::add` is the call that adds.
+    /// `worker=state` takes whatever the registry calls latest;
+    /// `worker=state@1.2.3` takes that one, which is how a downgrade is spelled.
+    /// Every container has to be declared already. This edits existing lines;
+    /// `compose::add` is the call that adds them.
     ///
-    /// The answer names both versions, because the operator asked for "latest"
-    /// without knowing what that is and the interesting part of the reply is
-    /// what it turned out to be.
+    /// The complete batch is validated and edited in memory before one atomic
+    /// write. A changed batch restarts the project once.
     pub async fn update(
         &self,
         file: Option<&Path>,
-        worker: Option<&str>,
+        workers: &[String],
         operation_id: String,
     ) -> Result<MutationOutcome> {
-        let Some(worker) = worker else {
+        if workers.is_empty() {
             return Err(ComposeError::InvalidWorkerSpec {
                 spec: String::new(),
-                reason: "no worker was named. Pass worker=<name> or worker=<name@version>"
+                reason: "no worker was named. Pass worker=<name>, worker=<name@version>, or a workers list"
                     .to_string(),
             });
-        };
+        }
+
+        let asked = workers
+            .iter()
+            .map(|worker| crate::edit::parse_worker(worker))
+            .collect::<Result<Vec<_>>>()?;
+        let requested = asked
+            .iter()
+            .map(|worker| worker.key.clone())
+            .collect::<Vec<_>>();
+        let primary = requested[0].clone();
+        let asked = coalesce_containers(asked)?;
 
         let path = self.resolve_file(file)?;
-        let asked = crate::edit::parse_worker(worker)?;
-        let crate::edit::Source::Package { reference, version } = &asked.source else {
-            return Err(ComposeError::NotAPackageContainer {
-                container: asked.key.clone(),
-                kind: "path".to_string(),
-            });
-        };
-
         let _mutation = self.lock_mutation(path).await;
         let text = std::fs::read_to_string(path).map_err(|source| ComposeError::Io {
             path: path.to_path_buf(),
@@ -647,55 +648,76 @@ impl Daemon {
         })?;
         let compose = crate::ComposeFile::parse(&text, path)?;
         self.engine_policy.validate_project(&compose)?;
-        let Some(container) = compose.containers.get(&asked.key) else {
-            return Err(ComposeError::UnknownContainer {
-                container: asked.key.clone(),
-            });
-        };
-        if !matches!(
-            container.worker,
-            crate::config::WorkerSource::Package { .. }
-        ) {
-            return Err(ComposeError::NotAPackageContainer {
-                container: asked.key.clone(),
-                kind: "path".to_string(),
+        let mut wanted = Vec::with_capacity(asked.len());
+        for worker in &asked {
+            let crate::edit::Source::Package { reference, version } = &worker.source else {
+                return Err(ComposeError::NotAPackageContainer {
+                    container: worker.key.clone(),
+                    kind: "path".to_string(),
+                });
+            };
+            let Some(container) = compose.containers.get(&worker.key) else {
+                return Err(ComposeError::UnknownContainer {
+                    container: worker.key.clone(),
+                });
+            };
+            if !matches!(
+                container.worker,
+                crate::config::WorkerSource::Package { .. }
+            ) {
+                return Err(ComposeError::NotAPackageContainer {
+                    container: worker.key.clone(),
+                    kind: "path".to_string(),
+                });
+            }
+
+            // Asked for by version, or whatever the registry calls latest today.
+            let version = match version {
+                Some(version) => version.clone(),
+                None => crate::registry::latest_version(&worker.key, reference).await?,
+            };
+
+            // The declared dependencies come along unchanged. An update moves
+            // versions; rewriting graphs is `compose::add`'s job.
+            wanted.push(crate::edit::NewContainer {
+                key: worker.key.clone(),
+                source: crate::edit::Source::Package {
+                    reference: reference.clone(),
+                    version: Some(version),
+                },
+                start_after: container.start_after.clone(),
             });
         }
 
-        // Asked for by version, or whatever the registry calls latest today.
-        let wanted = match version {
-            Some(version) => version.clone(),
-            None => crate::registry::latest_version(&asked.key, reference).await?,
-        };
-
-        // The declared dependencies come along unchanged. An update moves a
-        // version; rewriting the graph on the way is `compose::add`'s job, and
-        // doing it here would edit lines the operator did not ask about.
-        let new = crate::edit::NewContainer {
-            key: asked.key.clone(),
-            source: crate::edit::Source::Package {
-                reference: reference.clone(),
-                version: Some(wanted.clone()),
-            },
-            start_after: container.start_after.clone(),
-        };
-
-        let edited = match crate::edit::upsert_container(&text, &new)? {
-            crate::edit::Outcome::Unchanged => {
-                return Ok(MutationOutcome::from_operations(
-                    OpStatus::Ok,
-                    false,
-                    Some(&asked.key),
-                    None,
-                    Some(wanted),
-                    std::iter::empty::<&OpResult>(),
-                ));
+        let version = wanted
+            .iter()
+            .find(|worker| worker.key == primary)
+            .and_then(|worker| match &worker.source {
+                crate::edit::Source::Package { version, .. } => version.clone(),
+                crate::edit::Source::Path { .. } => None,
+            });
+        let mut edited = text.clone();
+        let mut changed = false;
+        for worker in &wanted {
+            match crate::edit::upsert_container(&edited, worker)? {
+                crate::edit::Outcome::Unchanged => {}
+                crate::edit::Outcome::Replaced { text, .. } | crate::edit::Outcome::Added(text) => {
+                    edited = text;
+                    changed = true;
+                }
             }
-            crate::edit::Outcome::Replaced { text, .. } => text,
-            // `upsert_container` only adds when the key is absent, and the key
-            // was read out of this same file a moment ago.
-            crate::edit::Outcome::Added(text) => text,
-        };
+        }
+
+        if !changed {
+            return Ok(MutationOutcome::from_operations(
+                OpStatus::Ok,
+                false,
+                Some(&primary),
+                Some(&requested),
+                version,
+                std::iter::empty::<&OpResult>(),
+            ));
+        }
 
         // Parsed before it is written, so a splice that would not load leaves
         // the operator's file exactly as it was.
@@ -711,9 +733,9 @@ impl Daemon {
         Ok(MutationOutcome::from_operations(
             up.status,
             true,
-            Some(&asked.key),
-            None,
-            Some(wanted),
+            Some(&primary),
+            Some(&requested),
+            version,
             [&down, &up].into_iter(),
         ))
     }
@@ -1716,7 +1738,8 @@ mod tests {
         let state = crate::edit::parse_worker("state@1.0.0").unwrap();
         let queue = crate::edit::parse_worker("queue@1.0.0").unwrap();
 
-        let merged = coalesce_expanded(vec![state.clone(), queue.clone(), state.clone()]).unwrap();
+        let merged =
+            coalesce_containers(vec![state.clone(), queue.clone(), state.clone()]).unwrap();
 
         assert_eq!(merged, vec![state, queue]);
     }
@@ -1727,7 +1750,7 @@ mod tests {
         let second = crate::edit::parse_worker("state@2.0.0").unwrap();
 
         for expanded in [vec![first.clone(), second.clone()], vec![second, first]] {
-            let error = coalesce_expanded(expanded)
+            let error = coalesce_containers(expanded)
                 .expect_err("two versions of one shared dependency must not be order-dependent");
 
             assert_eq!(error.code(), "INVALID_WORKER_SPEC");

--- a/crates/iii-compose/src/operation.rs
+++ b/crates/iii-compose/src/operation.rs
@@ -117,10 +117,14 @@ impl ProgressEmitter {
                     action: Some(TriggerAction::Void),
                     timeout_ms: Some(5_000),
                 };
+                let request = match binding.metadata {
+                    Some(metadata) => request.metadata(metadata),
+                    None => request.into(),
+                };
                 let request = if let Some(namespace) = binding.namespace {
                     request.namespace(namespace)
                 } else {
-                    request.into()
+                    request
                 };
                 let _ = client.trigger(request).await;
             }

--- a/crates/iii-compose/src/operation.rs
+++ b/crates/iii-compose/src/operation.rs
@@ -27,6 +27,9 @@ use tokio::sync::{RwLock, watch};
 pub struct ProgressSubscription {
     /// Operation to follow. Omit to receive every operation from this daemon.
     pub operation_id: Option<String>,
+    /// Deliver only the terminal success/failure event for the operation.
+    #[serde(default)]
+    pub terminal_only: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -102,8 +105,12 @@ impl ProgressEmitter {
             .filter(|binding| {
                 serde_json::from_value::<ProgressSubscription>(binding.config.clone())
                     .ok()
-                    .and_then(|config| config.operation_id)
-                    .is_none_or(|id| id == event.operation_id)
+                    .is_none_or(|config| {
+                        config
+                            .operation_id
+                            .is_none_or(|id| id == event.operation_id)
+                            && (!config.terminal_only || event.terminal)
+                    })
             })
             .cloned()
             .collect();
@@ -111,8 +118,9 @@ impl ProgressEmitter {
             let client = self.client.clone();
             let event = event.clone();
             async move {
+                let function_id = binding.function_id.clone();
                 let request = TriggerRequest {
-                    function_id: binding.function_id,
+                    function_id: function_id.clone(),
                     payload: serde_json::to_value(event).unwrap_or_default(),
                     action: Some(TriggerAction::Void),
                     timeout_ms: Some(5_000),
@@ -126,7 +134,12 @@ impl ProgressEmitter {
                 } else {
                     request
                 };
-                let _ = client.trigger(request).await;
+                if let Err(error) = client.trigger(request).await {
+                    eprintln!(
+                        "compose-operation delivery failed for trigger {} ({}): {}",
+                        binding.id, function_id, error
+                    );
+                }
             }
         });
         futures::future::join_all(deliveries).await;
@@ -432,5 +445,52 @@ mod tests {
                 .expect("first operation should remain"),
             &first
         ));
+    }
+
+    #[test]
+    fn terminal_only_subscription_filters_progress_events() {
+        let config: ProgressSubscription = serde_json::from_value(serde_json::json!({
+            "operation_id": "compose:test",
+            "terminal_only": true,
+        }))
+        .expect("subscription should deserialize");
+
+        let progress = ProgressEvent {
+            sequence: 1,
+            operation_id: "compose:test".into(),
+            container: None,
+            phase: "waiting".into(),
+            detail: "resolving".into(),
+            current: None,
+            total: None,
+            elapsed_ms: 0,
+            terminal: false,
+        };
+        let terminal = ProgressEvent {
+            terminal: true,
+            sequence: 2,
+            phase: "complete".into(),
+            detail: "done".into(),
+            ..progress.clone()
+        };
+
+        let matches = |event: &ProgressEvent| {
+            config
+                .operation_id
+                .as_ref()
+                .is_none_or(|id| id == &event.operation_id)
+                && (!config.terminal_only || event.terminal)
+        };
+        assert!(!matches(&progress));
+        assert!(matches(&terminal));
+    }
+
+    #[test]
+    fn subscription_defaults_to_all_events() {
+        let config: ProgressSubscription = serde_json::from_value(serde_json::json!({
+            "operation_id": "compose:test"
+        }))
+        .expect("subscription should deserialize");
+        assert!(!config.terminal_only);
     }
 }

--- a/crates/iii-compose/src/operation.rs
+++ b/crates/iii-compose/src/operation.rs
@@ -4,9 +4,9 @@
 //! Observable operations for long Compose mutations.
 //!
 //! Compose is a trigger provider. Clients bind `compose-operation` before
-//! submitting an add and receive structured dependency-tree transitions. A
-//! compact snapshot remains available for reconnect/recovery only; normal
-//! progress delivery never polls.
+//! submitting an add, update, or remove and receive structured mutation
+//! transitions. A compact snapshot remains available for reconnect/recovery
+//! only; normal progress delivery never polls.
 
 use std::{
     collections::BTreeMap,

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -562,18 +562,18 @@ impl Project {
         (restarted, up, interrupted)
     }
 
-    /// Applies a removal without dropping supervision of surviving containers.
+    /// Applies removals without dropping supervision of surviving containers.
     ///
-    /// The removed worker is stopped against the old declaration so its
-    /// cleanup hook and environment are still available. The validated new
-    /// declaration then replaces the held file, and normal idempotent `up`
-    /// starts only anything that was already missing.
-    pub async fn reconcile_removal(
+    /// Removed workers are stopped against the old declaration so their cleanup
+    /// hooks and environments are still available. The validated new declaration
+    /// then replaces the held file, and normal idempotent `up` starts only
+    /// anything that was already missing.
+    pub async fn reconcile_removals(
         &self,
         file: ComposeFile,
-        removed: &str,
+        removed: &[String],
         operation_id: String,
-    ) -> (OpResult, OpResult) {
+    ) -> (Vec<OpResult>, OpResult) {
         let config_dir = self.config_dir();
         let package_cache = self.package_cache();
         let vm_dir = self.vm_dir();
@@ -594,14 +594,20 @@ impl Project {
                 package_cache: &package_cache,
                 vm_dir: &vm_dir,
             };
-            lifecycle::remove_one(
-                &ctx,
-                children,
-                &mut state.containers,
-                removed,
-                format!("{operation_id}-down"),
-            )
-            .await
+            let mut stopped = Vec::with_capacity(removed.len());
+            for (index, worker) in removed.iter().enumerate() {
+                stopped.push(
+                    lifecycle::remove_one(
+                        &ctx,
+                        children,
+                        &mut state.containers,
+                        worker,
+                        format!("{operation_id}-remove-{index}"),
+                    )
+                    .await,
+                );
+            }
+            stopped
         };
 
         {

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -58,13 +58,14 @@ pub struct ComposeRequest {
     /// `compose::update` reads a spec: `name`, `name@version`, or a path.
     /// `compose::remove` and `compose::restart` read a container key, where it
     /// is the spelling for `container` — an operator naming a worker should not
-    /// have to know which of the two words this call wanted. `compose::add`
-    /// keeps this field as a compatibility alias for a single list item.
+    /// have to know which of the two words this call wanted. `compose::add` and
+    /// `compose::remove` keep this field as a compatibility alias for a single
+    /// list item.
     pub worker: Option<String>,
-    /// Workers to add in one file edit and one project restart.
+    /// Workers to add or remove in one file edit and one reconciliation.
     ///
-    /// This is the canonical `compose::add` JSON field. The singular `worker`
-    /// field remains accepted for clients that used the old contract.
+    /// This is the canonical JSON field for both operations. The singular
+    /// `worker` field remains accepted for clients that used the old contract.
     pub workers: Option<Vec<String>>,
     /// Caller-selected operation id used to bind mutation progress before submission.
     pub operation_id: Option<String>,
@@ -115,19 +116,20 @@ struct ProjectOptions {
     file: Option<String>,
 }
 
-/// Request fields used by `compose::add`.
+/// Request fields used by batch worker mutations.
 #[allow(dead_code)]
 #[derive(JsonSchema)]
-struct AddOptions {
+struct BatchWorkerOptions {
     /// Optional daemon guard. Use the trigger `--namespace` flag to route.
     namespace: Option<String>,
     /// Compose file on the daemon host. Defaults to `worker-compose.yaml` in
     /// the daemon working directory.
     file: Option<String>,
-    /// Canonical list of worker names, `name@version` references, registry
-    /// references, or local paths to add in one edit and one restart.
+    /// Canonical list of workers to mutate together. Add accepts worker names,
+    /// `name@version` references, registry references, or local paths. Remove
+    /// accepts declared worker keys.
     workers: Option<Vec<String>>,
-    /// Backward-compatible form for adding one worker.
+    /// Backward-compatible form for mutating one worker.
     worker: Option<String>,
     /// Caller-selected operation id for race-free progress subscription.
     operation_id: Option<String>,
@@ -397,10 +399,7 @@ async fn dispatch(
             Err(err) => Err(compose_error(&err)),
         },
         Operation::Add => {
-            let workers = request
-                .workers
-                .or_else(|| request.worker.map(|worker| vec![worker]))
-                .unwrap_or_default();
+            let workers = requested_workers(request.workers, request.worker);
             if workers.is_empty() {
                 return daemon
                     .add(file.as_deref(), &[], operation_id())
@@ -438,18 +437,20 @@ async fn dispatch(
             Ok(to_value(&accepted))
         }
         Operation::Remove => {
-            let Some(worker) = request.worker.filter(|worker| !worker.trim().is_empty()) else {
+            let workers = requested_workers(request.workers, request.worker);
+            if workers.is_empty() {
                 return daemon
-                    .remove(file.as_deref(), None, operation_id())
+                    .remove(file.as_deref(), &[], operation_id())
                     .await
                     .map(|outcome| to_value(&outcome))
                     .map_err(|err| compose_error(&err));
-            };
+            }
+            let requested = workers.len();
             let (operation, accepted) = admit_mutation(
                 &daemon,
                 request.operation_id,
-                1,
-                format!("removing worker {worker}"),
+                requested,
+                format!("removing {requested} requested workers"),
             )
             .await?;
 
@@ -458,17 +459,17 @@ async fn dispatch(
             let task_operation = Arc::clone(&operation);
             let mutation = async move {
                 task_operation
-                    .emit(None, "removing", format!("removing worker {worker}"))
+                    .emit(None, "removing", format!("removing {requested} workers"))
                     .await;
                 daemon_task
-                    .remove(file.as_deref(), Some(&worker), task_operation_id)
+                    .remove(file.as_deref(), &workers, task_operation_id)
                     .await
             };
             spawn_mutation(
                 operation,
                 mutation,
-                "worker removed",
-                "worker removal failed",
+                "all requested workers were removed",
+                "one or more workers could not be removed",
             );
             Ok(to_value(&accepted))
         }
@@ -699,14 +700,20 @@ fn schema_for_value<T: JsonSchema>() -> Option<Value> {
     serde_json::to_value(schema_for!(T)).ok()
 }
 
-/// `compose::add` accepts its canonical list or the old singular field.
+fn requested_workers(workers: Option<Vec<String>>, worker: Option<String>) -> Vec<String> {
+    workers
+        .or_else(|| worker.map(|worker| vec![worker]))
+        .unwrap_or_default()
+}
+
+/// Batch worker mutations accept their canonical list or the old singular field.
 ///
 /// Both fields are optional in the Rust shape so they can share the common
 /// namespace and file properties. `anyOf` states the runtime rule that at
 /// least one input form must be present. Supplying both is valid; dispatch
 /// gives the canonical `workers` list precedence.
-fn add_options_schema() -> Option<Value> {
-    let mut schema = schema_for_value::<AddOptions>()?;
+fn batch_worker_options_schema() -> Option<Value> {
+    let mut schema = schema_for_value::<BatchWorkerOptions>()?;
     for field in ["workers", "worker"] {
         let types = schema
             .pointer_mut(&format!("/properties/{field}/type"))?
@@ -767,8 +774,9 @@ fn op_description(function_id: &str) -> &'static str {
              workers once."
         }
         "compose::remove" => {
-            "Accept an observable operation that removes one declared worker and dependency \
-             references to it, stops only that worker, then reconciles anything already missing."
+            "Accept an observable operation that removes one or more declared workers and \
+             dependency references to them, stops only those workers, then reconciles anything \
+             already missing."
         }
         "compose::restart" => {
             "Restart the whole project, or restart one named container without \
@@ -859,12 +867,12 @@ fn schema_table() -> &'static [SchemaTriple] {
             ),
             (
                 "compose::add",
-                add_options_schema(),
+                batch_worker_options_schema(),
                 schema_for_value::<OperationAcceptedOutcome>(),
             ),
             (
                 "compose::remove",
-                schema_for_value::<WorkerOptions>(),
+                batch_worker_options_schema(),
                 schema_for_value::<OperationAcceptedOutcome>(),
             ),
             (
@@ -987,7 +995,7 @@ mod tests {
     }
 
     #[test]
-    fn add_request_accepts_a_worker_list_and_the_singular_compatibility_field() {
+    fn batch_worker_request_accepts_a_list_and_the_singular_compatibility_field() {
         let listed: ComposeRequest = serde_json::from_value(json!({
             "workers": ["database", "web"],
         }))
@@ -1004,36 +1012,54 @@ mod tests {
         .expect("the old singular field should deserialize");
         assert_eq!(singular.worker.as_deref(), Some("database"));
         assert_eq!(singular.workers, None);
+
+        assert_eq!(
+            requested_workers(None, singular.worker),
+            vec!["database".to_string()]
+        );
+        assert_eq!(
+            requested_workers(listed.workers, Some("ignored".to_string())),
+            vec!["database".to_string(), "web".to_string()]
+        );
     }
 
     #[test]
-    fn add_schema_requires_one_non_null_non_empty_worker_form() {
-        let schema = schema_entry("compose::add").1.as_ref().unwrap();
-        let validator = jsonschema::Validator::new(schema).expect("add schema should compile");
+    fn batch_worker_schemas_require_one_non_null_non_empty_worker_form() {
+        for function_id in ["compose::add", "compose::remove"] {
+            let schema = schema_entry(function_id).1.as_ref().unwrap();
+            let validator = jsonschema::Validator::new(schema)
+                .unwrap_or_else(|error| panic!("{function_id} schema should compile: {error}"));
 
-        for valid in [
-            json!({ "workers": ["database", "web"] }),
-            json!({ "worker": "database" }),
-        ] {
-            let errors = validator
-                .iter_errors(&valid)
-                .map(|error| error.to_string())
-                .collect::<Vec<_>>();
-            assert!(errors.is_empty(), "should accept {valid}: {errors:?}");
-        }
+            for valid in [
+                json!({ "workers": ["database", "web"] }),
+                json!({ "worker": "database" }),
+            ] {
+                let errors = validator
+                    .iter_errors(&valid)
+                    .map(|error| error.to_string())
+                    .collect::<Vec<_>>();
+                assert!(
+                    errors.is_empty(),
+                    "{function_id} should accept {valid}: {errors:?}"
+                );
+            }
 
-        for invalid in [
-            json!({}),
-            json!({ "workers": [] }),
-            json!({ "workers": null }),
-            json!({ "worker": null }),
-            json!({ "workers": [], "worker": "database" }),
-            json!({ "worker": "" }),
-            json!({ "worker": "  " }),
-            json!({ "workers": [""] }),
-            json!({ "workers": ["  "] }),
-        ] {
-            assert!(!validator.is_valid(&invalid), "should reject {invalid}");
+            for invalid in [
+                json!({}),
+                json!({ "workers": [] }),
+                json!({ "workers": null }),
+                json!({ "worker": null }),
+                json!({ "workers": [], "worker": "database" }),
+                json!({ "worker": "" }),
+                json!({ "worker": "  " }),
+                json!({ "workers": [""] }),
+                json!({ "workers": ["  "] }),
+            ] {
+                assert!(
+                    !validator.is_valid(&invalid),
+                    "{function_id} should reject {invalid}"
+                );
+            }
         }
     }
 
@@ -1046,38 +1072,39 @@ mod tests {
         assert!(up.contains_key("container"));
         assert!(!up.contains_key("worker"));
 
-        let (_, add, _) = schema_entry("compose::add");
-        let add = add.as_ref().unwrap()["properties"].as_object().unwrap();
-        assert!(add.contains_key("namespace"));
-        assert!(add.contains_key("file"));
-        assert!(add.contains_key("workers"));
-        assert!(add.contains_key("worker"));
-        assert!(add.contains_key("operation_id"));
-        assert!(!add.contains_key("container"));
-        assert_eq!(add["workers"]["minItems"], 1);
-        let alternatives = schema_entry("compose::add").1.as_ref().unwrap()["anyOf"]
-            .as_array()
-            .expect("add should require either request form");
-        for field in ["workers", "worker"] {
-            assert!(alternatives.iter().any(|alternative| {
-                alternative["required"]
-                    .as_array()
-                    .is_some_and(|required| required.iter().any(|item| item == field))
-            }));
-        }
-
-        for function_id in ["compose::update", "compose::remove"] {
+        for function_id in ["compose::add", "compose::remove"] {
             let (_, request, _) = schema_entry(function_id);
             let properties = request.as_ref().unwrap()["properties"].as_object().unwrap();
-            for field in ["namespace", "file", "worker", "operation_id"] {
+            for field in ["namespace", "file", "workers", "worker", "operation_id"] {
                 assert!(
                     properties.contains_key(field),
                     "{function_id} is missing {field}"
                 );
             }
             assert!(!properties.contains_key("container"));
-            assert!(!properties.contains_key("workers"));
+            assert_eq!(properties["workers"]["minItems"], 1);
+            let alternatives = request.as_ref().unwrap()["anyOf"]
+                .as_array()
+                .unwrap_or_else(|| panic!("{function_id} should require either request form"));
+            for field in ["workers", "worker"] {
+                assert!(alternatives.iter().any(|alternative| {
+                    alternative["required"]
+                        .as_array()
+                        .is_some_and(|required| required.iter().any(|item| item == field))
+                }));
+            }
         }
+
+        let (_, update, _) = schema_entry("compose::update");
+        let update = update.as_ref().unwrap()["properties"].as_object().unwrap();
+        for field in ["namespace", "file", "worker", "operation_id"] {
+            assert!(
+                update.contains_key(field),
+                "compose::update is missing {field}"
+            );
+        }
+        assert!(!update.contains_key("container"));
+        assert!(!update.contains_key("workers"));
 
         let (_, list, _) = schema_entry("compose::list");
         let list = list.as_ref().unwrap()["properties"].as_object().unwrap();

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -58,13 +58,13 @@ pub struct ComposeRequest {
     /// `compose::update` reads a spec: `name`, `name@version`, or a path.
     /// `compose::remove` and `compose::restart` read a container key, where it
     /// is the spelling for `container` — an operator naming a worker should not
-    /// have to know which of the two words this call wanted. `compose::add` and
-    /// `compose::remove` keep this field as a compatibility alias for a single
-    /// list item.
+    /// have to know which of the two words this call wanted. `compose::add`,
+    /// `compose::update`, and `compose::remove` keep this field as a
+    /// compatibility alias for a single list item.
     pub worker: Option<String>,
-    /// Workers to add or remove in one file edit and one reconciliation.
+    /// Workers to add, update, or remove in one file edit and one reconciliation.
     ///
-    /// This is the canonical JSON field for both operations. The singular
+    /// This is the canonical JSON field for all three operations. The singular
     /// `worker` field remains accepted for clients that used the old contract.
     pub workers: Option<Vec<String>>,
     /// Caller-selected operation id used to bind mutation progress before submission.
@@ -126,27 +126,12 @@ struct BatchWorkerOptions {
     /// the daemon working directory.
     file: Option<String>,
     /// Canonical list of workers to mutate together. Add accepts worker names,
-    /// `name@version` references, registry references, or local paths. Remove
-    /// accepts declared worker keys.
+    /// `name@version` references, registry references, or local paths. Update
+    /// accepts package names or `name@version` references. Remove accepts
+    /// declared worker keys.
     workers: Option<Vec<String>>,
     /// Backward-compatible form for mutating one worker.
     worker: Option<String>,
-    /// Caller-selected operation id for race-free progress subscription.
-    operation_id: Option<String>,
-}
-
-/// Request fields used by single-worker compose-file edits.
-#[allow(dead_code)]
-#[derive(JsonSchema)]
-struct WorkerOptions {
-    /// Optional daemon guard. Use the trigger `--namespace` flag to route.
-    namespace: Option<String>,
-    /// Compose file on the daemon host. Defaults to `worker-compose.yaml` in
-    /// the daemon working directory.
-    file: Option<String>,
-    /// Worker name, `name@version`, registry reference, or local path. The
-    /// accepted form depends on the operation.
-    worker: String,
     /// Caller-selected operation id for race-free progress subscription.
     operation_id: Option<String>,
 }
@@ -486,18 +471,20 @@ async fn dispatch(
             Err(err) => Err(compose_error(&err)),
         },
         Operation::Update => {
-            let Some(worker) = request.worker else {
+            let workers = requested_workers(request.workers, request.worker);
+            if workers.is_empty() {
                 return daemon
-                    .update(file.as_deref(), None, operation_id())
+                    .update(file.as_deref(), &[], operation_id())
                     .await
                     .map(|outcome| to_value(&outcome))
                     .map_err(|err| compose_error(&err));
-            };
+            }
+            let requested = workers.len();
             let (operation, accepted) = admit_mutation(
                 &daemon,
                 request.operation_id,
-                1,
-                format!("updating worker {worker}"),
+                requested,
+                format!("updating {requested} requested workers"),
             )
             .await?;
 
@@ -506,17 +493,21 @@ async fn dispatch(
             let task_operation = Arc::clone(&operation);
             let mutation = async move {
                 task_operation
-                    .emit(None, "resolving", format!("resolving update for {worker}"))
+                    .emit(
+                        None,
+                        "resolving",
+                        format!("resolving updates for {requested} workers"),
+                    )
                     .await;
                 daemon_task
-                    .update(file.as_deref(), Some(&worker), task_operation_id)
+                    .update(file.as_deref(), &workers, task_operation_id)
                     .await
             };
             spawn_mutation(
                 operation,
                 mutation,
-                "worker updated",
-                "worker update failed",
+                "all requested workers were updated",
+                "one or more workers could not be updated",
             );
             Ok(to_value(&accepted))
         }
@@ -783,8 +774,8 @@ fn op_description(function_id: &str) -> &'static str {
              changing its dependency graph."
         }
         "compose::update" => {
-            "Accept an observable operation that moves one declared package worker to a \
-             requested or latest version, then restarts the project."
+            "Accept an observable operation that moves one or more declared package workers to \
+             requested or latest versions, then restarts the project once."
         }
         "compose::schema" => {
             "Return request and response JSON Schemas for compose::* functions. \
@@ -882,7 +873,7 @@ fn schema_table() -> &'static [SchemaTriple] {
             ),
             (
                 "compose::update",
-                schema_for_value::<WorkerOptions>(),
+                batch_worker_options_schema(),
                 schema_for_value::<OperationAcceptedOutcome>(),
             ),
             (
@@ -1025,7 +1016,7 @@ mod tests {
 
     #[test]
     fn batch_worker_schemas_require_one_non_null_non_empty_worker_form() {
-        for function_id in ["compose::add", "compose::remove"] {
+        for function_id in ["compose::add", "compose::update", "compose::remove"] {
             let schema = schema_entry(function_id).1.as_ref().unwrap();
             let validator = jsonschema::Validator::new(schema)
                 .unwrap_or_else(|error| panic!("{function_id} schema should compile: {error}"));
@@ -1072,7 +1063,7 @@ mod tests {
         assert!(up.contains_key("container"));
         assert!(!up.contains_key("worker"));
 
-        for function_id in ["compose::add", "compose::remove"] {
+        for function_id in ["compose::add", "compose::update", "compose::remove"] {
             let (_, request, _) = schema_entry(function_id);
             let properties = request.as_ref().unwrap()["properties"].as_object().unwrap();
             for field in ["namespace", "file", "workers", "worker", "operation_id"] {
@@ -1094,17 +1085,6 @@ mod tests {
                 }));
             }
         }
-
-        let (_, update, _) = schema_entry("compose::update");
-        let update = update.as_ref().unwrap()["properties"].as_object().unwrap();
-        for field in ["namespace", "file", "worker", "operation_id"] {
-            assert!(
-                update.contains_key(field),
-                "compose::update is missing {field}"
-            );
-        }
-        assert!(!update.contains_key("container"));
-        assert!(!update.contains_key("workers"));
 
         let (_, list, _) = schema_entry("compose::list");
         let list = list.as_ref().unwrap()["properties"].as_object().unwrap();

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -21,7 +21,7 @@
 //! fall back to `worker-compose.yaml` in the daemon's own directory, and say
 //! so when there is none.
 
-use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
+use std::{collections::BTreeMap, future::Future, path::PathBuf, sync::Arc};
 
 use iii_sdk::{Error, RegisterFunction};
 use schemars::{JsonSchema, schema_for};
@@ -66,7 +66,7 @@ pub struct ComposeRequest {
     /// This is the canonical `compose::add` JSON field. The singular `worker`
     /// field remains accepted for clients that used the old contract.
     pub workers: Option<Vec<String>>,
-    /// Caller-selected operation id used to bind progress before submission.
+    /// Caller-selected operation id used to bind mutation progress before submission.
     pub operation_id: Option<String>,
     /// Last cursor returned for each selected worker.
     pub cursors: Option<BTreeMap<String, LogCursor>>,
@@ -145,6 +145,8 @@ struct WorkerOptions {
     /// Worker name, `name@version`, registry reference, or local path. The
     /// accepted form depends on the operation.
     worker: String,
+    /// Caller-selected operation id for race-free progress subscription.
+    operation_id: Option<String>,
 }
 
 /// `compose::restart` accepts either spelling for one container.
@@ -246,7 +248,7 @@ struct CancelOutcome {
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
-struct AddAcceptedOutcome {
+struct OperationAcceptedOutcome {
     operation_id: String,
     status: String,
     requested: usize,
@@ -408,91 +410,68 @@ async fn dispatch(
             }
 
             let requested = workers.len();
-            let operation_id = request
-                .operation_id
-                .unwrap_or_else(|| format!("compose:{}", uuid::Uuid::new_v4()));
-            let operation = daemon
-                .operations
-                .create_with_id(operation_id.clone(), requested)
-                .await
-                .map_err(|_| Error::Remote {
-                    code: "OPERATION_ID_ALREADY_EXISTS".to_string(),
-                    message: format!("compose operation '{operation_id}' already exists"),
-                    stacktrace: None,
-                })?;
-            let operation_id = operation.id().to_string();
-            operation
-                .emit(
-                    None,
-                    "accepted",
-                    format!("adding {requested} requested workers"),
-                )
-                .await;
+            let (operation, accepted) = admit_mutation(
+                &daemon,
+                request.operation_id,
+                requested,
+                format!("adding {requested} requested workers"),
+            )
+            .await?;
 
             let daemon_task = Arc::clone(&daemon);
-            let task_operation_id = operation_id.clone();
-            tokio::spawn(async move {
-                operation
+            let task_operation_id = accepted.operation_id.clone();
+            let task_operation = Arc::clone(&operation);
+            let mutation = async move {
+                task_operation
                     .emit(None, "resolving", "resolving dependency trees")
                     .await;
-                if operation.is_cancelled() {
-                    operation
-                        .finish(
-                            crate::operation::OperationStatus::Cancelled,
-                            "operation cancelled",
-                        )
-                        .await;
-                    return;
-                }
-                let result = daemon_task
+                daemon_task
                     .add(file.as_deref(), &workers, task_operation_id)
-                    .await;
-                match result {
-                    Ok(outcome) => {
-                        let failed = outcome.is_failed();
-                        operation
-                            .finish(
-                                if failed {
-                                    crate::operation::OperationStatus::Failed
-                                } else {
-                                    crate::operation::OperationStatus::Succeeded
-                                },
-                                if failed {
-                                    "one or more workers failed"
-                                } else {
-                                    "all requested workers are ready"
-                                },
-                            )
-                            .await;
-                    }
-                    Err(ComposeError::OperationCancelled { .. }) => {
-                        operation
-                            .finish(
-                                crate::operation::OperationStatus::Cancelled,
-                                "operation cancelled",
-                            )
-                            .await
-                    }
-                    Err(error) => {
-                        operation
-                            .finish(crate::operation::OperationStatus::Failed, error.to_string())
-                            .await
-                    }
-                }
-            });
-            Ok(json!({
-                "operation_id": operation_id,
-                "status": "accepted",
-                "requested": requested
-            }))
+                    .await
+            };
+            spawn_mutation(
+                operation,
+                mutation,
+                "all requested workers are ready",
+                "one or more workers failed",
+            );
+            Ok(to_value(&accepted))
         }
-        Operation::Remove => match daemon
-            .remove(file.as_deref(), request.worker.as_deref(), operation_id())
-            .await
-        {
-            Ok(result) => Ok(to_value(&result)),
-            Err(err) => Err(compose_error(&err)),
-        },
+        Operation::Remove => {
+            let Some(worker) = request.worker.filter(|worker| !worker.trim().is_empty()) else {
+                return daemon
+                    .remove(file.as_deref(), None, operation_id())
+                    .await
+                    .map(|outcome| to_value(&outcome))
+                    .map_err(|err| compose_error(&err));
+            };
+            let (operation, accepted) = admit_mutation(
+                &daemon,
+                request.operation_id,
+                1,
+                format!("removing worker {worker}"),
+            )
+            .await?;
+
+            let daemon_task = Arc::clone(&daemon);
+            let task_operation_id = accepted.operation_id.clone();
+            let task_operation = Arc::clone(&operation);
+            let mutation = async move {
+                task_operation
+                    .emit(None, "removing", format!("removing worker {worker}"))
+                    .await;
+                daemon_task
+                    .remove(file.as_deref(), Some(&worker), task_operation_id)
+                    .await
+            };
+            spawn_mutation(
+                operation,
+                mutation,
+                "worker removed",
+                "worker removal failed",
+            );
+            Ok(to_value(&accepted))
+        }
         Operation::Restart => match daemon
             .restart(
                 file.as_deref(),
@@ -505,13 +484,41 @@ async fn dispatch(
             Ok(result) => Ok(to_value(&result)),
             Err(err) => Err(compose_error(&err)),
         },
-        Operation::Update => match daemon
-            .update(file.as_deref(), request.worker.as_deref(), operation_id())
-            .await
-        {
-            Ok(result) => Ok(to_value(&result)),
-            Err(err) => Err(compose_error(&err)),
-        },
+        Operation::Update => {
+            let Some(worker) = request.worker else {
+                return daemon
+                    .update(file.as_deref(), None, operation_id())
+                    .await
+                    .map(|outcome| to_value(&outcome))
+                    .map_err(|err| compose_error(&err));
+            };
+            let (operation, accepted) = admit_mutation(
+                &daemon,
+                request.operation_id,
+                1,
+                format!("updating worker {worker}"),
+            )
+            .await?;
+
+            let daemon_task = Arc::clone(&daemon);
+            let task_operation_id = accepted.operation_id.clone();
+            let task_operation = Arc::clone(&operation);
+            let mutation = async move {
+                task_operation
+                    .emit(None, "resolving", format!("resolving update for {worker}"))
+                    .await;
+                daemon_task
+                    .update(file.as_deref(), Some(&worker), task_operation_id)
+                    .await
+            };
+            spawn_mutation(
+                operation,
+                mutation,
+                "worker updated",
+                "worker update failed",
+            );
+            Ok(to_value(&accepted))
+        }
         Operation::Down => match daemon
             .down(
                 file.as_deref(),
@@ -608,6 +615,85 @@ async fn dispatch(
     }
 }
 
+async fn admit_mutation(
+    daemon: &Daemon,
+    requested_id: Option<String>,
+    requested: usize,
+    detail: String,
+) -> Result<(Arc<crate::operation::Operation>, OperationAcceptedOutcome), Error> {
+    let operation_id = requested_id.unwrap_or_else(|| format!("compose:{}", uuid::Uuid::new_v4()));
+    let operation = daemon
+        .operations
+        .create_with_id(operation_id.clone(), requested)
+        .await
+        .map_err(|_| Error::Remote {
+            code: "OPERATION_ID_ALREADY_EXISTS".to_string(),
+            message: format!("compose operation '{operation_id}' already exists"),
+            stacktrace: None,
+        })?;
+    operation.emit(None, "accepted", detail).await;
+    let accepted = OperationAcceptedOutcome {
+        operation_id,
+        status: "accepted".to_string(),
+        requested,
+    };
+    Ok((operation, accepted))
+}
+
+fn spawn_mutation<F>(
+    operation: Arc<crate::operation::Operation>,
+    mutation: F,
+    success_detail: &'static str,
+    failed_detail: &'static str,
+) where
+    F: Future<Output = Result<MutationOutcome, ComposeError>> + Send + 'static,
+{
+    tokio::spawn(async move {
+        if operation.is_cancelled() {
+            operation
+                .finish(
+                    crate::operation::OperationStatus::Cancelled,
+                    "operation cancelled",
+                )
+                .await;
+            return;
+        }
+
+        match mutation.await {
+            Ok(outcome) => {
+                let failed = outcome.is_failed();
+                operation
+                    .finish(
+                        if failed {
+                            crate::operation::OperationStatus::Failed
+                        } else {
+                            crate::operation::OperationStatus::Succeeded
+                        },
+                        if failed {
+                            failed_detail
+                        } else {
+                            success_detail
+                        },
+                    )
+                    .await;
+            }
+            Err(ComposeError::OperationCancelled { .. }) => {
+                operation
+                    .finish(
+                        crate::operation::OperationStatus::Cancelled,
+                        "operation cancelled",
+                    )
+                    .await;
+            }
+            Err(error) => {
+                operation
+                    .finish(crate::operation::OperationStatus::Failed, error.to_string())
+                    .await;
+            }
+        }
+    });
+}
+
 /// Serialize the generated root schema into the value carried over the wire.
 fn schema_for_value<T: JsonSchema>() -> Option<Value> {
     serde_json::to_value(schema_for!(T)).ok()
@@ -676,20 +762,21 @@ fn op_description(function_id: &str) -> &'static str {
              starting its project."
         }
         "compose::add" => {
-            "Declare one or more workers and their registry dependencies in the compose \
-             file, pin resolved versions, then reconcile changed workers once."
+            "Accept an observable operation that declares one or more workers and their registry \
+             dependencies in the compose file, pins resolved versions, then reconciles changed \
+             workers once."
         }
         "compose::remove" => {
-            "Remove one declared worker and dependency references to it, stop \
-             only that worker, then reconcile anything already missing."
+            "Accept an observable operation that removes one declared worker and dependency \
+             references to it, stops only that worker, then reconciles anything already missing."
         }
         "compose::restart" => {
             "Restart the whole project, or restart one named container without \
              changing its dependency graph."
         }
         "compose::update" => {
-            "Move one declared package worker to a requested or latest version, \
-             then restart the project."
+            "Accept an observable operation that moves one declared package worker to a \
+             requested or latest version, then restarts the project."
         }
         "compose::schema" => {
             "Return request and response JSON Schemas for compose::* functions. \
@@ -773,12 +860,12 @@ fn schema_table() -> &'static [SchemaTriple] {
             (
                 "compose::add",
                 add_options_schema(),
-                schema_for_value::<AddAcceptedOutcome>(),
+                schema_for_value::<OperationAcceptedOutcome>(),
             ),
             (
                 "compose::remove",
                 schema_for_value::<WorkerOptions>(),
-                schema_for_value::<MutationOutcome>(),
+                schema_for_value::<OperationAcceptedOutcome>(),
             ),
             (
                 "compose::restart",
@@ -788,7 +875,7 @@ fn schema_table() -> &'static [SchemaTriple] {
             (
                 "compose::update",
                 schema_for_value::<WorkerOptions>(),
-                schema_for_value::<MutationOutcome>(),
+                schema_for_value::<OperationAcceptedOutcome>(),
             ),
             (
                 "compose::schema",
@@ -965,6 +1052,7 @@ mod tests {
         assert!(add.contains_key("file"));
         assert!(add.contains_key("workers"));
         assert!(add.contains_key("worker"));
+        assert!(add.contains_key("operation_id"));
         assert!(!add.contains_key("container"));
         assert_eq!(add["workers"]["minItems"], 1);
         let alternatives = schema_entry("compose::add").1.as_ref().unwrap()["anyOf"]
@@ -976,6 +1064,19 @@ mod tests {
                     .as_array()
                     .is_some_and(|required| required.iter().any(|item| item == field))
             }));
+        }
+
+        for function_id in ["compose::update", "compose::remove"] {
+            let (_, request, _) = schema_entry(function_id);
+            let properties = request.as_ref().unwrap()["properties"].as_object().unwrap();
+            for field in ["namespace", "file", "worker", "operation_id"] {
+                assert!(
+                    properties.contains_key(field),
+                    "{function_id} is missing {field}"
+                );
+            }
+            assert!(!properties.contains_key("container"));
+            assert!(!properties.contains_key("workers"));
         }
 
         let (_, list, _) = schema_entry("compose::list");
@@ -1037,13 +1138,7 @@ mod tests {
 
     #[test]
     fn mutation_schemas_do_not_expose_reconciliation_internals() {
-        for id in [
-            "compose::up",
-            "compose::down",
-            "compose::remove",
-            "compose::restart",
-            "compose::update",
-        ] {
+        for id in ["compose::up", "compose::down", "compose::restart"] {
             let properties = schema_entry(id).2.as_ref().unwrap()["properties"]
                 .as_object()
                 .unwrap();
@@ -1059,13 +1154,27 @@ mod tests {
     }
 
     #[test]
-    fn add_response_is_an_observable_operation_admission() {
-        let properties = schema_entry("compose::add").2.as_ref().unwrap()["properties"]
-            .as_object()
-            .unwrap();
-        assert!(properties.contains_key("operation_id"));
-        assert!(properties.contains_key("status"));
-        assert!(properties.contains_key("requested"));
-        assert!(!properties.contains_key("containers"));
+    fn observable_mutation_responses_are_operation_admissions() {
+        for function_id in ["compose::add", "compose::update", "compose::remove"] {
+            let properties = schema_entry(function_id).2.as_ref().unwrap()["properties"]
+                .as_object()
+                .unwrap();
+            assert!(
+                properties.contains_key("operation_id"),
+                "{function_id} is missing operation_id"
+            );
+            assert!(
+                properties.contains_key("status"),
+                "{function_id} is missing status"
+            );
+            assert!(
+                properties.contains_key("requested"),
+                "{function_id} is missing requested"
+            );
+            assert!(
+                !properties.contains_key("containers"),
+                "{function_id} exposes container internals"
+            );
+        }
     }
 }

--- a/crates/iii-compose/tests/project_cache.rs
+++ b/crates/iii-compose/tests/project_cache.rs
@@ -348,7 +348,7 @@ async fn update_rejects_an_engine_change_before_editing_the_file() {
     let err = daemon
         .update(
             Some(&file),
-            Some("state@2.0.0"),
+            &["state@2.0.0".to_string()],
             "update-after-engine-change".to_string(),
         )
         .await
@@ -356,6 +356,54 @@ async fn update_rejects_an_engine_change_before_editing_the_file() {
 
     assert_eq!(err.code(), "ENGINE_RESTART_REQUIRED");
     assert_eq!(std::fs::read_to_string(file).unwrap(), changed);
+}
+
+#[tokio::test]
+async fn update_accepts_multiple_unchanged_package_workers() {
+    let containers = concat!(
+        "  state:\n    worker: package://api.workers.iii.dev/state\n    version: '1.0.0'\n",
+        "  cache:\n    worker: package://api.workers.iii.dev/cache\n    version: '2.0.0'\n",
+    );
+    let (_tmp, file, daemon) = managed_mutation_fixture(containers);
+    let original = std::fs::read_to_string(&file).unwrap();
+
+    let outcome = daemon
+        .update(
+            Some(&file),
+            &["state@1.0.0".to_string(), "cache@2.0.0".to_string()],
+            "batch-update-unchanged".to_string(),
+        )
+        .await
+        .expect("the batch should succeed");
+    let outcome = serde_json::to_value(outcome).unwrap();
+
+    assert_eq!(outcome["status"], "ok");
+    assert_eq!(outcome["changed"], false);
+    assert_eq!(outcome["worker"], "state");
+    assert_eq!(outcome["workers"], serde_json::json!(["state", "cache"]));
+    assert_eq!(std::fs::read_to_string(file).unwrap(), original);
+}
+
+#[tokio::test]
+async fn update_rejects_the_batch_before_editing_when_one_worker_is_not_a_package() {
+    let containers = concat!(
+        "  state:\n    worker: package://api.workers.iii.dev/state\n    version: '1.0.0'\n",
+        "  api:\n    worker: path://./workers/api\n",
+    );
+    let (_tmp, file, daemon) = managed_mutation_fixture(containers);
+    let original = std::fs::read_to_string(&file).unwrap();
+
+    let err = daemon
+        .update(
+            Some(&file),
+            &["state@2.0.0".to_string(), "api@2.0.0".to_string()],
+            "batch-update-invalid".to_string(),
+        )
+        .await
+        .expect_err("the path worker should reject the whole batch");
+
+    assert_eq!(err.code(), "NOT_A_PACKAGE_CONTAINER");
+    assert_eq!(std::fs::read_to_string(file).unwrap(), original);
 }
 
 #[tokio::test]

--- a/crates/iii-compose/tests/project_cache.rs
+++ b/crates/iii-compose/tests/project_cache.rs
@@ -370,7 +370,7 @@ async fn remove_rejects_an_engine_change_before_editing_the_file() {
     let err = daemon
         .remove(
             Some(&file),
-            Some("api"),
+            &["api".to_string()],
             "remove-after-engine-change".to_string(),
         )
         .await
@@ -391,12 +391,34 @@ async fn remove_validates_the_edited_file_before_writing_it() {
     let err = daemon
         .remove(
             Some(&file),
-            Some("api"),
+            &["api".to_string()],
             "remove-only-container".to_string(),
         )
         .await
         .expect_err("remove must reject an empty edited project");
 
     assert_eq!(err.code(), "EMPTY_CONTAINERS");
+    assert_eq!(std::fs::read_to_string(file).unwrap(), before);
+}
+
+#[tokio::test]
+async fn remove_validates_every_worker_before_writing_the_batch() {
+    let containers = concat!(
+        "  api:\n    worker: path://./workers/api\n",
+        "  extra:\n    worker: path://./workers/extra\n",
+    );
+    let (_tmp, file, daemon) = managed_mutation_fixture(containers);
+    let before = std::fs::read_to_string(&file).unwrap();
+
+    let err = daemon
+        .remove(
+            Some(&file),
+            &["api".to_string(), "missing".to_string()],
+            "remove-invalid-batch".to_string(),
+        )
+        .await
+        .expect_err("an unknown worker must reject the complete removal batch");
+
+    assert_eq!(err.code(), "UNKNOWN_CONTAINER");
     assert_eq!(std::fs::read_to_string(file).unwrap(), before);
 }

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -725,7 +725,7 @@ async fn add_starts_a_managed_project_declared_with_null_containers() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn update_publishes_a_terminal_observable_operation() {
+async fn update_accepts_multiple_workers_and_publishes_one_terminal_operation() {
     isolate_state();
     let port = spawn_engine().await;
     let daemon = start_daemon(port).await;
@@ -739,6 +739,9 @@ containers:
   state:
     worker: package://api.workers.iii.dev/state
     version: "1.2.3"
+  cache:
+    worker: package://api.workers.iii.dev/cache
+    version: "2.3.4"
 "#,
         &[],
     );
@@ -751,7 +754,7 @@ containers:
         "compose::update",
         json!({
             "file": file.to_str().unwrap(),
-            "worker": "state@1.2.3",
+            "workers": ["state@1.2.3", "cache@2.3.4"],
             "operation_id": operation_id,
         }),
     )
@@ -759,7 +762,7 @@ containers:
     .expect("compose::update should answer");
 
     assert_eq!(result["status"], "accepted", "{result}");
-    assert_eq!(result["requested"], 1, "{result}");
+    assert_eq!(result["requested"], 2, "{result}");
     assert_eq!(result["operation_id"], operation_id, "{result}");
     let (event, metadata) = tokio::time::timeout(Duration::from_secs(15), events.recv())
         .await
@@ -770,6 +773,7 @@ containers:
     assert_eq!(metadata, Some(json!({ "__binding": "e2e-binding" })));
     let operation = wait_for_operation(port, None, &operation_id).await;
     assert_eq!(operation["status"], "succeeded", "{operation}");
+    assert_eq!(operation["requested"], 2, "{operation}");
 
     trigger.unregister();
     observer.shutdown_async().await;

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -21,8 +21,9 @@ use iii_compose::{
     daemon::{Daemon, EnginePolicy},
     remote,
 };
-use iii_sdk::protocol::TriggerRequest;
-use iii_sdk::{InitOptions, RegisterFunction, register_worker};
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::triggers::Trigger;
+use iii_sdk::{IIIClient, InitOptions, RegisterFunction, register_worker};
 use serde_json::{Value, json};
 use tokio::net::TcpListener;
 
@@ -220,6 +221,53 @@ async fn wait_for_operation(port: u16, namespace: Option<&str>, operation_id: &s
     })
     .await
     .unwrap_or_else(|_| panic!("operation {operation_id} did not finish"))
+}
+
+async fn subscribe_to_terminal_operation(
+    port: u16,
+    operation_id: &str,
+) -> (
+    IIIClient,
+    Trigger,
+    tokio::sync::mpsc::UnboundedReceiver<(Value, Option<Value>)>,
+) {
+    let observer = register_worker(
+        &format!("ws://127.0.0.1:{port}"),
+        InitOptions {
+            metadata: Some(iii_sdk::iii::WorkerMetadata {
+                name: format!("operation-observer-{}", uuid::Uuid::new_v4()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    );
+    let callback_id = format!("test::compose-operation::{}", uuid::Uuid::new_v4());
+    let (events_tx, events_rx) = tokio::sync::mpsc::unbounded_channel();
+    observer.register_function(
+        callback_id.clone(),
+        RegisterFunction::new_async(move |event: Value, metadata: Option<Value>| {
+            let events_tx = events_tx.clone();
+            async move {
+                let _ = events_tx.send((event, metadata));
+                Ok(Value::Null)
+            }
+        }),
+    );
+    let trigger = observer
+        .register_trigger(
+            RegisterTriggerInput::new(
+                "compose-operation",
+                callback_id,
+                json!({
+                    "operation_id": operation_id,
+                    "terminal_only": true,
+                }),
+            )
+            .with_metadata(json!({ "__binding": "e2e-binding" })),
+        )
+        .expect("register compose-operation trigger");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    (observer, trigger, events_rx)
 }
 
 fn operation_containers(operation: &Value) -> Vec<&str> {
@@ -677,6 +725,58 @@ async fn add_starts_a_managed_project_declared_with_null_containers() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn update_publishes_a_terminal_observable_operation() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: update
+containers:
+  state:
+    worker: package://api.workers.iii.dev/state
+    version: "1.2.3"
+"#,
+        &[],
+    );
+    let operation_id = format!("compose:update-test:00000000-0000-0000-0000-{}", port);
+    let (observer, trigger, mut events) =
+        subscribe_to_terminal_operation(port, &operation_id).await;
+
+    let result = call(
+        port,
+        "compose::update",
+        json!({
+            "file": file.to_str().unwrap(),
+            "worker": "state@1.2.3",
+            "operation_id": operation_id,
+        }),
+    )
+    .await
+    .expect("compose::update should answer");
+
+    assert_eq!(result["status"], "accepted", "{result}");
+    assert_eq!(result["requested"], 1, "{result}");
+    assert_eq!(result["operation_id"], operation_id, "{result}");
+    let (event, metadata) = tokio::time::timeout(Duration::from_secs(15), events.recv())
+        .await
+        .expect("update terminal event timed out")
+        .expect("update terminal event channel closed");
+    assert_eq!(event["operation_id"], operation_id, "{event}");
+    assert_eq!(event["terminal"], true, "{event}");
+    assert_eq!(metadata, Some(json!({ "__binding": "e2e-binding" })));
+    let operation = wait_for_operation(port, None, &operation_id).await;
+    assert_eq!(operation["status"], "succeeded", "{operation}");
+
+    trigger.unregister();
+    observer.shutdown_async().await;
+    daemon.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn remove_drops_dependency_edges_and_keeps_survivors_running() {
     isolate_state();
     let port = spawn_engine().await;
@@ -758,26 +858,39 @@ containers:
     let keep_pid = pid(&before, "keep");
     let discard_pid = pid(&before, "discard");
 
+    let operation_id = format!("compose:remove-test:00000000-0000-0000-0000-{}", port);
+    let (observer, trigger, mut events) =
+        subscribe_to_terminal_operation(port, &operation_id).await;
     let result = call(
         port,
         "compose::remove",
         json!({
             "file": file.to_str().unwrap(),
             "worker": "foundation",
+            "operation_id": operation_id,
         }),
     )
     .await
     .expect("compose::remove should answer");
 
-    assert_eq!(result["status"], "ok", "{result}");
-    assert_eq!(result["worker"], "foundation", "{result}");
-    assert_eq!(result["changed"], true, "{result}");
-    for internal in ["containers", "down", "restarted", "up", "operation_id"] {
+    assert_eq!(result["status"], "accepted", "{result}");
+    assert_eq!(result["requested"], 1, "{result}");
+    assert_eq!(result["operation_id"], operation_id, "{result}");
+    for internal in ["containers", "down", "restarted", "up", "changed", "worker"] {
         assert!(
             result.get(internal).is_none(),
             "mutation leaked {internal}: {result}"
         );
     }
+    let (event, metadata) = tokio::time::timeout(Duration::from_secs(15), events.recv())
+        .await
+        .expect("remove terminal event timed out")
+        .expect("remove terminal event channel closed");
+    assert_eq!(event["operation_id"], operation_id, "{event}");
+    assert_eq!(event["terminal"], true, "{event}");
+    assert_eq!(metadata, Some(json!({ "__binding": "e2e-binding" })));
+    let operation = wait_for_operation(port, None, &operation_id).await;
+    assert_eq!(operation["status"], "succeeded", "{operation}");
 
     let edited = std::fs::read_to_string(&file).expect("read edited compose file");
     assert!(
@@ -845,6 +958,8 @@ containers:
     foundation.shutdown_async().await;
     keep.shutdown_async().await;
     discard.shutdown_async().await;
+    trigger.unregister();
+    observer.shutdown_async().await;
     daemon.shutdown().await;
 }
 

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -266,7 +266,7 @@ async fn subscribe_to_terminal_operation(
             .with_metadata(json!({ "__binding": "e2e-binding" })),
         )
         .expect("register compose-operation trigger");
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(600)).await;
     (observer, trigger, events_rx)
 }
 

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -777,7 +777,7 @@ containers:
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn remove_drops_dependency_edges_and_keeps_survivors_running() {
+async fn remove_accepts_multiple_workers_and_keeps_survivors_running() {
     isolate_state();
     let port = spawn_engine().await;
     let daemon = start_daemon(port).await;
@@ -856,8 +856,6 @@ containers:
             .unwrap_or_else(|| panic!("missing pid for {key}: {status}"))
     };
     let keep_pid = pid(&before, "keep");
-    let discard_pid = pid(&before, "discard");
-
     let operation_id = format!("compose:remove-test:00000000-0000-0000-0000-{}", port);
     let (observer, trigger, mut events) =
         subscribe_to_terminal_operation(port, &operation_id).await;
@@ -866,7 +864,7 @@ containers:
         "compose::remove",
         json!({
             "file": file.to_str().unwrap(),
-            "worker": "foundation",
+            "workers": ["foundation", "discard"],
             "operation_id": operation_id,
         }),
     )
@@ -874,7 +872,7 @@ containers:
     .expect("compose::remove should answer");
 
     assert_eq!(result["status"], "accepted", "{result}");
-    assert_eq!(result["requested"], 1, "{result}");
+    assert_eq!(result["requested"], 2, "{result}");
     assert_eq!(result["operation_id"], operation_id, "{result}");
     for internal in ["containers", "down", "restarted", "up", "changed", "worker"] {
         assert!(
@@ -905,6 +903,10 @@ containers:
         !edited.contains("  foundation:"),
         "named worker survived: {edited}"
     );
+    assert!(
+        !edited.contains("  discard:"),
+        "second named worker survived: {edited}"
+    );
 
     let after = call(
         port,
@@ -918,18 +920,16 @@ containers:
         keep_pid,
         "dependent restarted: {after}"
     );
-    assert_eq!(
-        pid(&after, "discard"),
-        discard_pid,
-        "unrelated worker restarted: {after}"
-    );
     assert!(
         after["containers"]
             .as_array()
             .expect("containers")
             .iter()
-            .all(|container| container["container"] != "foundation"),
-        "removed worker remains declared: {after}"
+            .all(|container| !matches!(
+                container["container"].as_str(),
+                Some("foundation" | "discard")
+            )),
+        "removed workers remain declared: {after}"
     );
 
     let later_up = call(
@@ -953,7 +953,6 @@ containers:
     .await
     .expect("final status");
     assert_eq!(pid(&final_status, "keep"), keep_pid);
-    assert_eq!(pid(&final_status, "discard"), discard_pid);
 
     foundation.shutdown_async().await;
     keep.shutdown_async().await;


### PR DESCRIPTION
## Summary

Make Compose mutation completion observable and reliable for Harness-managed trigger bindings.

## Changes

- Forward trigger metadata when Compose publishes operation events, including the binding metadata required by Harness.
- Add terminal-only subscriptions so one-shot watches ignore intermediate progress.
- Return observable operation admissions from `compose::add`, `compose::update`, and `compose::remove`.
- Accept a caller-selected operation ID for race-free trigger registration.
- Let `compose::add`, `compose::update`, and `compose::remove` accept a canonical `workers` list while preserving the singular `worker` field.
- Validate update and removal batches before writing, then reconcile each batch once.
- Publish succeeded, failed, or cancelled terminal events for all three mutations.
- Report trigger delivery failures instead of discarding them.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p iii-compose --locked`
- `cargo test -p iii --test compose_daemon_e2e --locked`
- `cargo clippy -p iii-compose --all-targets --locked -- -D warnings`

## Companion change

The companion iii-hq/workers PR documents and uses the exact-operation-ID, terminal-only workflow, including batch updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update multiple workers in a single compose operation with one operation ID and completion event.
  * Compose add, update, and remove operations now return immediately with an accepted status and operation ID.
  * Track operation progress through terminal-only subscriptions and receive terminal completion events.
  * Remove multiple workers while keeping remaining workers running.
  * Removal results now report aggregated failures when requested workers cannot be stopped.

* **Bug Fixes**
  * Invalid batch updates and removals are rejected without changing the compose configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->