### PR TITLE
fix(engine): keep serving when the config hot-reload watcher cannot b…

### DIFF
--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -38,6 +38,54 @@ fn config_event_touches_path(changed_paths: &[PathBuf], configured_path: &Path) 
         .any(|changed| absolutize_path(changed) == configured)
 }
 
+/// Build a filesystem watcher that nudges `tx` whenever `path` is written.
+///
+/// Watches the parent directory so rename-based writes are caught (editors
+/// like vim write a temp file then rename it). For bare filenames like
+/// "config.yaml", `parent()` returns "" which is not a valid path — fall back
+/// to ".".
+fn start_config_file_watcher(
+    path: &str,
+    tx: tokio::sync::mpsc::Sender<()>,
+) -> anyhow::Result<notify::RecommendedWatcher> {
+    let watched_path = std::path::PathBuf::from(path);
+    let configured_path = absolutize_path(&watched_path);
+
+    let mut watcher = notify::RecommendedWatcher::new(
+        move |res: Result<notify::Event, notify::Error>| {
+            if let Ok(event) = res {
+                use notify::EventKind;
+                match event.kind {
+                    EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_)
+                        if config_event_touches_path(&event.paths, &configured_path) =>
+                    {
+                        let _ = tx.try_send(());
+                    }
+                    _ => {}
+                }
+            }
+        },
+        notify::Config::default(),
+    )
+    .map_err(|e| anyhow::anyhow!("failed to create config file watcher: {}", e))?;
+
+    let watch_target = watched_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(std::path::Path::new("."));
+    watcher
+        .watch(watch_target, notify::RecursiveMode::NonRecursive)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "failed to watch config directory '{}': {}",
+                watch_target.display(),
+                e
+            )
+        })?;
+
+    Ok(watcher)
+}
+
 fn absolutize_path(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| {
         if path.is_absolute() {
@@ -936,41 +984,27 @@ impl EngineBuilder {
         // coalesce rapid writes into a single reload.
         let (config_change_tx, mut config_change_rx) = tokio::sync::mpsc::channel::<()>(1);
 
-        // Keep the watcher alive for the duration of serve().
+        // Keep the watcher alive for the duration of serve(). Hot-reload is a
+        // convenience, not a requirement: if the OS refuses to hand out a
+        // watcher (typically EMFILE from a shared host's per-user
+        // `fs.inotify.max_user_instances` cap, which no process rlimit can
+        // raise), log it and keep serving — the configuration worker's own
+        // adapter watcher already degrades the same way.
         let _watcher = if let Some(ref path) = config_path {
-            let tx = config_change_tx.clone();
-            let watched_path = std::path::PathBuf::from(path);
-            let configured_path = absolutize_path(&watched_path);
-
-            let mut watcher = notify::RecommendedWatcher::new(
-                move |res: Result<notify::Event, notify::Error>| {
-                    if let Ok(event) = res {
-                        use notify::EventKind;
-                        match event.kind {
-                            EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_)
-                                if config_event_touches_path(&event.paths, &configured_path) =>
-                            {
-                                let _ = tx.try_send(());
-                            }
-                            _ => {}
-                        }
-                    }
-                },
-                notify::Config::default(),
-            )?;
-
-            // Watch the parent directory so we catch rename-based writes
-            // (editors like vim write a temp file then rename it).
-            // For bare filenames like "config.yaml", parent() returns ""
-            // which is not a valid path — fall back to ".".
-            let watch_target = watched_path
-                .parent()
-                .filter(|p| !p.as_os_str().is_empty())
-                .unwrap_or(std::path::Path::new("."));
-            watcher.watch(watch_target, notify::RecursiveMode::NonRecursive)?;
-
-            tracing::info!("reload: watching {} for changes", path);
-            Some(watcher)
+            match start_config_file_watcher(path, config_change_tx.clone()) {
+                Ok(watcher) => {
+                    tracing::info!("reload: watching {} for changes", path);
+                    Some(watcher)
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        "reload: config file watcher unavailable; edits to {} will not hot-reload (restart to apply)",
+                        path
+                    );
+                    None
+                }
+            }
         } else {
             tracing::info!("reload: no config file to watch (running with in-memory config)");
             None


### PR DESCRIPTION

Creating the config.yaml inotify watcher in EngineBuilder::serve used `?`, so an EMFILE from the kernel's per-user fs.inotify.max_user_instances cap (shared across containers on a host; not raisable via rlimit) exited the engine after every worker had already booted. Log a warning and run without hot-reload instead, matching how the configuration worker's adapter watcher already degrades.

## What

Make the config.yaml hot-reload watcher in EngineBuilder::serve non-fatal. If the OS refuses to create or attach the watcher, the engine now logs a warning and keeps serving without hot-reload instead of exiting.

The watcher construction moves into a small module-level helper, start_config_file_watcher, which returns anyhow::Result<RecommendedWatcher> with the same error wording style as the configuration adapter's watcher (failed to create config file watcher: … / failed to watch config directory '…': …). serve matches on it:

Ok → unchanged: reload: watching <path> for changes
Err → WARN reload: config file watcher unavailable; edits to <path> will not hot-reload (restart to apply) with the underlying error attached, and _watcher is None.
No behaviour change on the happy path; the reload loop already handles None (that is the in-memory-config branch).

## Why

On shared hosts the per-user fs.inotify.max_user_instances cap (default 128) is pooled across every container running as the same uid on the node. When a neighbour exhausts it, inotify_init1 returns EMFILE and the engine exits at boot with a bare Error: Too many open files (os error 24), after every worker has already come up. No process rlimit can raise that cap (ours was 1048576/1048576), so the only recovery is waiting for the neighbour to let go, which is what we hit in production on iii 0.22.0.

The configuration worker's own fs-adapter watcher already treats the identical failure as a warning (Adapter watch failed; external edits will not fire triggers). This brings the config-file watcher in line with it: hot-reload is a convenience, not something the engine needs in order to serve.

## Notes

- Behaviour on failure is now the same as running with an in-memory config: edits to config.yaml need a restart. The warning says so.
- No new tests: reliably provoking EMFILE from inotify_init1 needs root to lower a sysctl, which does not fit the unit test setup. The refactor keeps the watcher body byte-for-byte apart from the error mapping, and cargo check / cargo fmt --check pass.
- Verified against the failure in production (Render, Linux x86_64) by reading the log sequence; the fix was reviewed but not deployed since we pin the release image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Engine startup now continues even if configuration file watching cannot be enabled.
  * Configuration hot-reload remains active when the watcher starts successfully, with clearer warnings when it cannot be configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->