### PR TITLE
feat(compose): restart policy for a container that exits after readiness

### DIFF
--- a/crates/iii-compose/src/config.rs
+++ b/crates/iii-compose/src/config.rs
@@ -22,7 +22,7 @@ use std::{
 
 use indexmap::IndexMap;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     dag,
@@ -96,6 +96,39 @@ impl Default for Scripts {
     }
 }
 
+/// What the supervisor does when a container that had become ready exits.
+///
+/// A run-time answer only. Whether a container that never became ready fails
+/// the operation that started it is [`Container::required`], and the two are
+/// deliberately separate: a policy that also covered the start would give one
+/// field two blast radii again, which is the thing `required` exists to fix.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema, PartialOrd, Ord,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum RestartPolicy {
+    /// Leave it down and take its transitive dependents with it. The default,
+    /// and what compose did before this field existed.
+    #[default]
+    No,
+    /// Restart it when it exited with a non-zero status.
+    OnFailure,
+    /// Restart it whenever it exits, a clean exit included. For a worker that
+    /// is only correct while it is running, exit code 0 is still an outage.
+    Always,
+}
+
+impl RestartPolicy {
+    /// Whether an exit with this status should be answered with a restart.
+    pub fn wants_restart(self, exit_code: i32) -> bool {
+        match self {
+            Self::No => false,
+            Self::OnFailure => exit_code != 0,
+            Self::Always => true,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Container {
     pub worker: WorkerSource,
@@ -136,6 +169,13 @@ pub struct Container {
     /// that waited on a non-required one starts as if it had come up. A
     /// dependent that genuinely needs it says so by failing on its own.
     pub required: bool,
+    /// What happens when this container exits after it was ready.
+    ///
+    /// `no` is the default and matches the behaviour this field was added to:
+    /// the exit takes the container's transitive dependents down with it and
+    /// nothing comes back until someone runs `up` again. Anything else asks the
+    /// supervisor to try again, with a backoff and a capped number of attempts.
+    pub restart: RestartPolicy,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -442,6 +482,7 @@ fn validate_container(
             .collect(),
         startup_timeout,
         required: raw.required,
+        restart: raw.restart,
     })
 }
 
@@ -749,6 +790,12 @@ struct RawContainer {
     #[serde(default = "required_by_default")]
     #[schemars(default = "required_by_default")]
     required: bool,
+    /// Absent means `no`: a file written before this field existed keeps the
+    /// behaviour it was written against, which is that a ready container that
+    /// exits stays down.
+    #[serde(default)]
+    #[schemars(default)]
+    restart: RestartPolicy,
 }
 
 fn required_by_default() -> bool {

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -1014,6 +1014,10 @@ impl Daemon {
                         project.reconcile_after_reconnect().await;
                     }
                     project.reap_unexpected_exits().await;
+                    // After the reap, so a container that has just exited
+                    // spends its first attempt on the tick that noticed rather
+                    // than waiting for the next one.
+                    project.drive_restarts().await;
                 }
             }
         });

--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -46,7 +46,7 @@ pub mod spawn;
 pub mod state;
 
 pub use cli::{BuildCli, ComposeCli, ComposeCommand, ComposeLogsCli, ComposeSubcommand};
-pub use config::{ComposeFile, Container, EngineSpec, WorkerSource};
+pub use config::{ComposeFile, Container, EngineSpec, RestartPolicy, WorkerSource};
 pub use error::{ComposeError, Result};
 pub use manifest::{StartSpec, ValidationReport, VmSpec};
 

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -25,13 +25,16 @@ use std::{
     time::Duration,
 };
 
-use tokio::sync::{Mutex, RwLock};
+use tokio::{
+    sync::{Mutex, RwLock},
+    time::Instant,
+};
 
 use crate::{
-    config::ComposeFile,
+    config::{ComposeFile, RestartPolicy},
     engine::EngineClient,
     error::{ComposeError, Result},
-    lifecycle::{self, Children, LifecycleCtx, OpResult},
+    lifecycle::{self, Children, LifecycleCtx, OpResult, OpStatus},
     logs::{LogCursor, LogStore, LogStream, LogsOutcome},
     process::Supervised,
     state::{ChildStatus, DaemonState, Reconciliation, StateStore, reconcile},
@@ -56,12 +59,68 @@ pub struct Project {
     logs: LogStore,
     store: StateStore,
     inner: Mutex<Inner>,
+    /// Attempt bookkeeping for the containers the supervisor is currently
+    /// retrying, keyed by container.
+    ///
+    /// Deliberately not in [`DaemonState`], so not on disk. An attempt count
+    /// describes one supervisor's patience with one crash loop, and a daemon
+    /// that restarts re-reconciles from scratch: carrying the old count over
+    /// would let a project come back with its budget already spent.
+    restarts: Mutex<BTreeMap<String, RestartAttempts>>,
 }
 
 /// How often the supervisor checks whether a ready child is still alive.
 /// Fast enough that a crash is reported while the operator is still watching,
 /// slow enough that an idle project costs nothing.
 const SUPERVISION_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Wait before the second restart attempt. Each further attempt doubles it, up
+/// to [`RESTART_BACKOFF_MAX`]. The first attempt does not wait at all: a worker
+/// that died because of a transient is back before the operator looks up, and
+/// one that is genuinely broken has stopped being hammered within seconds.
+const RESTART_BACKOFF_BASE: Duration = Duration::from_millis(500);
+
+/// Ceiling on the wait between attempts. Past this, a longer backoff would only
+/// delay the operator's answer without giving the worker anything it needs.
+const RESTART_BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+/// Consecutive attempts before the supervisor gives up. On the last one it does
+/// what it would have done with no policy at all: fail the container and take
+/// its dependents down. A cap is what separates a restart policy from a busy
+/// loop.
+const RESTART_MAX_ATTEMPTS: u32 = 5;
+
+/// How long a container has to hold `Ready` before its attempt budget refills.
+/// Without it, a worker that crashes once an hour would spend five attempts
+/// over an afternoon and then never be restarted again, which is the opposite
+/// of what its file asked for.
+const RESTART_BUDGET_RESET_AFTER: Duration = Duration::from_secs(60);
+
+/// Where one container is in its restart budget.
+#[derive(Debug, Clone, Copy)]
+struct RestartAttempts {
+    /// Attempts already spent in this run of failures.
+    spent: u32,
+    /// When the next attempt becomes due, and `None` when none is owed — the
+    /// container came back, or an operator took it over. The supervision tick
+    /// is what makes an attempt due, so the backoff never blocks the loop.
+    ///
+    /// A container that is not owed an attempt still keeps its `spent` count.
+    /// Clearing it on every recovery would refill the budget for a worker that
+    /// comes back for a second each time, which is the busy loop wearing a
+    /// slower coat. Only [`Project::refill_budget_if_it_held`] clears it.
+    due: Option<Instant>,
+}
+
+impl RestartAttempts {
+    /// Backoff before the attempt after `spent` have been made: doubling from
+    /// [`RESTART_BACKOFF_BASE`], held at [`RESTART_BACKOFF_MAX`].
+    fn backoff(spent: u32) -> Duration {
+        RESTART_BACKOFF_BASE
+            .saturating_mul(2u32.saturating_pow(spent.saturating_sub(1)))
+            .min(RESTART_BACKOFF_MAX)
+    }
+}
 
 /// The parts that change together. One lock: a caller must never see the
 /// children and the records disagree.
@@ -116,6 +175,7 @@ impl Project {
                 children: BTreeMap::new(),
                 state,
             }),
+            restarts: Mutex::new(BTreeMap::new()),
         });
 
         project.reconcile_recovered().await;
@@ -234,33 +294,222 @@ impl Project {
                 Tone::Warn,
             );
 
-            // Cascade through the same path a targeted `down` takes: it stops
-            // the dependents first and ends on the dead container itself, which
-            // fires its `post_run` and drops it from the map. Leaving dependents
-            // running would leave them talking to something that is gone.
-            let file = self.file.read().await;
-            let dependents = crate::dag::transitive_dependents(&file, &key);
-            drop(file);
-            if !dependents.is_empty() {
-                daemon_line(
-                    &self.project_namespace,
-                    &format!("stopping what depended on {key}: {}", dependents.join(", ")),
-                    Tone::Warn,
-                );
+            // A container that asked to be restarted gets the first attempt
+            // immediately: its dependents stay up, and the exit only cascades
+            // once the budget below is spent.
+            if self.restart_policy(&key).await.wants_restart(code) {
+                self.refill_budget_if_it_held(&key).await;
+                if self.spend_attempt(&key).await {
+                    self.run_restart_attempt(&key).await;
+                    continue;
+                }
+                self.report_gave_up(&key).await;
+                self.cascade_failure(&key, Self::exhausted_reason()).await;
+                continue;
             }
-            self.down(Some(&key), format!("supervisor:{key}")).await;
 
-            // After the cascade, so `down` marking everything Stopped does not
-            // erase why this one went.
-            let mut inner = self.inner.lock().await;
-            if let Some(entry) = inner.state.containers.get_mut(&key) {
-                entry.status = ChildStatus::Failed;
-                entry.last_error = Some(reason);
-            }
-            let snapshot = inner.state.clone();
-            drop(inner);
-            let _ = self.store.save(&snapshot);
+            self.cascade_failure(&key, reason).await;
         }
+    }
+
+    /// Takes the attempts that came due since the last tick.
+    ///
+    /// The waiting happens here rather than in [`Self::run_restart_attempt`] so
+    /// a backoff never blocks the supervision loop, and so a project whose
+    /// worker is in a crash loop does not stop the daemon noticing anything
+    /// else. The tick interval is the granularity of the backoff.
+    pub(crate) async fn drive_restarts(&self) {
+        let now = Instant::now();
+        let due: Vec<String> = {
+            let attempts = self.restarts.lock().await;
+            attempts
+                .iter()
+                .filter(|(_, attempt)| attempt.due.is_some_and(|due| due <= now))
+                .map(|(key, _)| key.clone())
+                .collect()
+        };
+
+        for key in due {
+            // An operator who ran `up` or `restart` in the meantime has taken
+            // the container back, and the supervisor stops competing for it.
+            // The spent count stays: the operator changed who is driving, not
+            // whether this container has been crashing.
+            let still_waiting = {
+                let inner = self.inner.lock().await;
+                inner
+                    .state
+                    .containers
+                    .get(&key)
+                    .is_some_and(|record| record.status == ChildStatus::Restarting)
+            };
+            if !still_waiting {
+                if let Some(attempt) = self.restarts.lock().await.get_mut(&key) {
+                    attempt.due = None;
+                }
+                continue;
+            }
+
+            if self.spend_attempt(&key).await {
+                self.run_restart_attempt(&key).await;
+                continue;
+            }
+
+            self.report_gave_up(&key).await;
+            self.cascade_failure(&key, Self::exhausted_reason()).await;
+        }
+    }
+
+    /// One attempt: the same stop-then-start that `compose::restart` performs,
+    /// so a supervised restart and an operator's restart are the same act and
+    /// cannot drift apart. It also means the attempt inherits the rule that a
+    /// restart touches one container and not a graph, which is what keeps the
+    /// dependents up while this one is gone.
+    async fn run_restart_attempt(&self, key: &str) {
+        let spent = self
+            .restarts
+            .lock()
+            .await
+            .get(key)
+            .map_or(1, |attempt| attempt.spent);
+        daemon_line(
+            &self.project_namespace,
+            &format!("restarting {key} (attempt {spent} of {RESTART_MAX_ATTEMPTS})"),
+            Tone::Warn,
+        );
+
+        // Written before the start so a `compose::status` racing the attempt
+        // says `restarting` rather than the `failed` this is trying to undo.
+        self.mark(key, ChildStatus::Restarting, None).await;
+
+        let result = self.restart_one(key, format!("supervisor:{key}")).await;
+        if result.status == OpStatus::Ok {
+            // The record is already `Ready` and nothing more is owed. The spent
+            // count survives, so a worker that comes back for a moment each
+            // time still runs out of attempts.
+            if let Some(attempt) = self.restarts.lock().await.get_mut(key) {
+                attempt.due = None;
+            }
+            return;
+        }
+
+        // Only wait if there is something to wait for. Backing off after the
+        // last attempt would hold the container in `restarting` for a wait
+        // nobody is going to use, and delay the operator's answer by it.
+        let exhausted = {
+            let mut attempts = self.restarts.lock().await;
+            match attempts.get_mut(key) {
+                Some(attempt) if attempt.spent < RESTART_MAX_ATTEMPTS => {
+                    attempt.due = Some(Instant::now() + RestartAttempts::backoff(attempt.spent));
+                    false
+                }
+                _ => true,
+            }
+        };
+
+        if exhausted {
+            self.report_gave_up(key).await;
+            self.cascade_failure(key, Self::exhausted_reason()).await;
+        } else {
+            self.mark(key, ChildStatus::Restarting, None).await;
+        }
+    }
+
+    /// Fails the container and takes its transitive dependents with it: what
+    /// compose did for every unexpected exit before there was a policy, and
+    /// what it still does once one has run out of attempts.
+    async fn cascade_failure(&self, key: &str, reason: String) {
+        self.restarts.lock().await.remove(key);
+
+        // Cascade through the same path a targeted `down` takes: it stops
+        // the dependents first and ends on the dead container itself, which
+        // fires its `post_run` and drops it from the map. Leaving dependents
+        // running would leave them talking to something that is gone.
+        let file = self.file.read().await;
+        let dependents = crate::dag::transitive_dependents(&file, key);
+        drop(file);
+        if !dependents.is_empty() {
+            daemon_line(
+                &self.project_namespace,
+                &format!("stopping what depended on {key}: {}", dependents.join(", ")),
+                Tone::Warn,
+            );
+        }
+        self.down(Some(key), format!("supervisor:{key}")).await;
+
+        // After the cascade, so `down` marking everything Stopped does not
+        // erase why this one went.
+        self.mark(key, ChildStatus::Failed, Some(reason)).await;
+    }
+
+    /// This container's declared answer to exiting after it was ready. A
+    /// container the file no longer declares gets `no`, matching `is_required`:
+    /// the rule that stops is the one to fall back on.
+    async fn restart_policy(&self, key: &str) -> RestartPolicy {
+        self.file
+            .read()
+            .await
+            .containers
+            .get(key)
+            .map_or(RestartPolicy::No, |container| container.restart)
+    }
+
+    /// Takes one attempt from the budget. `false` means it is spent, which is
+    /// the supervisor's cue to stop and let the failure cascade.
+    async fn spend_attempt(&self, key: &str) -> bool {
+        let mut attempts = self.restarts.lock().await;
+        let attempt = attempts.entry(key.to_string()).or_insert(RestartAttempts {
+            spent: 0,
+            due: None,
+        });
+        if attempt.spent >= RESTART_MAX_ATTEMPTS {
+            return false;
+        }
+        attempt.spent += 1;
+        true
+    }
+
+    /// Refills the budget of a container that had held ready long enough to
+    /// count as recovered, so this crash starts a new run of failures rather
+    /// than continuing one the container already came back from.
+    async fn refill_budget_if_it_held(&self, key: &str) {
+        let held_for = {
+            let inner = self.inner.lock().await;
+            inner
+                .state
+                .containers
+                .get(key)
+                .map_or(0, |record| seconds_since(record.started_at))
+        };
+        if held_for >= RESTART_BUDGET_RESET_AFTER.as_secs() {
+            self.restarts.lock().await.remove(key);
+        }
+    }
+
+    fn exhausted_reason() -> String {
+        format!("did not stay up after {RESTART_MAX_ATTEMPTS} restart attempts")
+    }
+
+    async fn report_gave_up(&self, key: &str) {
+        daemon_line(
+            &self.project_namespace,
+            &format!("{key} {}: giving up", Self::exhausted_reason()),
+            Tone::Warn,
+        );
+    }
+
+    /// Writes a container's status and persists it on the same path, which is
+    /// the rule the whole module is built on.
+    async fn mark(&self, key: &str, status: ChildStatus, last_error: Option<String>) {
+        let mut inner = self.inner.lock().await;
+        if let Some(entry) = inner.state.containers.get_mut(key) {
+            entry.status = status;
+            if last_error.is_some() {
+                entry.last_error = last_error;
+            }
+        }
+        let snapshot = inner.state.clone();
+        drop(inner);
+        let _ = self.store.save(&snapshot);
     }
 
     /// Fatal registration rejection, if the engine refused this daemon —
@@ -833,6 +1082,15 @@ pub struct ContainerStatus {
     pub last_error: Option<String>,
 }
 
+/// How long ago a `started_at` was, in seconds. Saturating, so a clock that
+/// went backwards reads as "just now" rather than as a very old container.
+fn seconds_since(unix_secs: u64) -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|now| now.as_secs().saturating_sub(unix_secs))
+        .unwrap_or_default()
+}
+
 /// Severity of a project log line. Amber means "look at this", not "it broke".
 enum Tone {
     Plain,
@@ -848,5 +1106,42 @@ fn daemon_line(id: &str, message: &str, tone: Tone) {
     match tone {
         Tone::Plain => crate::report::line(&format!("{prefix} {message}")),
         Tone::Warn => crate::report::line(&format!("{prefix} {}", message.yellow())),
+    }
+}
+
+#[cfg(test)]
+mod restart_backoff_tests {
+    use super::{RESTART_BACKOFF_BASE, RESTART_BACKOFF_MAX, RESTART_MAX_ATTEMPTS, RestartAttempts};
+
+    /// The wait doubles per attempt and then stops doubling. A ceiling the
+    /// budget can never reach would be a ceiling in name only, so this pins
+    /// both halves.
+    #[test]
+    fn backoff_doubles_and_then_holds_at_the_ceiling() {
+        assert_eq!(RestartAttempts::backoff(1), RESTART_BACKOFF_BASE);
+        assert_eq!(RestartAttempts::backoff(2), RESTART_BACKOFF_BASE * 2);
+        assert_eq!(RestartAttempts::backoff(3), RESTART_BACKOFF_BASE * 4);
+        assert_eq!(
+            RestartAttempts::backoff(30),
+            RESTART_BACKOFF_MAX,
+            "a long-running loop must not overflow into an unbounded wait"
+        );
+    }
+
+    /// Without a cap the policy is a busy loop, which is what the issue this
+    /// field came from was written to avoid.
+    #[test]
+    fn the_budget_is_spent_in_bounded_time() {
+        let total: std::time::Duration = (1..=RESTART_MAX_ATTEMPTS)
+            .map(RestartAttempts::backoff)
+            .sum();
+        assert!(
+            total <= RESTART_BACKOFF_MAX * RESTART_MAX_ATTEMPTS,
+            "every attempt waits at most the ceiling"
+        );
+        assert!(
+            total >= RESTART_BACKOFF_BASE,
+            "attempts after the first always wait"
+        );
     }
 }

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -663,7 +663,9 @@ fn op_description(function_id: &str) -> &'static str {
         "compose::list" => "List every project loaded by this compose daemon.",
         "compose::status" => {
             "Report the project namespace, state directory, daemon pid, and \
-             current state of every declared container."
+             current state of every declared container. A container declaring \
+             a 'restart' policy reports as 'restarting' while it waits for the \
+             supervisor's next attempt."
         }
         "compose::logs" => {
             "Read bounded worker stdout and stderr. A cursor continues from the last response; \

--- a/crates/iii-compose/src/state.rs
+++ b/crates/iii-compose/src/state.rs
@@ -64,6 +64,12 @@ pub enum ChildStatus {
     Starting,
     /// Registered in the engine under `(namespace, container)`.
     Ready,
+    /// Exited after it was ready, declared a `restart` policy, and is inside
+    /// the wait before the supervisor's next attempt. Nothing is running under
+    /// this name right now, which is what separates it from `Ready`, and the
+    /// supervisor has not given up on it, which is what separates it from
+    /// `Failed`.
+    Restarting,
     /// Exited unexpectedly, or a hook failed.
     Failed,
     /// Stopped on purpose by this daemon.

--- a/crates/iii-compose/tests/config_validation.rs
+++ b/crates/iii-compose/tests/config_validation.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use iii_compose::ComposeFile;
+use iii_compose::{ComposeFile, RestartPolicy};
 
 fn parse(text: &str) -> Result<ComposeFile, iii_compose::ComposeError> {
     ComposeFile::parse(text, PathBuf::from("/srv/app/worker-compose.yaml"))
@@ -600,6 +600,78 @@ containers:
         ),
         "INVALID_COMPOSE_FILE"
     );
+}
+
+/// A file written before the field existed keeps the behaviour it was written
+/// against, which is that a ready container that exits stays down.
+///
+/// `no` is spelled unquoted on purpose. YAML 1.1 reads it as `false`, and a
+/// parser that agreed would turn the default spelling into a type error the
+/// first time anyone wrote it out.
+#[test]
+fn restart_defaults_to_no_and_is_declared_per_container() {
+    let file = parse(
+        r#"
+namespace: orders
+containers:
+  api:
+    worker: path://./workers/api
+  mailer:
+    worker: path://./workers/mailer
+    restart: on-failure
+  clock:
+    worker: path://./workers/clock
+    restart: always
+  batch:
+    worker: path://./workers/batch
+    restart: no
+"#,
+    )
+    .expect("restart is part of the container schema");
+
+    assert_eq!(
+        file.containers["api"].restart,
+        RestartPolicy::No,
+        "a container that says nothing keeps the old behaviour"
+    );
+    assert_eq!(file.containers["mailer"].restart, RestartPolicy::OnFailure);
+    assert_eq!(file.containers["clock"].restart, RestartPolicy::Always);
+    assert_eq!(
+        file.containers["batch"].restart,
+        RestartPolicy::No,
+        "an unquoted `no` is the policy, not the boolean false"
+    );
+}
+
+#[test]
+fn rejects_an_unknown_restart_policy() {
+    assert_eq!(
+        code(
+            r#"
+namespace: orders
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    restart: unless-stopped
+"#
+        ),
+        "INVALID_COMPOSE_FILE"
+    );
+}
+
+/// The policies differ only on a clean exit. `on-failure` treats exit 0 as the
+/// worker having finished; `always` treats it as an outage either way.
+#[test]
+fn restart_policies_differ_only_on_a_clean_exit() {
+    assert!(!RestartPolicy::No.wants_restart(1));
+    assert!(!RestartPolicy::No.wants_restart(0));
+
+    assert!(RestartPolicy::OnFailure.wants_restart(1));
+    assert!(RestartPolicy::OnFailure.wants_restart(-1));
+    assert!(!RestartPolicy::OnFailure.wants_restart(0));
+
+    assert!(RestartPolicy::Always.wants_restart(1));
+    assert!(RestartPolicy::Always.wants_restart(0));
 }
 
 #[test]

--- a/docs/next/understanding-iii/compose.mdx
+++ b/docs/next/understanding-iii/compose.mdx
@@ -196,12 +196,48 @@ That moves what `status: ok` means. It used to say every planned container is up
 required one is, so the return names the rest in `not_required_failures` rather than leaving a
 caller to compare the plan against a later status call.
 
-The field answers the start-time question and only that one. Once a container is ready, the
-supervisor still takes its transitive dependents down when it exits, whatever the container
-declared, and a project still cannot ask for a dead container to be restarted, because there is no
-restart policy at all. So the two blast radii have narrowed rather than met. The property worth
-keeping is that the answer reads the same at start time and at run time, and the run-time half is
-the restart policy that does not exist yet.
+The field answers the start-time question and only that one. What happens once a container is ready
+is a second question, and it has its own field.
+
+### The run-time half
+
+A container declares what the supervisor does when it exits after it was ready:
+
+```yaml
+containers:
+  api:
+    worker: path://./workers/api
+    restart: on-failure
+```
+
+`no` is the default and the behaviour above: the exit takes the container's transitive dependents
+with it and nothing comes back until someone runs `up` again. `on-failure` asks for a restart when
+the exit status was non-zero. `always` asks for one whatever the status, which is the answer for a
+worker that is only correct while it is running, where exiting cleanly is still an outage.
+
+A supervised restart is the same act as `compose::restart`: one container stops and starts, and the
+graph around it is left alone. So its dependents stay up while it is gone. That is the reasoning
+`required: false` already uses: `start_after` is a start order rather than a claim that the
+dependent cannot run without it. What that costs is a dependent holding a connection that drops and
+has to reconnect, which is the cost the file asked for by declaring a policy at all.
+
+Attempts are capped at five, and each one waits longer than the last, from 500ms up to a ceiling of
+30 seconds. Both halves are load-bearing: a policy with no backoff turns a crash loop into a busy
+loop, and a policy with no cap never lets the operator find out. A container that holds ready for a
+minute has recovered, so its budget refills. A worker that crashes once an hour is therefore
+restarted every time, rather than five times ever.
+
+When the budget runs out the supervisor does what it would have done with no policy at all. It fails
+the container, takes its dependents down, and says which in the log. That is the shape worth
+keeping: `restart` changes how many times compose tries, and never what happens when trying is over.
+
+`compose::status` reports a container waiting on its next attempt as `restarting`. It is not
+`ready`, because nothing is running under that name, and not `failed`, because the supervisor has
+not given up on it.
+
+The policy is deliberately silent about a container that never became ready. That is the start-time
+question, and `required` already answers it. Keeping them apart is what stops one field from
+carrying two blast radii again, which is the thing this whole section exists to fix.
 
 ## Related
 

--- a/docs/next/understanding-iii/compose.mdx.skill.md
+++ b/docs/next/understanding-iii/compose.mdx.skill.md
@@ -192,12 +192,48 @@ That moves what `status: ok` means. It used to say every planned container is up
 required one is, so the return names the rest in `not_required_failures` rather than leaving a
 caller to compare the plan against a later status call.
 
-The field answers the start-time question and only that one. Once a container is ready, the
-supervisor still takes its transitive dependents down when it exits, whatever the container
-declared, and a project still cannot ask for a dead container to be restarted, because there is no
-restart policy at all. So the two blast radii have narrowed rather than met. The property worth
-keeping is that the answer reads the same at start time and at run time, and the run-time half is
-the restart policy that does not exist yet.
+The field answers the start-time question and only that one. What happens once a container is ready
+is a second question, and it has its own field.
+
+### The run-time half
+
+A container declares what the supervisor does when it exits after it was ready:
+
+```yaml
+containers:
+  api:
+    worker: path://./workers/api
+    restart: on-failure
+```
+
+`no` is the default and the behaviour above: the exit takes the container's transitive dependents
+with it and nothing comes back until someone runs `up` again. `on-failure` asks for a restart when
+the exit status was non-zero. `always` asks for one whatever the status, which is the answer for a
+worker that is only correct while it is running, where exiting cleanly is still an outage.
+
+A supervised restart is the same act as `compose::restart`: one container stops and starts, and the
+graph around it is left alone. So its dependents stay up while it is gone. That is the reasoning
+`required: false` already uses: `start_after` is a start order rather than a claim that the
+dependent cannot run without it. What that costs is a dependent holding a connection that drops and
+has to reconnect, which is the cost the file asked for by declaring a policy at all.
+
+Attempts are capped at five, and each one waits longer than the last, from 500ms up to a ceiling of
+30 seconds. Both halves are load-bearing: a policy with no backoff turns a crash loop into a busy
+loop, and a policy with no cap never lets the operator find out. A container that holds ready for a
+minute has recovered, so its budget refills. A worker that crashes once an hour is therefore
+restarted every time, rather than five times ever.
+
+When the budget runs out the supervisor does what it would have done with no policy at all. It fails
+the container, takes its dependents down, and says which in the log. That is the shape worth
+keeping: `restart` changes how many times compose tries, and never what happens when trying is over.
+
+`compose::status` reports a container waiting on its next attempt as `restarting`. It is not
+`ready`, because nothing is running under that name, and not `failed`, because the supervisor has
+not given up on it.
+
+The policy is deliberately silent about a container that never became ready. That is the start-time
+question, and `required` already answers it. Keeping them apart is what stops one field from
+carrying two blast radii again, which is the thing this whole section exists to fix.
 
 ## Related
 

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -177,6 +177,31 @@ not a claim that the dependent cannot run without it. The response lists every w
 this way in `not_required_failures`, so an `ok` still says which workers are down, and `error`
 carries the first reason.
 
+#### Restarting a worker that exits
+
+A worker that exits after it was ready takes its dependents down with it and stays down. To ask for
+it back instead, declare a restart policy:
+
+```yaml
+containers:
+  api:
+    worker: path://./workers/api
+    restart: on-failure
+```
+
+`no` is the default. `on-failure` restarts the worker when it exited with a non-zero status, and
+`always` restarts it whatever the status.
+
+The supervisor tries five times, waiting longer before each attempt, from 500ms up to 30 seconds.
+Only the named worker bounces: workers that name it in `start_after` keep running and see their
+connection drop and reconnect. `compose::status` reports the worker as `restarting` while it waits
+for the next attempt. Once the five are spent, the worker is marked `failed`, its dependents are
+stopped, and `last_error` says the supervisor gave up. A worker that stays ready for a minute counts
+as recovered, so its next crash starts the five over.
+
+The policy covers exits only. A worker that never becomes ready in the first place is `required`'s
+question, not this one.
+
 ### Stopping a project
 
 `compose::down` stops the project in reverse dependency order.
@@ -468,6 +493,7 @@ Each key under `containers` is the name the worker registers under.
 | `env_file`        | array of paths | empty                | Read at start time, in declaration order. A later file wins on conflicting entries.                        |
 | `startup_timeout` | string         | the file's value     | Readiness budget for this worker.                                                                          |
 | `required`        | boolean        | `true`               | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
+| `restart`         | string         | `no`                 | What happens when the worker exits after it was ready. `no`, `on-failure`, or `always`.                    |
 | `scripts`         | mapping        | absent               | See below.                                                                                                 |
 
 `path://` directories resolve against the compose file's directory. A missing directory fails with

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -171,6 +171,31 @@ not a claim that the dependent cannot run without it. The response lists every w
 this way in `not_required_failures`, so an `ok` still says which workers are down, and `error`
 carries the first reason.
 
+#### Restarting a worker that exits
+
+A worker that exits after it was ready takes its dependents down with it and stays down. To ask for
+it back instead, declare a restart policy:
+
+```yaml
+containers:
+  api:
+    worker: path://./workers/api
+    restart: on-failure
+```
+
+`no` is the default. `on-failure` restarts the worker when it exited with a non-zero status, and
+`always` restarts it whatever the status.
+
+The supervisor tries five times, waiting longer before each attempt, from 500ms up to 30 seconds.
+Only the named worker bounces: workers that name it in `start_after` keep running and see their
+connection drop and reconnect. `compose::status` reports the worker as `restarting` while it waits
+for the next attempt. Once the five are spent, the worker is marked `failed`, its dependents are
+stopped, and `last_error` says the supervisor gave up. A worker that stays ready for a minute counts
+as recovered, so its next crash starts the five over.
+
+The policy covers exits only. A worker that never becomes ready in the first place is `required`'s
+question, not this one.
+
 ### Stopping a project
 
 `compose::down` stops the project in reverse dependency order.
@@ -462,6 +487,7 @@ Each key under `containers` is the name the worker registers under.
 | `env_file`        | array of paths | empty                | Read at start time, in declaration order. A later file wins on conflicting entries.                        |
 | `startup_timeout` | string         | the file's value     | Readiness budget for this worker.                                                                          |
 | `required`        | boolean        | `true`               | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
+| `restart`         | string         | `no`                 | What happens when the worker exits after it was ready. `no`, `on-failure`, or `always`.                    |
 | `scripts`         | mapping        | absent               | See below.                                                                                                 |
 
 `path://` directories resolve against the compose file's directory. A missing directory fails with

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -187,6 +187,60 @@ async fn wait_for_start_markers(paths: &[&std::path::Path]) {
     .expect("children did not reach their start barriers");
 }
 
+/// Waits until a child has recorded at least `wanted` incarnations.
+///
+/// One line per start, so the count is how many times the supervisor has
+/// spawned the container rather than how many times it crashed.
+async fn wait_for_attempts(path: &std::path::Path, wanted: usize) {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let seen = std::fs::read_to_string(path)
+                .map(|text| text.lines().count())
+                .unwrap_or(0);
+            if seen >= wanted {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("{} did not reach {wanted} starts", path.display()));
+}
+
+/// Waits until `compose::status` reports a container in `wanted`.
+///
+/// The engine seeing a registration and compose having recorded the container
+/// as ready are two different facts, and a supervised restart is where they
+/// come apart: the replacement registers a moment before the start that is
+/// waiting on it returns.
+async fn wait_for_container_state(port: u16, file: &std::path::Path, key: &str, wanted: &str) {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let status = call(
+                port,
+                "compose::status",
+                json!({ "file": file.to_str().unwrap() }),
+            )
+            .await
+            .expect("compose::status should answer");
+            let seen = status["containers"]
+                .as_array()
+                .and_then(|containers| {
+                    containers
+                        .iter()
+                        .find(|container| container["container"] == key)
+                })
+                .map(|container| container["state"].clone());
+            if seen.as_ref().and_then(|state| state.as_str()) == Some(wanted) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("{key} did not reach state {wanted}"));
+}
+
 /// Waits for the engine to observe a worker registration or its removal.
 async fn wait_for_worker_state(daemon: &Daemon, namespace: &str, name: &str, registered: bool) {
     tokio::time::timeout(Duration::from_secs(15), async {
@@ -1015,6 +1069,214 @@ containers:
     );
 
     api.shutdown_async().await;
+    daemon.shutdown().await;
+}
+
+/// `restart: on-failure` answers the run-time half of the same question
+/// `required` answers at start time: a ready container that exits comes back
+/// instead of taking its dependents down with it.
+///
+/// The dependent staying up is the point. A restart is one container bouncing,
+/// so `web` sees its dependency drop and reconnect, which is the cost the file
+/// asked for by declaring the policy at all.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_ready_container_that_exits_is_restarted_and_its_dependent_stays_up() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let attempts = tmp.path().join("workers/api/attempts");
+    let die = tmp.path().join("workers/api/die");
+    let web_started = tmp.path().join("workers/web/started");
+
+    // `api` records every incarnation, then exits non-zero the moment `die`
+    // appears. It removes the file on its way out so the replacement survives
+    // and the test controls exactly how many times it crashes.
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: restarts
+startup_timeout: 5s
+stop_timeout: 100ms
+containers:
+  api:
+    worker: path://./workers/api
+    restart: on-failure
+    scripts:
+      run: "echo up >> attempts; while [ ! -f die ]; do sleep 0.05; done; rm -f die; exit 1"
+  web:
+    worker: path://./workers/web
+    start_after: [api]
+    scripts:
+      run: "touch started && sleep 30"
+"#,
+        &["api", "web"],
+    );
+
+    let up = call(
+        port,
+        "compose::up",
+        json!({ "file": file.to_str().unwrap() }),
+    );
+    let ready = async {
+        wait_for_start_markers(&[attempts.as_path()]).await;
+        let api = register_test_worker(port, "restarts", "api");
+        wait_for_worker_state(&daemon, "restarts", "api", true).await;
+        wait_for_start_markers(&[web_started.as_path()]).await;
+        let web = register_test_worker(port, "restarts", "web");
+        wait_for_worker_state(&daemon, "restarts", "web", true).await;
+        (api, web)
+    };
+    let (up, (api, web)) = tokio::join!(up, ready);
+    let up = up.expect("compose::up should answer");
+    assert_eq!(up["status"], "ok", "the project should start: {up}");
+
+    // Kill the ready container. A real worker's registration dies with its
+    // process; here the test holds that identity, so it has to let go for the
+    // replacement to be able to take the name.
+    std::fs::write(&die, "").expect("ask api to exit");
+    api.shutdown_async().await;
+    wait_for_worker_state(&daemon, "restarts", "api", false).await;
+
+    // The supervisor spawns a replacement, which reaches the same barrier.
+    wait_for_attempts(&attempts, 2).await;
+    let api = register_test_worker(port, "restarts", "api");
+    wait_for_container_state(port, &file, "api", "ready").await;
+
+    let status = call(
+        port,
+        "compose::status",
+        json!({ "file": file.to_str().unwrap() }),
+    )
+    .await
+    .expect("status after a supervised restart");
+    let state = |key: &str| {
+        status["containers"]
+            .as_array()
+            .expect("containers")
+            .iter()
+            .find(|container| container["container"] == key)
+            .unwrap_or_else(|| panic!("missing {key}: {status}"))["state"]
+            .clone()
+    };
+    assert_eq!(
+        state("api"),
+        "ready",
+        "the restarted container should be ready again: {status}"
+    );
+    assert_eq!(
+        state("web"),
+        "ready",
+        "a restart must not cascade to dependents: {status}"
+    );
+
+    api.shutdown_async().await;
+    web.shutdown_async().await;
+    daemon.shutdown().await;
+}
+
+/// The cap is what separates a restart policy from a busy loop. Once it is
+/// spent the supervisor does what it would have done with no policy at all:
+/// fails the container and takes its dependents down.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_container_that_never_stays_up_exhausts_its_attempts_and_cascades() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let attempts = tmp.path().join("workers/api/attempts");
+    let die = tmp.path().join("workers/api/die");
+    let web_started = tmp.path().join("workers/web/started");
+
+    // Unlike the test above, `api` leaves `die` in place, so every replacement
+    // exits the moment it starts and none of them ever becomes ready.
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: exhausted
+startup_timeout: 2s
+stop_timeout: 100ms
+containers:
+  api:
+    worker: path://./workers/api
+    restart: on-failure
+    scripts:
+      run: "echo up >> attempts; while [ ! -f die ]; do sleep 0.05; done; exit 1"
+  web:
+    worker: path://./workers/web
+    start_after: [api]
+    scripts:
+      run: "touch started && sleep 30"
+"#,
+        &["api", "web"],
+    );
+
+    let up = call(
+        port,
+        "compose::up",
+        json!({ "file": file.to_str().unwrap() }),
+    );
+    let ready = async {
+        wait_for_start_markers(&[attempts.as_path()]).await;
+        let api = register_test_worker(port, "exhausted", "api");
+        wait_for_worker_state(&daemon, "exhausted", "api", true).await;
+        wait_for_start_markers(&[web_started.as_path()]).await;
+        let web = register_test_worker(port, "exhausted", "web");
+        wait_for_worker_state(&daemon, "exhausted", "web", true).await;
+        (api, web)
+    };
+    let (up, (api, web)) = tokio::join!(up, ready);
+    assert_eq!(
+        up.expect("compose::up should answer")["status"],
+        "ok",
+        "the project should start before anything crashes"
+    );
+
+    std::fs::write(&die, "").expect("ask api to exit");
+    api.shutdown_async().await;
+
+    // Every attempt is spent, and only then does the failure cascade.
+    wait_for_container_state(port, &file, "api", "failed").await;
+
+    let status = call(
+        port,
+        "compose::status",
+        json!({ "file": file.to_str().unwrap() }),
+    )
+    .await
+    .expect("status after the budget is spent");
+    let container = |key: &str| {
+        status["containers"]
+            .as_array()
+            .expect("containers")
+            .iter()
+            .find(|container| container["container"] == key)
+            .unwrap_or_else(|| panic!("missing {key}: {status}"))
+            .clone()
+    };
+    assert_ne!(
+        container("web")["state"],
+        "ready",
+        "a container that ran out of attempts must take its dependents down: {status}"
+    );
+    assert!(
+        container("api")["last_error"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("restart attempts")),
+        "the record should say the supervisor gave up: {status}"
+    );
+
+    let starts = std::fs::read_to_string(&attempts)
+        .map(|text| text.lines().count())
+        .unwrap_or(0);
+    assert_eq!(
+        starts, 6,
+        "one original start plus a capped five attempts, not a busy loop"
+    );
+
+    web.shutdown_async().await;
     daemon.shutdown().await;
 }
 


### PR DESCRIPTION
There was no restart policy. A container that exited after readiness took its transitive dependents down and stayed down, so any crash was permanent until someone ran `up` again.

A container now declares what the supervisor does when it exits:

    containers:
      api:
        worker: path://./workers/api
        restart: on-failure

`no` is the default and matches the previous behaviour. `on-failure` restarts on a non-zero exit; `always` restarts on any exit, for a worker that is only correct while it is running.

The decisions the issue asked for:

- Backoff doubles from 500ms to a 30s ceiling, and attempts are capped at five. Without both, the policy is a busy loop.
- The budget refills once a container has held ready for a minute, so a worker that crashes hourly is restarted every time rather than five times ever.
- Dependents stay up during the restart window. An attempt reuses `restart_one`, the same act `compose::restart` performs, which already bounces one container and leaves the graph alone. That is the rule `required: false` established: `start_after` is a start order, not a claim that the dependent cannot run without the dependency.
- When the budget runs out the supervisor does what it would have done with no policy at all: fails the container, cascades to its dependents, and records why in `last_error`.
- `ChildStatus::Restarting` is new, and `compose::status` reports it while a container waits for its next attempt. It is neither `ready`, because nothing is running under the name, nor `failed`, because the supervisor has not given up.
- The policy is silent about a container that never became ready. That is the start-time question and `required` answers it, so one field does not carry two blast radii again.

Attempt bookkeeping is in memory rather than in `DaemonState`: it describes one supervisor's patience with one crash loop, and a daemon that restarts re-reconciles from scratch. Waiting happens between supervision ticks, so a backoff never blocks the loop.

The e2e for the exhausted budget also covers the crash-cascade path, which had no integration test before.

Closes #2052

## What

<!-- Brief description of the change -->

## Why

<!-- Motivation or context -->

## Notes

<!-- Anything reviewers should know (breaking changes, migration steps, etc.) -->
