### PR TITLE
feat(compose): add optional containers and restart policies

### DIFF
--- a/crates/iii-compose/src/config.rs
+++ b/crates/iii-compose/src/config.rs
@@ -126,6 +126,19 @@ pub struct Container {
     pub env_file: Vec<PathBuf>,
     /// Readiness budget for this container: its own override, else the file's.
     pub startup_timeout: Duration,
+    /// Whether a failed start fails the operation that started it.
+    ///
+    /// `true` is the default and the rule everything else is written against:
+    /// an `up` that cannot start a declared container refuses and undoes
+    /// itself. `false` says the project would rather run without this one, so
+    /// the failure is reported against the container and the operation carries
+    /// on.
+    ///
+    /// Dependents carry on too. `start_after` is a start order, not a claim
+    /// that the dependent cannot run without the dependency, so a container
+    /// that waited on a non-required one starts as if it had come up. A
+    /// dependent that genuinely needs it says so by failing on its own.
+    pub required: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -432,6 +445,7 @@ fn validate_container(
             .map(|path| resolve_relative(base_dir, path))
             .collect(),
         startup_timeout,
+        required: raw.required,
     })
 }
 
@@ -734,6 +748,15 @@ pub(crate) struct RawContainer {
     env_file: Vec<PathBuf>,
     #[serde(default)]
     startup_timeout: Option<String>,
+    /// Absent means `true`: the default is the strict rule, so a file written
+    /// before this field existed keeps the behaviour it was written against.
+    #[serde(default = "required_by_default")]
+    #[schemars(default = "required_by_default")]
+    required: bool,
+}
+
+fn required_by_default() -> bool {
+    true
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/crates/iii-compose/src/config.rs
+++ b/crates/iii-compose/src/config.rs
@@ -161,11 +161,10 @@ pub struct Container {
     pub startup_timeout: Duration,
     /// Whether a failed start fails the operation that started it.
     ///
-    /// `true` is the default and the rule everything else is written against:
-    /// an `up` that cannot start a declared container refuses and undoes
-    /// itself. `false` says the project would rather run without this one, so
-    /// the failure is reported against the container and the operation carries
-    /// on.
+    /// A container declaration wins over [`ComposeFile::required_default`].
+    /// When neither is present, this is `false`: the project runs without a
+    /// container that failed to start. `true` makes the `up` refuse and undo
+    /// what it started.
     ///
     /// Dependents carry on too. `start_after` is a start order, not a claim
     /// that the dependent cannot run without the dependency, so a container
@@ -202,6 +201,9 @@ pub struct ComposeFile {
     pub startup_timeout: Duration,
     /// Grace between the polite stop and the forced kill, project-wide.
     pub stop_timeout: Duration,
+    /// Fallback for containers that do not declare `required` themselves.
+    /// Defaults to `false`.
+    pub required_default: bool,
     /// Present when this Compose invocation owns the engine process. Absent
     /// projects must connect to an externally managed engine.
     pub engine: Option<EngineSpec>,
@@ -286,13 +288,20 @@ impl ComposeFile {
             DEFAULT_STARTUP_TIMEOUT,
         )?;
         let stop_timeout = file_duration("stop_timeout", &raw.stop_timeout, DEFAULT_STOP_TIMEOUT)?;
+        let required_default = raw.required_default;
         let engine = raw.engine.map(validate_engine).transpose()?;
 
         let mut containers = IndexMap::with_capacity(raw_containers.len());
         for (key, raw_container) in &raw_containers {
             containers.insert(
                 key.clone(),
-                validate_container(key, raw_container, &base_dir, startup_timeout)?,
+                validate_container(
+                    key,
+                    raw_container,
+                    &base_dir,
+                    startup_timeout,
+                    required_default,
+                )?,
             );
         }
 
@@ -302,6 +311,7 @@ impl ComposeFile {
             base_dir,
             startup_timeout,
             stop_timeout,
+            required_default,
             engine,
             containers,
         };
@@ -394,6 +404,7 @@ fn validate_container(
     raw: &RawContainer,
     base_dir: &Path,
     file_startup_timeout: Duration,
+    required_default: bool,
 ) -> Result<Container> {
     let worker = parse_worker_source(key, &raw.worker, base_dir)?;
     let is_package = matches!(worker, WorkerSource::Package { .. });
@@ -485,7 +496,7 @@ fn validate_container(
             .map(|path| resolve_relative(base_dir, path))
             .collect(),
         startup_timeout,
-        required: raw.required,
+        required: raw.required.unwrap_or(required_default),
         restart: raw.restart,
     })
 }
@@ -658,6 +669,11 @@ struct RawComposeFile {
     startup_timeout: Option<String>,
     #[serde(default)]
     stop_timeout: Option<String>,
+    /// Fallback for containers that omit `required`. The default keeps
+    /// containers optional unless the project chooses the strict rule.
+    #[serde(default)]
+    #[schemars(default)]
+    required_default: bool,
     #[serde(default)]
     engine: Option<RawEngineSpec>,
     #[serde(default, deserialize_with = "deserialize_optional_unique_map")]
@@ -789,11 +805,17 @@ pub(crate) struct RawContainer {
     env_file: Vec<PathBuf>,
     #[serde(default)]
     startup_timeout: Option<String>,
-    /// Absent means `true`: the default is the strict rule, so a file written
-    /// before this field existed keeps the behaviour it was written against.
-    #[serde(default = "required_by_default")]
-    #[schemars(default = "required_by_default")]
-    required: bool,
+    /// Absent inherits the file's `required_default`. Deserialization keeps the
+    /// absence visible until the container is validated.
+    // Schemars uses this serialization rule to omit the raw `None` default from
+    // the schema. The YAML value is still a non-nullable boolean.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_bool",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[schemars(with = "bool")]
+    required: Option<bool>,
     /// Absent means `no`: a file written before this field existed keeps the
     /// behaviour it was written against, which is that a ready container that
     /// exits stays down.
@@ -802,8 +824,11 @@ pub(crate) struct RawContainer {
     restart: RestartPolicy,
 }
 
-fn required_by_default() -> bool {
-    true
+fn deserialize_optional_bool<'de, D>(deserializer: D) -> std::result::Result<Option<bool>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    bool::deserialize(deserializer).map(Some)
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -919,5 +944,26 @@ containers:
         let text = example["worker-compose.yaml"].as_str().unwrap();
         let parsed = ComposeFile::parse(text, "/tmp/worker-compose.yaml").unwrap();
         assert!(parsed.containers.contains_key("state"));
+    }
+
+    #[test]
+    fn worker_compose_schema_exposes_required_inheritance() {
+        let schema = worker_compose_schema_json();
+        let container = &schema["definitions"]["RawContainer"];
+
+        assert_eq!(
+            (
+                schema["properties"]["required_default"]["type"].as_str(),
+                schema["properties"]["required_default"]["default"].as_bool(),
+                container["properties"]["required"]["type"].as_str(),
+                container["properties"]["required"].get("default").is_some(),
+                container["required"].as_array().is_some_and(|fields| {
+                    fields
+                        .iter()
+                        .any(|field| field.as_str() == Some("required"))
+                }),
+            ),
+            (Some("boolean"), Some(false), Some("boolean"), false, false,)
+        );
     }
 }

--- a/crates/iii-compose/src/config.rs
+++ b/crates/iii-compose/src/config.rs
@@ -41,6 +41,18 @@ pub const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
 /// Default teardown grace between the polite stop and the forced kill.
 pub const DEFAULT_STOP_TIMEOUT: Duration = crate::process::DEFAULT_STOP_GRACE;
 
+/// Default base wait between failed replacement attempts.
+pub const DEFAULT_RESTART_DELAY: Duration = Duration::from_millis(500);
+
+/// Default ceiling for the exponential restart delay.
+pub const DEFAULT_RESTART_MAX_DELAY: Duration = Duration::from_secs(30);
+
+/// Default replacement attempts available after a failed start or exit.
+pub const DEFAULT_RESTART_MAX_ATTEMPTS: u32 = 5;
+
+/// Default time a ready container must hold before its restart budget refills.
+pub const DEFAULT_RESTART_WINDOW: Duration = Duration::from_secs(60);
+
 pub const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
 
 pub const CONFIGURABLE_ENGINE_WORKERS: &[&str] = &[
@@ -128,6 +140,52 @@ impl RestartPolicy {
     }
 }
 
+/// Restart behavior and retry limits for one container.
+///
+/// A scalar `restart` value uses these defaults. The object form can override
+/// each limit while keeping the same restart conditions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RestartConfig {
+    /// Which exits cause a restart.
+    pub condition: RestartPolicy,
+    /// Base delay used by exponential backoff.
+    pub delay: Duration,
+    /// Longest delay between two replacement attempts.
+    pub max_delay: Duration,
+    /// Replacement attempts available after a failed start or exit.
+    pub max_attempts: u32,
+    /// Time a ready container must hold before its restart budget refills.
+    pub window: Duration,
+}
+
+impl Default for RestartConfig {
+    fn default() -> Self {
+        Self {
+            condition: RestartPolicy::No,
+            delay: DEFAULT_RESTART_DELAY,
+            max_delay: DEFAULT_RESTART_MAX_DELAY,
+            max_attempts: DEFAULT_RESTART_MAX_ATTEMPTS,
+            window: DEFAULT_RESTART_WINDOW,
+        }
+    }
+}
+
+impl From<RestartPolicy> for RestartConfig {
+    fn from(condition: RestartPolicy) -> Self {
+        Self {
+            condition,
+            ..Self::default()
+        }
+    }
+}
+
+impl RestartConfig {
+    /// Whether an exit with this status should be answered with a restart.
+    pub fn wants_restart(&self, exit_code: i32) -> bool {
+        self.condition.wants_restart(exit_code)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Container {
     pub worker: WorkerSource,
@@ -177,7 +235,7 @@ pub struct Container {
     /// run-time exit takes the container's transitive dependents down. Anything
     /// else asks Compose to try the container again, with backoff and a capped
     /// number of attempts.
-    pub restart: RestartPolicy,
+    pub restart: RestartConfig,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -497,8 +555,31 @@ fn validate_container(
             .collect(),
         startup_timeout,
         required: raw.required.unwrap_or(required_default),
-        restart: raw.restart,
+        restart: validate_restart(key, &raw.restart)?,
     })
+}
+
+fn validate_restart(key: &str, raw: &RawRestart) -> Result<RestartConfig> {
+    match raw {
+        RawRestart::Condition(condition) => Ok((*condition).into()),
+        RawRestart::Config(raw) => Ok(RestartConfig {
+            condition: raw.condition,
+            delay: restart_duration(key, &raw.delay, DEFAULT_RESTART_DELAY)?,
+            max_delay: restart_duration(key, &raw.max_delay, DEFAULT_RESTART_MAX_DELAY)?,
+            max_attempts: raw.max_attempts.unwrap_or(DEFAULT_RESTART_MAX_ATTEMPTS),
+            window: restart_duration(key, &raw.window, DEFAULT_RESTART_WINDOW)?,
+        }),
+    }
+}
+
+fn restart_duration(key: &str, raw: &Option<String>, default: Duration) -> Result<Duration> {
+    match raw {
+        None => Ok(default),
+        Some(value) => parse_duration(value).ok_or_else(|| ComposeError::InvalidDuration {
+            container: key.to_string(),
+            value: value.clone(),
+        }),
+    }
 }
 
 impl Container {
@@ -821,7 +902,34 @@ pub(crate) struct RawContainer {
     /// exits stays down.
     #[serde(default)]
     #[schemars(default)]
-    restart: RestartPolicy,
+    restart: RawRestart,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum RawRestart {
+    Condition(RestartPolicy),
+    Config(RawRestartConfig),
+}
+
+impl Default for RawRestart {
+    fn default() -> Self {
+        Self::Condition(RestartPolicy::No)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct RawRestartConfig {
+    condition: RestartPolicy,
+    #[serde(default)]
+    delay: Option<String>,
+    #[serde(default)]
+    max_delay: Option<String>,
+    #[serde(default)]
+    max_attempts: Option<u32>,
+    #[serde(default)]
+    window: Option<String>,
 }
 
 fn deserialize_optional_bool<'de, D>(deserializer: D) -> std::result::Result<Option<bool>, D::Error>
@@ -964,6 +1072,32 @@ containers:
                 }),
             ),
             (Some("boolean"), Some(false), Some("boolean"), false, false,)
+        );
+    }
+
+    #[test]
+    fn worker_compose_schema_exposes_both_restart_forms() {
+        let schema = worker_compose_schema_json();
+        let restart = &schema["definitions"]["RawRestart"];
+        let restart_config = &schema["definitions"]["RawRestartConfig"];
+        let properties = &restart_config["properties"];
+
+        assert_eq!(
+            (
+                restart["anyOf"].as_array().map(Vec::len),
+                restart_config["required"]
+                    .as_array()
+                    .is_some_and(|required| {
+                        required
+                            .iter()
+                            .any(|field| field.as_str() == Some("condition"))
+                    }),
+                properties.get("delay").is_some(),
+                properties.get("max_delay").is_some(),
+                properties.get("max_attempts").is_some(),
+                properties.get("window").is_some(),
+            ),
+            (Some(2), true, true, true, true, true)
         );
     }
 }

--- a/crates/iii-compose/src/config.rs
+++ b/crates/iii-compose/src/config.rs
@@ -96,12 +96,11 @@ impl Default for Scripts {
     }
 }
 
-/// What the supervisor does when a container that had become ready exits.
+/// What Compose does when a start fails or a ready container exits.
 ///
-/// A run-time answer only. Whether a container that never became ready fails
-/// the operation that started it is [`Container::required`], and the two are
-/// deliberately separate: a policy that also covered the start would give one
-/// field two blast radii again, which is the thing `required` exists to fix.
+/// [`Container::required`] still controls the operation outcome: after the
+/// retry budget is spent, a required failure fails and rolls back `up`, while
+/// a non-required failure is reported and lets the rest of the graph start.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema, PartialOrd, Ord,
 )]
@@ -171,12 +170,13 @@ pub struct Container {
     /// that waited on a non-required one starts as if it had come up. A
     /// dependent that genuinely needs it says so by failing on its own.
     pub required: bool,
-    /// What happens when this container exits after it was ready.
+    /// What happens when this container fails to start or exits after it was
+    /// ready.
     ///
-    /// `no` is the default and matches the behaviour this field was added to:
-    /// the exit takes the container's transitive dependents down with it and
-    /// nothing comes back until someone runs `up` again. Anything else asks the
-    /// supervisor to try again, with a backoff and a capped number of attempts.
+    /// `no` is the default. A failed first start settles immediately, while a
+    /// run-time exit takes the container's transitive dependents down. Anything
+    /// else asks Compose to try the container again, with backoff and a capped
+    /// number of attempts.
     pub restart: RestartPolicy,
 }
 

--- a/crates/iii-compose/src/config.rs
+++ b/crates/iii-compose/src/config.rs
@@ -22,7 +22,7 @@ use std::{
 
 use indexmap::IndexMap;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     dag,
@@ -96,6 +96,39 @@ impl Default for Scripts {
     }
 }
 
+/// What the supervisor does when a container that had become ready exits.
+///
+/// A run-time answer only. Whether a container that never became ready fails
+/// the operation that started it is [`Container::required`], and the two are
+/// deliberately separate: a policy that also covered the start would give one
+/// field two blast radii again, which is the thing `required` exists to fix.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema, PartialOrd, Ord,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum RestartPolicy {
+    /// Leave it down and take its transitive dependents with it. The default,
+    /// and what compose did before this field existed.
+    #[default]
+    No,
+    /// Restart it when it exited with a non-zero status.
+    OnFailure,
+    /// Restart it whenever it exits, a clean exit included. For a worker that
+    /// is only correct while it is running, exit code 0 is still an outage.
+    Always,
+}
+
+impl RestartPolicy {
+    /// Whether an exit with this status should be answered with a restart.
+    pub fn wants_restart(self, exit_code: i32) -> bool {
+        match self {
+            Self::No => false,
+            Self::OnFailure => exit_code != 0,
+            Self::Always => true,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Container {
     pub worker: WorkerSource,
@@ -139,6 +172,13 @@ pub struct Container {
     /// that waited on a non-required one starts as if it had come up. A
     /// dependent that genuinely needs it says so by failing on its own.
     pub required: bool,
+    /// What happens when this container exits after it was ready.
+    ///
+    /// `no` is the default and matches the behaviour this field was added to:
+    /// the exit takes the container's transitive dependents down with it and
+    /// nothing comes back until someone runs `up` again. Anything else asks the
+    /// supervisor to try again, with a backoff and a capped number of attempts.
+    pub restart: RestartPolicy,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -446,6 +486,7 @@ fn validate_container(
             .collect(),
         startup_timeout,
         required: raw.required,
+        restart: raw.restart,
     })
 }
 
@@ -753,6 +794,12 @@ pub(crate) struct RawContainer {
     #[serde(default = "required_by_default")]
     #[schemars(default = "required_by_default")]
     required: bool,
+    /// Absent means `no`: a file written before this field existed keeps the
+    /// behaviour it was written against, which is that a ready container that
+    /// exits stays down.
+    #[serde(default)]
+    #[schemars(default)]
+    restart: RestartPolicy,
 }
 
 fn required_by_default() -> bool {

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -1434,21 +1434,32 @@ impl MutationOutcome {
             .chain(worker)
             .collect();
         let mut affected_workers = std::collections::BTreeSet::new();
-        let mut error = None;
+        let mut primary_error = None;
+        let mut first_container_error = None;
         let mut failed = Vec::new();
 
-        for result in operations.flat_map(|operation| &operation.containers) {
-            if result.changed && !requested.contains(result.container.as_str()) {
-                affected_workers.insert(result.container.clone());
+        for operation in operations {
+            if primary_error.is_none() {
+                primary_error = operation.primary_error.as_ref().map(MutationError::from);
             }
-            if result.error.is_some() {
-                failed.push(result.container.clone());
-            }
-            if error.is_none() {
-                error = result.error.as_ref().map(MutationError::from);
+            for result in &operation.containers {
+                if result.changed && !requested.contains(result.container.as_str()) {
+                    affected_workers.insert(result.container.clone());
+                }
+                if result.error.is_some() {
+                    failed.push(result.container.clone());
+                }
+                if first_container_error.is_none() {
+                    first_container_error = result.error.as_ref().map(MutationError::from);
+                }
             }
         }
 
+        let error = if status == OpStatus::Failed {
+            primary_error.or(first_container_error)
+        } else {
+            first_container_error
+        };
         // A succeeding operation with a failed container is the `required:
         // false` case and nothing else: a required failure is what makes the
         // status `failed` in the first place.
@@ -2398,6 +2409,10 @@ mod mutation_outcome_tests {
 
     #[test]
     fn concise_outcome_omits_healthy_containers_and_log_tails() {
+        let primary_error = OpError {
+            code: "CHILD_EXITED_BEFORE_REGISTRATION".into(),
+            message: "container 'tailscale' exited with 1 before it registered. It last said:\nretry secret output".into(),
+        };
         let result = OpResult {
             operation_id: "diagnostic-only".into(),
             status: OpStatus::Failed,
@@ -2419,12 +2434,10 @@ mod mutation_outcome_tests {
                     container: "tailscale".into(),
                     state: ChildStatus::Failed,
                     changed: false,
-                    error: Some(OpError {
-                        code: "CHILD_EXITED_BEFORE_REGISTRATION".into(),
-                        message: "container 'tailscale' exited with 1 before it registered. It last said:\nretry secret output".into(),
-                    }),
+                    error: Some(primary_error.clone()),
                 },
             ],
+            primary_error: Some(primary_error),
         };
 
         let outcome = MutationOutcome::from_operations(
@@ -2450,6 +2463,52 @@ mod mutation_outcome_tests {
         for internal in ["operation_id", "containers", "queue", "retry secret output"] {
             assert!(!encoded.contains(internal), "leaked {internal}: {encoded}");
         }
+    }
+
+    #[test]
+    fn failed_outcome_prefers_primary_error_over_earlier_container_error() {
+        let primary_error = OpError {
+            code: "CHILD_EXITED_BEFORE_REGISTRATION".into(),
+            message: "container 'api' exited with 9 before it registered".into(),
+        };
+
+        let result = OpResult {
+            operation_id: "mixed-failure".into(),
+            status: OpStatus::Failed,
+            changed: false,
+            containers: vec![
+                ContainerResult {
+                    container: "mailer".into(),
+                    state: ChildStatus::Failed,
+                    changed: false,
+                    error: Some(OpError {
+                        code: "STARTUP_TIMEOUT".into(),
+                        message: "container 'mailer' was not ready after 2s".into(),
+                    }),
+                },
+                ContainerResult {
+                    container: "api".into(),
+                    state: ChildStatus::Failed,
+                    changed: false,
+                    error: Some(primary_error.clone()),
+                },
+            ],
+            primary_error: Some(primary_error),
+        };
+
+        let outcome = MutationOutcome::from_operations(
+            OpStatus::Failed,
+            false,
+            None,
+            None,
+            None,
+            std::iter::once(&result),
+        );
+        let encoded = serde_json::to_value(&outcome).unwrap();
+        assert_eq!(
+            encoded["error"]["code"], "CHILD_EXITED_BEFORE_REGISTRATION",
+            "{encoded}"
+        );
     }
 }
 

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -1379,6 +1379,10 @@ impl Daemon {
                         project.reconcile_after_reconnect().await;
                     }
                     project.reap_unexpected_exits().await;
+                    // After the reap, so a container that has just exited
+                    // spends its first attempt on the tick that noticed rather
+                    // than waiting for the next one.
+                    project.drive_restarts().await;
                 }
             }
         });

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -1439,8 +1439,9 @@ impl MutationOutcome {
             .collect();
         let mut affected_workers = std::collections::BTreeSet::new();
         let mut primary_error = None;
-        let mut first_container_error = None;
-        let mut failed = Vec::new();
+        // Reconciliation can restart and then start the same container. Keep
+        // its first position, but let its last result describe the final state.
+        let mut latest_container_errors = indexmap::IndexMap::new();
 
         for operation in operations {
             if primary_error.is_none() {
@@ -1450,15 +1451,18 @@ impl MutationOutcome {
                 if result.changed && !requested.contains(result.container.as_str()) {
                     affected_workers.insert(result.container.clone());
                 }
-                if result.error.is_some() {
-                    failed.push(result.container.clone());
-                }
-                if first_container_error.is_none() {
-                    first_container_error = result.error.as_ref().map(MutationError::from);
-                }
+                latest_container_errors.insert(
+                    result.container.clone(),
+                    result.error.as_ref().map(MutationError::from),
+                );
             }
         }
 
+        let first_container_error = latest_container_errors.values().find_map(Clone::clone);
+        let failed: Vec<String> = latest_container_errors
+            .iter()
+            .filter_map(|(container, error)| error.as_ref().map(|_| container.clone()))
+            .collect();
         let error = if status == OpStatus::Failed {
             primary_error.or(first_container_error)
         } else {
@@ -2411,6 +2415,39 @@ mod mutation_outcome_tests {
         state::ChildStatus,
     };
 
+    fn optional_mailer_failure(operation_id: &str) -> OpResult {
+        OpResult {
+            operation_id: operation_id.into(),
+            status: OpStatus::Ok,
+            changed: false,
+            containers: vec![ContainerResult {
+                container: "mailer".into(),
+                state: ChildStatus::Failed,
+                changed: false,
+                error: Some(OpError {
+                    code: "STARTUP_TIMEOUT".into(),
+                    message: "container 'mailer' was not ready after 2s".into(),
+                }),
+            }],
+            primary_error: None,
+        }
+    }
+
+    fn ready_mailer(operation_id: &str) -> OpResult {
+        OpResult {
+            operation_id: operation_id.into(),
+            status: OpStatus::Ok,
+            changed: true,
+            containers: vec![ContainerResult {
+                container: "mailer".into(),
+                state: ChildStatus::Ready,
+                changed: true,
+                error: None,
+            }],
+            primary_error: None,
+        }
+    }
+
     #[test]
     fn concise_outcome_omits_healthy_containers_and_log_tails() {
         let primary_error = OpError {
@@ -2513,6 +2550,43 @@ mod mutation_outcome_tests {
             encoded["error"]["code"], "CHILD_EXITED_BEFORE_REGISTRATION",
             "{encoded}"
         );
+    }
+
+    #[test]
+    fn successful_outcome_reports_each_not_required_failure_once() {
+        let restart = optional_mailer_failure("restart");
+        let up = optional_mailer_failure("up");
+
+        let outcome = MutationOutcome::from_operations(
+            OpStatus::Ok,
+            false,
+            None,
+            None,
+            None,
+            [&restart, &up].into_iter(),
+        );
+
+        assert_eq!(
+            outcome.not_required_failures,
+            Some(vec!["mailer".to_string()])
+        );
+    }
+
+    #[test]
+    fn successful_outcome_omits_a_failure_recovered_by_a_later_operation() {
+        let restart = optional_mailer_failure("restart");
+        let up = ready_mailer("up");
+
+        let outcome = MutationOutcome::from_operations(
+            OpStatus::Ok,
+            true,
+            None,
+            None,
+            None,
+            [&restart, &up].into_iter(),
+        );
+
+        assert_eq!((outcome.error, outcome.not_required_failures), (None, None));
     }
 }
 

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -1407,6 +1407,14 @@ pub struct MutationOutcome {
     /// Concise failure for the first worker that could not reach its target state.
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<MutationError>,
+    /// Workers that failed while the operation still succeeded, which is only
+    /// possible for a container declaring `required: false`.
+    ///
+    /// `status: ok` used to mean every planned container is up. It now means
+    /// every *required* one is, so the return has to name the rest rather than
+    /// leave a caller to compare the plan against a later status call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    not_required_failures: Option<Vec<String>>,
 }
 
 impl MutationOutcome {
@@ -1427,15 +1435,25 @@ impl MutationOutcome {
             .collect();
         let mut affected_workers = std::collections::BTreeSet::new();
         let mut error = None;
+        let mut failed = Vec::new();
 
         for result in operations.flat_map(|operation| &operation.containers) {
             if result.changed && !requested.contains(result.container.as_str()) {
                 affected_workers.insert(result.container.clone());
             }
+            if result.error.is_some() {
+                failed.push(result.container.clone());
+            }
             if error.is_none() {
                 error = result.error.as_ref().map(MutationError::from);
             }
         }
+
+        // A succeeding operation with a failed container is the `required:
+        // false` case and nothing else: a required failure is what makes the
+        // status `failed` in the first place.
+        let not_required_failures =
+            (status == OpStatus::Ok && !failed.is_empty()).then_some(failed);
 
         Self {
             status,
@@ -1448,6 +1466,7 @@ impl MutationOutcome {
             affected_workers: (!affected_workers.is_empty())
                 .then(|| affected_workers.into_iter().collect()),
             error,
+            not_required_failures,
         }
     }
 

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -1466,7 +1466,7 @@ impl MutationOutcome {
         let error = if status == OpStatus::Failed {
             primary_error.or(first_container_error)
         } else {
-            first_container_error
+            None
         };
         // A succeeding operation with a failed container is the non-required
         // case and nothing else: a required failure is what makes the status
@@ -2567,8 +2567,8 @@ mod mutation_outcome_tests {
         );
 
         assert_eq!(
-            outcome.not_required_failures,
-            Some(vec!["mailer".to_string()])
+            (outcome.error, outcome.not_required_failures),
+            (None, Some(vec!["mailer".to_string()]))
         );
     }
 

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -1412,7 +1412,7 @@ pub struct MutationOutcome {
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<MutationError>,
     /// Workers that failed while the operation still succeeded, which is only
-    /// possible for a container declaring `required: false`.
+    /// possible for a container whose effective `required` value is `false`.
     ///
     /// `status: ok` used to mean every planned container is up. It now means
     /// every *required* one is, so the return has to name the rest rather than
@@ -1468,9 +1468,9 @@ impl MutationOutcome {
         } else {
             first_container_error
         };
-        // A succeeding operation with a failed container is the `required:
-        // false` case and nothing else: a required failure is what makes the
-        // status `failed` in the first place.
+        // A succeeding operation with a failed container is the non-required
+        // case and nothing else: a required failure is what makes the status
+        // `failed` in the first place.
         let not_required_failures =
             (status == OpStatus::Ok && !failed.is_empty()).then_some(failed);
 

--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -44,6 +44,7 @@ pub mod project;
 pub mod registry;
 pub mod remote;
 pub mod report;
+mod restart;
 mod shutdown;
 pub mod spawn;
 pub mod state;

--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -50,7 +50,7 @@ pub mod spawn;
 pub mod state;
 
 pub use cli::{BuildCli, ComposeCli, ComposeCommand, ComposeLogsCli, ComposeSubcommand};
-pub use config::{ComposeFile, Container, EngineSpec, RestartPolicy, WorkerSource};
+pub use config::{ComposeFile, Container, EngineSpec, RestartConfig, RestartPolicy, WorkerSource};
 pub use error::{ComposeError, Result};
 pub use manifest::{StartSpec, ValidationReport, VmSpec};
 

--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -49,7 +49,7 @@ pub mod spawn;
 pub mod state;
 
 pub use cli::{BuildCli, ComposeCli, ComposeCommand, ComposeLogsCli, ComposeSubcommand};
-pub use config::{ComposeFile, Container, EngineSpec, WorkerSource};
+pub use config::{ComposeFile, Container, EngineSpec, RestartPolicy, WorkerSource};
 pub use error::{ComposeError, Result};
 pub use manifest::{StartSpec, ValidationReport, VmSpec};
 

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -462,18 +462,30 @@ async fn restart_one_inner(
                 &strip_container_prefix(&error.to_string(), key),
             );
             report::plan_done();
-            report::summary_failed("restart", error.code(), began.elapsed());
+            let required = is_required(ctx.file, key);
+            if required {
+                report::summary_failed("restart", error.code(), began.elapsed());
+            } else {
+                report::not_required_failed(1);
+                report::summary_ok("restart", 0, 1, began.elapsed());
+            }
+            let error = OpError::from(&error);
+            let primary_error = required.then(|| error.clone());
             return Some(OpResult {
                 operation_id,
-                status: OpStatus::Failed,
+                status: if required {
+                    OpStatus::Failed
+                } else {
+                    OpStatus::Ok
+                },
                 changed: false,
                 containers: vec![ContainerResult {
                     container: key.to_string(),
                     state: ChildStatus::Failed,
                     changed: false,
-                    error: Some(OpError::from(&error)),
+                    error: Some(error),
                 }],
-                primary_error: Some(OpError::from(&error)),
+                primary_error,
             });
         }
         StartAttempt::Interrupted => {

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -177,6 +177,10 @@ async fn up_inner(
     let mut results: Vec<ContainerResult> = Vec::new();
     // Only what *this* operation started may be rolled back.
     let mut started: Vec<String> = Vec::new();
+    // Containers that failed and said their failure does not fail the
+    // operation. Counted so the closing line reports a partial project as
+    // partial rather than reading like a clean start.
+    let mut not_required_failures = 0usize;
     let max_parallel_workers = crate::parallelism::max_parallel_workers();
 
     // Everything this operation will touch, drawn before any of it moves, so an
@@ -281,8 +285,17 @@ async fn up_inner(
                     if let Some(operation) = crate::operation::active(&operation_id) {
                         operation.emit(Some(key), "failed", error.to_string()).await;
                     }
-                    if failure.is_none() {
-                        failure = Some((key.clone(), error));
+                    if is_required(ctx.file, key) {
+                        if failure.is_none() {
+                            failure = Some((key.clone(), error));
+                        }
+                    } else {
+                        // The plan counted it, so the progress has to account
+                        // for it however it settled.
+                        if let Some(operation) = crate::operation::active(&operation_id) {
+                            operation.completed_one().await;
+                        }
+                        not_required_failures += 1;
                     }
                 }
                 StartAttempt::Interrupted => interrupted = true,
@@ -321,6 +334,9 @@ async fn up_inner(
 
     report::plan_done();
     let changed = results.iter().filter(|result| result.changed).count();
+    if not_required_failures > 0 {
+        report::not_required_failed(not_required_failures);
+    }
     report::summary_ok("up", changed, results.len(), began.elapsed());
     Some(OpResult {
         operation_id,
@@ -328,6 +344,15 @@ async fn up_inner(
         changed: changed > 0,
         containers: results,
     })
+}
+
+/// Whether this container's failure fails the operation. A container the file
+/// no longer declares is treated as required: the strict rule is the one that
+/// refuses rather than the one that carries on.
+fn is_required(file: &ComposeFile, key: &str) -> bool {
+    file.containers
+        .get(key)
+        .is_none_or(|container| container.required)
 }
 
 /// Drops a leading `container '<name>': ` from a message that is already being

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -28,7 +28,7 @@ use futures::StreamExt;
 use serde::Serialize;
 
 use crate::{
-    config::{ComposeFile, Container},
+    config::{ComposeFile, Container, RestartPolicy},
     configuration::{ConfigFile, merge},
     dag,
     engine::EngineClient,
@@ -37,7 +37,7 @@ use crate::{
     logs::LogStore,
     manifest::{StartSpec, VmSpec, resolve_start},
     process::{Outcome, Supervised, spawn_supervised_piped},
-    report,
+    report, restart,
     spawn::{SpawnCtx, resolve_working_dir, spawn_plan},
     state::{ChildRecord, ChildStatus},
 };
@@ -112,9 +112,18 @@ pub struct LifecycleCtx<'a> {
 /// What one container's start produced: which one, how long it took, and
 /// whether it came up.
 enum StartAttempt {
-    Ready(ChildRecord, Supervised),
+    Ready {
+        record: ChildRecord,
+        child: Supervised,
+        recovery: Option<RetryRecovery>,
+    },
     Failed(ComposeError),
     Interrupted,
+}
+
+struct RetryRecovery {
+    attempt: u32,
+    elapsed: Duration,
 }
 
 enum StartFailure {
@@ -242,7 +251,7 @@ async fn up_inner(
             async move {
                 let began = Instant::now();
                 let outcome =
-                    start_one_attempt(ctx, &key, shutdown, Some(&start_operation_id)).await;
+                    start_one_with_retries(ctx, &key, shutdown, Some(&start_operation_id)).await;
                 (key, began.elapsed(), outcome)
             }
         }))
@@ -255,8 +264,21 @@ async fn up_inner(
         while let Some((key, took, outcome)) = outcomes.next().await {
             let key = &key;
             match outcome {
-                StartAttempt::Ready(record, child) => {
-                    report::ready(key, took);
+                StartAttempt::Ready {
+                    record,
+                    child,
+                    recovery,
+                } => {
+                    if let Some(recovery) = recovery {
+                        report::retry_recovered(
+                            key,
+                            recovery.attempt,
+                            restart::MAX_ATTEMPTS,
+                            recovery.elapsed,
+                        );
+                    } else {
+                        report::ready(key, took);
+                    }
                     records.insert(key.clone(), record);
                     children.insert(key.clone(), child);
                     started.push(key.clone());
@@ -480,7 +502,11 @@ async fn restart_one_inner(
     let took = started.elapsed();
 
     let result = match outcome {
-        StartAttempt::Ready(record, child) => {
+        StartAttempt::Ready {
+            record,
+            child,
+            recovery: _,
+        } => {
             if let Some((attempt, total_attempts)) = retry {
                 report::retry_recovered(key, attempt, total_attempts, took);
             } else {
@@ -686,6 +712,114 @@ pub async fn down(
     }
 }
 
+/// Starts a container and applies its restart policy before the operation
+/// settles. The original start is not part of the replacement budget, which
+/// matches run-time supervision: a worker gets up to five replacements after
+/// the process it was using failed.
+async fn start_one_with_retries(
+    ctx: &LifecycleCtx<'_>,
+    key: &str,
+    mut shutdown: Option<crate::shutdown::ShutdownSignal>,
+    operation_id: Option<&str>,
+) -> StartAttempt {
+    let policy = ctx
+        .file
+        .containers
+        .get(key)
+        .map_or(RestartPolicy::No, |container| container.restart);
+    let mut error = match start_one_attempt(ctx, key, shutdown.clone(), operation_id).await {
+        StartAttempt::Failed(error) if retries_start_failure(policy, &error) => error,
+        settled => return settled,
+    };
+
+    for attempt in 1..=restart::MAX_ATTEMPTS {
+        report::retry_starting(key, attempt, restart::MAX_ATTEMPTS);
+        if let Some(operation) = operation_id.and_then(crate::operation::active) {
+            operation
+                .emit(
+                    Some(key),
+                    "retrying",
+                    format!("starting attempt {attempt} of {}", restart::MAX_ATTEMPTS),
+                )
+                .await;
+        }
+
+        let began = Instant::now();
+        match start_one_attempt(ctx, key, shutdown.clone(), operation_id).await {
+            StartAttempt::Ready {
+                record,
+                child,
+                recovery: _,
+            } => {
+                return StartAttempt::Ready {
+                    record,
+                    child,
+                    recovery: Some(RetryRecovery {
+                        attempt,
+                        elapsed: began.elapsed(),
+                    }),
+                };
+            }
+            StartAttempt::Failed(next_error) => error = next_error,
+            StartAttempt::Interrupted => return StartAttempt::Interrupted,
+        }
+
+        if attempt == restart::MAX_ATTEMPTS || !retries_start_failure(policy, &error) {
+            break;
+        }
+
+        let delay = restart::backoff(attempt);
+        let next_attempt = attempt + 1;
+        report::retry_waiting(key, next_attempt, restart::MAX_ATTEMPTS, delay);
+        if let Some(operation) = operation_id.and_then(crate::operation::active) {
+            operation
+                .emit(
+                    Some(key),
+                    "retrying",
+                    format!(
+                        "waiting before attempt {next_attempt} of {}",
+                        restart::MAX_ATTEMPTS
+                    ),
+                )
+                .await;
+        }
+        if !wait_for_retry(&mut shutdown, delay).await {
+            return StartAttempt::Interrupted;
+        }
+    }
+
+    StartAttempt::Failed(error)
+}
+
+/// `on-failure` excludes the one start outcome that is not a failure: a child
+/// that exits successfully before registration. Every other startup error is a
+/// failed attempt, including a rejected `pre_run` hook.
+fn retries_start_failure(policy: RestartPolicy, error: &ComposeError) -> bool {
+    match policy {
+        RestartPolicy::No => false,
+        RestartPolicy::Always => true,
+        RestartPolicy::OnFailure => {
+            !matches!(error, ComposeError::ChildExitedBeforeReady { code: 0, .. })
+        }
+    }
+}
+
+async fn wait_for_retry(
+    shutdown: &mut Option<crate::shutdown::ShutdownSignal>,
+    delay: Duration,
+) -> bool {
+    if let Some(signal) = shutdown {
+        tokio::select! {
+            biased;
+            _ = signal.wait() => false,
+            _ = tokio::time::sleep(delay) => true,
+        }
+    } else {
+        tokio::time::sleep(delay).await;
+        true
+    }
+}
+
 async fn start_one_attempt(
     ctx: &LifecycleCtx<'_>,
     key: &str,
@@ -693,7 +827,11 @@ async fn start_one_attempt(
     operation_id: Option<&str>,
 ) -> StartAttempt {
     match start_one_until_shutdown(ctx, key, shutdown, operation_id).await {
-        Ok((record, child)) => StartAttempt::Ready(record, child),
+        Ok((record, child)) => StartAttempt::Ready {
+            record,
+            child,
+            recovery: None,
+        },
         Err(StartFailure::Failed(error)) => StartAttempt::Failed(error),
         Err(StartFailure::Interrupted) => StartAttempt::Interrupted,
     }
@@ -1381,6 +1519,28 @@ containers:
     fn an_unknown_target_is_rejected_before_anything_starts() {
         let err = plan_targets(&file(), Some("ghost")).unwrap_err();
         assert_eq!(err.code(), "UNKNOWN_CONTAINER");
+    }
+
+    #[test]
+    fn on_failure_does_not_retry_a_clean_exit_before_ready() {
+        let error = ComposeError::ChildExitedBeforeReady {
+            container: "api".to_string(),
+            code: 0,
+            tail: None,
+        };
+
+        assert!(!retries_start_failure(RestartPolicy::OnFailure, &error));
+    }
+
+    #[test]
+    fn always_retries_a_clean_exit_before_ready() {
+        let error = ComposeError::ChildExitedBeforeReady {
+            container: "api".to_string(),
+            code: 0,
+            tail: None,
+        };
+
+        assert!(retries_start_failure(RestartPolicy::Always, &error));
     }
 
     #[test]

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -123,6 +123,7 @@ enum StartAttempt {
 
 struct RetryRecovery {
     attempt: u32,
+    total_attempts: u32,
     elapsed: Duration,
 }
 
@@ -273,7 +274,7 @@ async fn up_inner(
                         report::retry_recovered(
                             key,
                             recovery.attempt,
-                            restart::MAX_ATTEMPTS,
+                            recovery.total_attempts,
                             recovery.elapsed,
                         );
                     } else {
@@ -714,32 +715,38 @@ pub async fn down(
 
 /// Starts a container and applies its restart policy before the operation
 /// settles. The original start is not part of the replacement budget, which
-/// matches run-time supervision: a worker gets up to five replacements after
-/// the process it was using failed.
+/// matches run-time supervision: a worker gets the configured number of
+/// replacements after the process it was using failed.
 async fn start_one_with_retries(
     ctx: &LifecycleCtx<'_>,
     key: &str,
     mut shutdown: Option<crate::shutdown::ShutdownSignal>,
     operation_id: Option<&str>,
 ) -> StartAttempt {
-    let policy = ctx
+    let restart_config = ctx
         .file
         .containers
         .get(key)
-        .map_or(RestartPolicy::No, |container| container.restart);
+        .map(|container| container.restart.clone())
+        .unwrap_or_default();
     let mut error = match start_one_attempt(ctx, key, shutdown.clone(), operation_id).await {
-        StartAttempt::Failed(error) if retries_start_failure(policy, &error) => error,
+        StartAttempt::Failed(error) if retries_start_failure(restart_config.condition, &error) => {
+            error
+        }
         settled => return settled,
     };
 
-    for attempt in 1..=restart::MAX_ATTEMPTS {
-        report::retry_starting(key, attempt, restart::MAX_ATTEMPTS);
+    for attempt in 1..=restart_config.max_attempts {
+        report::retry_starting(key, attempt, restart_config.max_attempts);
         if let Some(operation) = operation_id.and_then(crate::operation::active) {
             operation
                 .emit(
                     Some(key),
                     "retrying",
-                    format!("starting attempt {attempt} of {}", restart::MAX_ATTEMPTS),
+                    format!(
+                        "starting attempt {attempt} of {}",
+                        restart_config.max_attempts
+                    ),
                 )
                 .await;
         }
@@ -756,6 +763,7 @@ async fn start_one_with_retries(
                     child,
                     recovery: Some(RetryRecovery {
                         attempt,
+                        total_attempts: restart_config.max_attempts,
                         elapsed: began.elapsed(),
                     }),
                 };
@@ -764,13 +772,15 @@ async fn start_one_with_retries(
             StartAttempt::Interrupted => return StartAttempt::Interrupted,
         }
 
-        if attempt == restart::MAX_ATTEMPTS || !retries_start_failure(policy, &error) {
+        if attempt == restart_config.max_attempts
+            || !retries_start_failure(restart_config.condition, &error)
+        {
             break;
         }
 
-        let delay = restart::backoff(attempt);
+        let delay = restart::backoff(&restart_config, attempt);
         let next_attempt = attempt + 1;
-        report::retry_waiting(key, next_attempt, restart::MAX_ATTEMPTS, delay);
+        report::retry_waiting(key, next_attempt, restart_config.max_attempts, delay);
         if let Some(operation) = operation_id.and_then(crate::operation::active) {
             operation
                 .emit(
@@ -778,7 +788,7 @@ async fn start_one_with_retries(
                     "retrying",
                     format!(
                         "waiting before attempt {next_attempt} of {}",
-                        restart::MAX_ATTEMPTS
+                        restart_config.max_attempts
                     ),
                 )
                 .await;

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -52,6 +52,9 @@ pub struct OpResult {
     /// already in the desired state.
     pub changed: bool,
     pub containers: Vec<ContainerResult>,
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub(crate) primary_error: Option<OpError>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, schemars::JsonSchema, PartialEq, Eq)]
@@ -318,6 +321,7 @@ async fn up_inner(
                 status: OpStatus::Failed,
                 changed: !started.is_empty(),
                 containers: results,
+                primary_error: Some(OpError::from(&error)),
             });
         }
     }
@@ -343,6 +347,7 @@ async fn up_inner(
         status: OpStatus::Ok,
         changed: changed > 0,
         containers: results,
+        primary_error: None,
     })
 }
 
@@ -468,6 +473,7 @@ async fn restart_one_inner(
                     changed: false,
                     error: Some(OpError::from(&error)),
                 }],
+                primary_error: Some(OpError::from(&error)),
             });
         }
         StartAttempt::Interrupted => {
@@ -482,6 +488,7 @@ async fn restart_one_inner(
         status: OpStatus::Ok,
         changed: true,
         containers: vec![result],
+        primary_error: None,
     })
 }
 
@@ -531,6 +538,7 @@ pub async fn remove_one(
             changed,
             error: None,
         }],
+        primary_error: None,
     }
 }
 
@@ -622,6 +630,7 @@ pub async fn down(
         status: OpStatus::Ok,
         changed: changed > 0,
         containers: results,
+        primary_error: None,
     }
 }
 
@@ -1263,6 +1272,7 @@ fn failed_op(operation_id: String, target: Option<&str>, error: &ComposeError) -
             changed: false,
             error: Some(OpError::from(error)),
         }],
+        primary_error: Some(OpError::from(error)),
     }
 }
 
@@ -1348,6 +1358,7 @@ containers:
                 changed: true,
                 error: None,
             }],
+            primary_error: None,
         };
 
         let json = serde_json::to_value(&result).unwrap();
@@ -1360,6 +1371,10 @@ containers:
             json["containers"][0].get("error").is_none(),
             "a successful container carries no error key"
         );
+        assert!(
+            json.get("primary_error").is_none(),
+            "the internal primary error must not be serialized"
+        )
     }
 }
 

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -191,9 +191,8 @@ async fn up_inner(
     // Only what *this* operation started may be rolled back.
     let mut started: Vec<String> = Vec::new();
     // Containers that failed and said their failure does not fail the
-    // operation. Counted so the closing line reports a partial project as
-    // partial rather than reading like a clean start.
-    let mut not_required_failures = 0usize;
+    // operation. Named so the closing line reports the partial project.
+    let mut not_required_failures = Vec::new();
     let max_parallel_workers = crate::parallelism::max_parallel_workers();
 
     // Everything this operation will touch, drawn before any of it moves, so an
@@ -321,7 +320,7 @@ async fn up_inner(
                         if let Some(operation) = crate::operation::active(&operation_id) {
                             operation.completed_one().await;
                         }
-                        not_required_failures += 1;
+                        not_required_failures.push(key.clone());
                     }
                 }
                 StartAttempt::Interrupted => interrupted = true,
@@ -361,8 +360,8 @@ async fn up_inner(
 
     report::plan_done();
     let changed = results.iter().filter(|result| result.changed).count();
-    if not_required_failures > 0 {
-        report::not_required_failed(not_required_failures);
+    if !not_required_failures.is_empty() {
+        report::not_required_failed(&not_required_failures);
     }
     report::summary_ok("up", changed, results.len(), began.elapsed());
     Some(OpResult {
@@ -533,7 +532,7 @@ async fn restart_one_inner(
             if required {
                 report::summary_failed("restart", error.code(), began.elapsed());
             } else {
-                report::not_required_failed(1);
+                report::not_required_failed(&[key.to_string()]);
                 report::summary_ok("restart", 0, 1, began.elapsed());
             }
             let error = OpError::from(&error);

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -385,9 +385,31 @@ pub async fn restart_one(
     key: &str,
     operation_id: String,
 ) -> OpResult {
-    restart_one_inner(ctx, children, records, key, operation_id, None)
+    restart_one_inner(ctx, children, records, key, operation_id, None, None)
         .await
         .expect("restart without a shutdown signal cannot be interrupted")
+}
+
+pub(crate) async fn restart_one_supervised(
+    ctx: &LifecycleCtx<'_>,
+    children: &mut Children,
+    records: &mut BTreeMap<String, ChildRecord>,
+    key: &str,
+    operation_id: String,
+    attempt: u32,
+    total_attempts: u32,
+) -> OpResult {
+    restart_one_inner(
+        ctx,
+        children,
+        records,
+        key,
+        operation_id,
+        None,
+        Some((attempt, total_attempts)),
+    )
+    .await
+    .expect("supervised restart without a shutdown signal cannot be interrupted")
 }
 
 pub(crate) async fn restart_one_until_shutdown(
@@ -398,7 +420,16 @@ pub(crate) async fn restart_one_until_shutdown(
     operation_id: String,
     shutdown: crate::shutdown::ShutdownSignal,
 ) -> Option<OpResult> {
-    restart_one_inner(ctx, children, records, key, operation_id, Some(shutdown)).await
+    restart_one_inner(
+        ctx,
+        children,
+        records,
+        key,
+        operation_id,
+        Some(shutdown),
+        None,
+    )
+    .await
 }
 
 async fn restart_one_inner(
@@ -408,6 +439,7 @@ async fn restart_one_inner(
     key: &str,
     operation_id: String,
     shutdown: Option<crate::shutdown::ShutdownSignal>,
+    retry: Option<(u32, u32)>,
 ) -> Option<OpResult> {
     let began = Instant::now();
     if !ctx.file.containers.contains_key(key) {
@@ -421,7 +453,11 @@ async fn restart_one_inner(
         return None;
     }
 
-    report::plan(&[(key.to_string(), 0)]);
+    if let Some((attempt, total_attempts)) = retry {
+        report::retry_starting(key, attempt, total_attempts);
+    } else {
+        report::plan(&[(key.to_string(), 0)]);
+    }
     let stopped = stop_one(ctx, children, records, key).await;
 
     // The child is gone, but the engine learns that from a socket closing and
@@ -445,7 +481,11 @@ async fn restart_one_inner(
 
     let result = match outcome {
         StartAttempt::Ready(record, child) => {
-            report::ready(key, took);
+            if let Some((attempt, total_attempts)) = retry {
+                report::retry_recovered(key, attempt, total_attempts, took);
+            } else {
+                report::ready(key, took);
+            }
             records.insert(key.to_string(), record);
             children.insert(key.to_string(), child);
             ContainerResult {

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -422,7 +422,7 @@ async fn restart_one_inner(
     }
 
     report::plan(&[(key.to_string(), 0)]);
-    stop_one(ctx, children, records, key).await;
+    let stopped = stop_one(ctx, children, records, key).await;
 
     // The child is gone, but the engine learns that from a socket closing and
     // not from us. Starting into that window makes the replacement collide
@@ -478,11 +478,11 @@ async fn restart_one_inner(
                 } else {
                     OpStatus::Ok
                 },
-                changed: false,
+                changed: stopped,
                 containers: vec![ContainerResult {
                     container: key.to_string(),
                     state: ChildStatus::Failed,
-                    changed: false,
+                    changed: stopped,
                     error: Some(error),
                 }],
                 primary_error,
@@ -1103,9 +1103,9 @@ async fn stop_one(
     children: &mut Children,
     records: &mut BTreeMap<String, ChildRecord>,
     key: &str,
-) {
+) -> bool {
     let Some(child) = children.remove(key) else {
-        return;
+        return false;
     };
     child.stop(ctx.file.stop_timeout).await;
 
@@ -1147,6 +1147,8 @@ async fn stop_one(
     if let Some(record) = records.get_mut(key) {
         record.status = ChildStatus::Stopped;
     }
+
+    true
 }
 
 /// Undoes one failed `up`: stops what this operation started, in reverse.

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -37,6 +37,7 @@ use crate::{
     lifecycle::{self, Children, LifecycleCtx, OpResult},
     logs::{LogCursor, LogStore, LogStream, LogsOutcome},
     process::Supervised,
+    restart,
     state::{ChildStatus, DaemonState, Reconciliation, StateStore, reconcile},
 };
 
@@ -65,28 +66,6 @@ pub struct Project {
 /// Fast enough that a crash is reported while the operator is still watching,
 /// slow enough that an idle project costs nothing.
 const SUPERVISION_INTERVAL: Duration = Duration::from_millis(250);
-
-/// Wait before the second restart attempt. Each further attempt doubles it, up
-/// to [`RESTART_BACKOFF_MAX`]. The first attempt does not wait at all: a worker
-/// that died because of a transient is back before the operator looks up, and
-/// one that is genuinely broken has stopped being hammered within seconds.
-const RESTART_BACKOFF_BASE: Duration = Duration::from_millis(500);
-
-/// Ceiling on the wait between attempts. Past this, a longer backoff would only
-/// delay the operator's answer without giving the worker anything it needs.
-const RESTART_BACKOFF_MAX: Duration = Duration::from_secs(30);
-
-/// Consecutive attempts before the supervisor gives up. On the last one it does
-/// what it would have done with no policy at all: fail the container and take
-/// its dependents down. A cap is what separates a restart policy from a busy
-/// loop.
-const RESTART_MAX_ATTEMPTS: u32 = 5;
-
-/// How long a container has to hold `Ready` before its attempt budget refills.
-/// Without it, a worker that crashes once an hour would spend five attempts
-/// over an afternoon and then never be restarted again, which is the opposite
-/// of what its file asked for.
-const RESTART_BUDGET_RESET_AFTER: Duration = Duration::from_secs(60);
 
 /// Where one container is in its restart budget.
 #[derive(Debug, Clone, Copy, Default)]
@@ -173,16 +152,6 @@ impl RestartBookkeeping {
     fn remove(&mut self, key: &str) {
         self.attempts.remove(key);
         self.leases.remove(key);
-    }
-}
-
-impl RestartAttempts {
-    /// Backoff before the attempt after `spent` have been made: doubling from
-    /// [`RESTART_BACKOFF_BASE`], held at [`RESTART_BACKOFF_MAX`].
-    fn backoff(spent: u32) -> Duration {
-        RESTART_BACKOFF_BASE
-            .saturating_mul(2u32.saturating_pow(spent.saturating_sub(1)))
-            .min(RESTART_BACKOFF_MAX)
     }
 }
 
@@ -476,14 +445,14 @@ impl Project {
                 .containers
                 .get(key)
                 .map_or(0, |record| seconds_since(record.started_at))
-                >= RESTART_BUDGET_RESET_AFTER.as_secs()
+                >= restart::BUDGET_RESET_AFTER.as_secs()
         {
             inner.restarts.attempts.remove(key);
         }
 
         let spent = {
             let attempt = inner.restarts.attempts.entry(key.to_string()).or_default();
-            if attempt.spent >= RESTART_MAX_ATTEMPTS {
+            if attempt.spent >= restart::MAX_ATTEMPTS {
                 None
             } else {
                 attempt.spent += 1;
@@ -500,7 +469,10 @@ impl Project {
 
         daemon_line(
             &self.project_namespace,
-            &format!("restarting {key} (attempt {spent} of {RESTART_MAX_ATTEMPTS})"),
+            &format!(
+                "restarting {key} (attempt {spent} of {})",
+                restart::MAX_ATTEMPTS
+            ),
             Tone::Warn,
         );
 
@@ -537,8 +509,8 @@ impl Project {
         // last attempt would hold the container in `restarting` for a wait
         // nobody is going to use, and delay the operator's answer by it.
         let next_retry = match inner.restarts.attempts.get_mut(key) {
-            Some(attempt) if attempt.spent < RESTART_MAX_ATTEMPTS => {
-                let delay = RestartAttempts::backoff(attempt.spent);
+            Some(attempt) if attempt.spent < restart::MAX_ATTEMPTS => {
+                let delay = restart::backoff(attempt.spent);
                 attempt.due = Some(Instant::now() + delay);
                 Some((attempt.spent + 1, delay))
             }
@@ -555,7 +527,7 @@ impl Project {
         let _ = self.store.save(&snapshot);
 
         if let Some((next_attempt, delay)) = next_retry {
-            crate::report::retry_waiting(key, next_attempt, RESTART_MAX_ATTEMPTS, delay);
+            crate::report::retry_waiting(key, next_attempt, restart::MAX_ATTEMPTS, delay);
         } else {
             self.report_gave_up(key).await;
             self.cascade_failure(key, Self::exhausted_reason()).await;
@@ -602,7 +574,10 @@ impl Project {
     }
 
     fn exhausted_reason() -> String {
-        format!("did not stay up after {RESTART_MAX_ATTEMPTS} restart attempts")
+        format!(
+            "did not stay up after {} restart attempts",
+            restart::MAX_ATTEMPTS
+        )
     }
 
     async fn report_gave_up(&self, key: &str) {
@@ -1076,7 +1051,7 @@ impl Project {
                 key,
                 operation_id,
                 attempt,
-                RESTART_MAX_ATTEMPTS,
+                restart::MAX_ATTEMPTS,
             )
             .await
         } else {
@@ -1280,42 +1255,7 @@ fn daemon_line(id: &str, message: &str, tone: Tone) {
 
 #[cfg(test)]
 mod restart_backoff_tests {
-    use super::{
-        RESTART_BACKOFF_BASE, RESTART_BACKOFF_MAX, RESTART_MAX_ATTEMPTS, RestartAttempts,
-        RestartBookkeeping,
-    };
-
-    /// The wait doubles per attempt and then stops doubling. A ceiling the
-    /// budget can never reach would be a ceiling in name only, so this pins
-    /// both halves.
-    #[test]
-    fn backoff_doubles_and_then_holds_at_the_ceiling() {
-        assert_eq!(RestartAttempts::backoff(1), RESTART_BACKOFF_BASE);
-        assert_eq!(RestartAttempts::backoff(2), RESTART_BACKOFF_BASE * 2);
-        assert_eq!(RestartAttempts::backoff(3), RESTART_BACKOFF_BASE * 4);
-        assert_eq!(
-            RestartAttempts::backoff(30),
-            RESTART_BACKOFF_MAX,
-            "a long-running loop must not overflow into an unbounded wait"
-        );
-    }
-
-    /// Without a cap the policy is a busy loop, which is what the issue this
-    /// field came from was written to avoid.
-    #[test]
-    fn the_budget_is_spent_in_bounded_time() {
-        let total: std::time::Duration = (1..=RESTART_MAX_ATTEMPTS)
-            .map(RestartAttempts::backoff)
-            .sum();
-        assert!(
-            total <= RESTART_BACKOFF_MAX * RESTART_MAX_ATTEMPTS,
-            "every attempt waits at most the ceiling"
-        );
-        assert!(
-            total >= RESTART_BACKOFF_BASE,
-            "attempts after the first always wait"
-        );
-    }
+    use super::{RestartAttempts, RestartBookkeeping};
 
     #[test]
     fn operator_control_invalidates_a_supervisor_lease() {

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -31,7 +31,7 @@ use tokio::{
 };
 
 use crate::{
-    config::{ComposeFile, RestartPolicy},
+    config::{ComposeFile, RestartConfig},
     engine::EngineClient,
     error::{ComposeError, Result},
     lifecycle::{self, Children, LifecycleCtx, OpResult},
@@ -344,7 +344,7 @@ impl Project {
             // A container that asked to be restarted gets the first attempt
             // immediately: its dependents stay up, and the exit only cascades
             // once the budget below is spent.
-            if self.restart_policy(&key).await.wants_restart(code) {
+            if self.restart_config(&key).await.wants_restart(code) {
                 if let Some(lease) = self.claim_restart(&key, RestartCause::UnexpectedExit).await {
                     self.run_restart_attempt(&key, lease, RestartCause::UnexpectedExit)
                         .await;
@@ -431,6 +431,7 @@ impl Project {
     /// restart touches one container and not a graph, which is what keeps the
     /// dependents up while this one is gone.
     async fn run_restart_attempt(&self, key: &str, lease: RestartLease, cause: RestartCause) {
+        let restart_config = self.restart_config(key).await;
         let mut inner = self.inner.lock().await;
         if !inner.restarts.is_current(key, lease)
             || !Self::restart_is_eligible(&inner, key, cause, Instant::now())
@@ -444,15 +445,17 @@ impl Project {
                 .state
                 .containers
                 .get(key)
-                .map_or(0, |record| seconds_since(record.started_at))
-                >= restart::BUDGET_RESET_AFTER.as_secs()
+                .map_or(Duration::ZERO, |record| {
+                    Duration::from_secs(seconds_since(record.started_at))
+                })
+                >= restart_config.window
         {
             inner.restarts.attempts.remove(key);
         }
 
         let spent = {
             let attempt = inner.restarts.attempts.entry(key.to_string()).or_default();
-            if attempt.spent >= restart::MAX_ATTEMPTS {
+            if attempt.spent >= restart_config.max_attempts {
                 None
             } else {
                 attempt.spent += 1;
@@ -462,8 +465,9 @@ impl Project {
         let Some(spent) = spent else {
             inner.restarts.release(key, lease);
             drop(inner);
-            self.report_gave_up(key).await;
-            self.cascade_failure(key, Self::exhausted_reason()).await;
+            self.report_gave_up(key, restart_config.max_attempts).await;
+            self.cascade_failure(key, Self::exhausted_reason(restart_config.max_attempts))
+                .await;
             return;
         };
 
@@ -471,7 +475,7 @@ impl Project {
             &self.project_namespace,
             &format!(
                 "restarting {key} (attempt {spent} of {})",
-                restart::MAX_ATTEMPTS
+                restart_config.max_attempts
             ),
             Tone::Warn,
         );
@@ -485,7 +489,12 @@ impl Project {
         let _ = self.store.save(&restarting);
 
         let result = self
-            .restart_one_locked(&mut inner, key, format!("supervisor:{key}"), Some(spent))
+            .restart_one_locked(
+                &mut inner,
+                key,
+                format!("supervisor:{key}"),
+                Some((spent, restart_config.max_attempts)),
+            )
             .await;
         let ready = result
             .containers
@@ -509,8 +518,8 @@ impl Project {
         // last attempt would hold the container in `restarting` for a wait
         // nobody is going to use, and delay the operator's answer by it.
         let next_retry = match inner.restarts.attempts.get_mut(key) {
-            Some(attempt) if attempt.spent < restart::MAX_ATTEMPTS => {
-                let delay = restart::backoff(attempt.spent);
+            Some(attempt) if attempt.spent < restart_config.max_attempts => {
+                let delay = restart::backoff(&restart_config, attempt.spent);
                 attempt.due = Some(Instant::now() + delay);
                 Some((attempt.spent + 1, delay))
             }
@@ -527,10 +536,11 @@ impl Project {
         let _ = self.store.save(&snapshot);
 
         if let Some((next_attempt, delay)) = next_retry {
-            crate::report::retry_waiting(key, next_attempt, restart::MAX_ATTEMPTS, delay);
+            crate::report::retry_waiting(key, next_attempt, restart_config.max_attempts, delay);
         } else {
-            self.report_gave_up(key).await;
-            self.cascade_failure(key, Self::exhausted_reason()).await;
+            self.report_gave_up(key, restart_config.max_attempts).await;
+            self.cascade_failure(key, Self::exhausted_reason(restart_config.max_attempts))
+                .await;
         }
     }
 
@@ -564,26 +574,24 @@ impl Project {
     /// This container's declared answer to exiting after it was ready. A
     /// container the file no longer declares gets `no`, matching `is_required`:
     /// the rule that stops is the one to fall back on.
-    async fn restart_policy(&self, key: &str) -> RestartPolicy {
+    async fn restart_config(&self, key: &str) -> RestartConfig {
         self.file
             .read()
             .await
             .containers
             .get(key)
-            .map_or(RestartPolicy::No, |container| container.restart)
+            .map(|container| container.restart.clone())
+            .unwrap_or_default()
     }
 
-    fn exhausted_reason() -> String {
-        format!(
-            "did not stay up after {} restart attempts",
-            restart::MAX_ATTEMPTS
-        )
+    fn exhausted_reason(max_attempts: u32) -> String {
+        format!("did not stay up after {max_attempts} restart attempts")
     }
 
-    async fn report_gave_up(&self, key: &str) {
+    async fn report_gave_up(&self, key: &str, max_attempts: u32) {
         daemon_line(
             &self.project_namespace,
-            &format!("{key} {}: giving up", Self::exhausted_reason()),
+            &format!("{key} {}: giving up", Self::exhausted_reason(max_attempts)),
             Tone::Warn,
         );
     }
@@ -1021,7 +1029,7 @@ impl Project {
         inner: &mut Inner,
         key: &str,
         operation_id: String,
-        supervised_attempt: Option<u32>,
+        supervised_attempt: Option<(u32, u32)>,
     ) -> OpResult {
         let config_dir = self.config_dir();
         let package_cache = self.package_cache();
@@ -1043,7 +1051,7 @@ impl Project {
             vm_dir: &vm_dir,
         };
 
-        if let Some(attempt) = supervised_attempt {
+        if let Some((attempt, total_attempts)) = supervised_attempt {
             lifecycle::restart_one_supervised(
                 &ctx,
                 children,
@@ -1051,7 +1059,7 @@ impl Project {
                 key,
                 operation_id,
                 attempt,
-                restart::MAX_ATTEMPTS,
+                total_attempts,
             )
             .await
         } else {

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -59,14 +59,6 @@ pub struct Project {
     logs: LogStore,
     store: StateStore,
     inner: Mutex<Inner>,
-    /// Attempt bookkeeping for the containers the supervisor is currently
-    /// retrying, keyed by container.
-    ///
-    /// Deliberately not in [`DaemonState`], so not on disk. An attempt count
-    /// describes one supervisor's patience with one crash loop, and a daemon
-    /// that restarts re-reconciles from scratch: carrying the old count over
-    /// would let a project come back with its budget already spent.
-    restarts: Mutex<BTreeMap<String, RestartAttempts>>,
 }
 
 /// How often the supervisor checks whether a ready child is still alive.
@@ -97,7 +89,7 @@ const RESTART_MAX_ATTEMPTS: u32 = 5;
 const RESTART_BUDGET_RESET_AFTER: Duration = Duration::from_secs(60);
 
 /// Where one container is in its restart budget.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 struct RestartAttempts {
     /// Attempts already spent in this run of failures.
     spent: u32,
@@ -110,6 +102,78 @@ struct RestartAttempts {
     /// comes back for a second each time, which is the busy loop wearing a
     /// slower coat. Only [`Project::refill_budget_if_it_held`] clears it.
     due: Option<Instant>,
+}
+
+/// Identifies one supervisor claim. Operator operations invalidate the active
+/// claim before they change the same container.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RestartLease(u64);
+
+#[derive(Debug, Clone, Copy)]
+enum RestartCause {
+    UnexpectedExit,
+    RetryDue,
+}
+
+/// In-memory restart state for one daemon run.
+///
+/// Deliberately not in [`DaemonState`], so not on disk. An attempt count
+/// describes one supervisor's patience with one crash loop, and a daemon that
+/// restarts re-reconciles from scratch: carrying the old count over would let
+/// a project come back with its budget already spent.
+#[derive(Debug, Default)]
+struct RestartBookkeeping {
+    attempts: BTreeMap<String, RestartAttempts>,
+    leases: BTreeMap<String, RestartLease>,
+    next_lease: u64,
+}
+
+impl RestartBookkeeping {
+    fn claim(&mut self, key: &str) -> Option<RestartLease> {
+        if self.leases.contains_key(key) {
+            return None;
+        }
+        self.next_lease = self.next_lease.wrapping_add(1);
+        let lease = RestartLease(self.next_lease);
+        self.leases.insert(key.to_string(), lease);
+        Some(lease)
+    }
+
+    fn is_current(&self, key: &str, lease: RestartLease) -> bool {
+        self.leases
+            .get(key)
+            .is_some_and(|current| *current == lease)
+    }
+
+    fn release(&mut self, key: &str, lease: RestartLease) {
+        if self.is_current(key, lease) {
+            self.leases.remove(key);
+        }
+    }
+
+    /// Transfers control from the supervisor to an operator operation without
+    /// refilling the crash-loop budget.
+    fn operator_took_control(&mut self, target: Option<&str>) {
+        match target {
+            Some(key) => {
+                self.leases.remove(key);
+                if let Some(attempt) = self.attempts.get_mut(key) {
+                    attempt.due = None;
+                }
+            }
+            None => {
+                self.leases.clear();
+                for attempt in self.attempts.values_mut() {
+                    attempt.due = None;
+                }
+            }
+        }
+    }
+
+    fn remove(&mut self, key: &str) {
+        self.attempts.remove(key);
+        self.leases.remove(key);
+    }
 }
 
 impl RestartAttempts {
@@ -127,6 +191,7 @@ impl RestartAttempts {
 struct Inner {
     children: Children,
     state: DaemonState,
+    restarts: RestartBookkeeping,
 }
 
 impl Project {
@@ -173,8 +238,8 @@ impl Project {
             inner: Mutex::new(Inner {
                 children: BTreeMap::new(),
                 state,
+                restarts: RestartBookkeeping::default(),
             }),
-            restarts: Mutex::new(BTreeMap::new()),
         });
 
         project.reconcile_recovered().await;
@@ -311,13 +376,10 @@ impl Project {
             // immediately: its dependents stay up, and the exit only cascades
             // once the budget below is spent.
             if self.restart_policy(&key).await.wants_restart(code) {
-                self.refill_budget_if_it_held(&key).await;
-                if self.spend_attempt(&key).await {
-                    self.run_restart_attempt(&key).await;
-                    continue;
+                if let Some(lease) = self.claim_restart(&key, RestartCause::UnexpectedExit).await {
+                    self.run_restart_attempt(&key, lease, RestartCause::UnexpectedExit)
+                        .await;
                 }
-                self.report_gave_up(&key).await;
-                self.cascade_failure(&key, Self::exhausted_reason()).await;
                 continue;
             }
 
@@ -334,8 +396,10 @@ impl Project {
     pub(crate) async fn drive_restarts(&self) {
         let now = Instant::now();
         let due: Vec<String> = {
-            let attempts = self.restarts.lock().await;
-            attempts
+            let inner = self.inner.lock().await;
+            inner
+                .restarts
+                .attempts
                 .iter()
                 .filter(|(_, attempt)| attempt.due.is_some_and(|due| due <= now))
                 .map(|(key, _)| key.clone())
@@ -343,32 +407,52 @@ impl Project {
         };
 
         for key in due {
-            // An operator who ran `up` or `restart` in the meantime has taken
-            // the container back, and the supervisor stops competing for it.
-            // The spent count stays: the operator changed who is driving, not
-            // whether this container has been crashing.
-            let still_waiting = {
-                let inner = self.inner.lock().await;
+            if let Some(lease) = self.claim_restart(&key, RestartCause::RetryDue).await {
+                self.run_restart_attempt(&key, lease, RestartCause::RetryDue)
+                    .await;
+            }
+        }
+    }
+
+    /// Claims the right to restart under the same lock used by operator
+    /// operations. The attempt is not spent until the claim is checked again
+    /// immediately before the bounce.
+    async fn claim_restart(&self, key: &str, cause: RestartCause) -> Option<RestartLease> {
+        let mut inner = self.inner.lock().await;
+        if !Self::restart_is_eligible(&inner, key, cause, Instant::now()) {
+            if matches!(cause, RestartCause::RetryDue)
+                && !inner
+                    .state
+                    .containers
+                    .get(key)
+                    .is_some_and(|record| record.status == ChildStatus::Restarting)
+                && let Some(attempt) = inner.restarts.attempts.get_mut(key)
+            {
+                attempt.due = None;
+            }
+            return None;
+        }
+        inner.restarts.claim(key)
+    }
+
+    fn restart_is_eligible(inner: &Inner, key: &str, cause: RestartCause, now: Instant) -> bool {
+        match cause {
+            RestartCause::UnexpectedExit => inner
+                .children
+                .get(key)
+                .is_some_and(|child| matches!(child.poll(), crate::process::Outcome::Exited(_))),
+            RestartCause::RetryDue => {
                 inner
                     .state
                     .containers
-                    .get(&key)
+                    .get(key)
                     .is_some_and(|record| record.status == ChildStatus::Restarting)
-            };
-            if !still_waiting {
-                if let Some(attempt) = self.restarts.lock().await.get_mut(&key) {
-                    attempt.due = None;
-                }
-                continue;
+                    && inner
+                        .restarts
+                        .attempts
+                        .get(key)
+                        .is_some_and(|attempt| attempt.due.is_some_and(|due| due <= now))
             }
-
-            if self.spend_attempt(&key).await {
-                self.run_restart_attempt(&key).await;
-                continue;
-            }
-
-            self.report_gave_up(&key).await;
-            self.cascade_failure(&key, Self::exhausted_reason()).await;
         }
     }
 
@@ -377,13 +461,43 @@ impl Project {
     /// cannot drift apart. It also means the attempt inherits the rule that a
     /// restart touches one container and not a graph, which is what keeps the
     /// dependents up while this one is gone.
-    async fn run_restart_attempt(&self, key: &str) {
-        let spent = self
-            .restarts
-            .lock()
-            .await
-            .get(key)
-            .map_or(1, |attempt| attempt.spent);
+    async fn run_restart_attempt(&self, key: &str, lease: RestartLease, cause: RestartCause) {
+        let mut inner = self.inner.lock().await;
+        if !inner.restarts.is_current(key, lease)
+            || !Self::restart_is_eligible(&inner, key, cause, Instant::now())
+        {
+            inner.restarts.release(key, lease);
+            return;
+        }
+
+        if matches!(cause, RestartCause::UnexpectedExit)
+            && inner
+                .state
+                .containers
+                .get(key)
+                .map_or(0, |record| seconds_since(record.started_at))
+                >= RESTART_BUDGET_RESET_AFTER.as_secs()
+        {
+            inner.restarts.attempts.remove(key);
+        }
+
+        let spent = {
+            let attempt = inner.restarts.attempts.entry(key.to_string()).or_default();
+            if attempt.spent >= RESTART_MAX_ATTEMPTS {
+                None
+            } else {
+                attempt.spent += 1;
+                Some(attempt.spent)
+            }
+        };
+        let Some(spent) = spent else {
+            inner.restarts.release(key, lease);
+            drop(inner);
+            self.report_gave_up(key).await;
+            self.cascade_failure(key, Self::exhausted_reason()).await;
+            return;
+        };
+
         daemon_line(
             &self.project_namespace,
             &format!("restarting {key} (attempt {spent} of {RESTART_MAX_ATTEMPTS})"),
@@ -392,42 +506,54 @@ impl Project {
 
         // Written before the start so a `compose::status` racing the attempt
         // says `restarting` rather than the `failed` this is trying to undo.
-        self.mark(key, ChildStatus::Restarting, None).await;
+        if let Some(entry) = inner.state.containers.get_mut(key) {
+            entry.status = ChildStatus::Restarting;
+        }
+        let restarting = inner.state.clone();
+        let _ = self.store.save(&restarting);
 
-        let result = self.restart_one(key, format!("supervisor:{key}")).await;
+        let result = self
+            .restart_one_locked(&mut inner, key, format!("supervisor:{key}"))
+            .await;
         let ready = result
             .containers
             .iter()
             .any(|result| result.container == key && result.state == ChildStatus::Ready);
+        inner.restarts.release(key, lease);
         if ready {
             // The record is already `Ready` and nothing more is owed. The spent
             // count survives, so a worker that comes back for a moment each
             // time still runs out of attempts.
-            if let Some(attempt) = self.restarts.lock().await.get_mut(key) {
+            if let Some(attempt) = inner.restarts.attempts.get_mut(key) {
                 attempt.due = None;
             }
+            let snapshot = inner.state.clone();
+            drop(inner);
+            let _ = self.store.save(&snapshot);
             return;
         }
 
         // Only wait if there is something to wait for. Backing off after the
         // last attempt would hold the container in `restarting` for a wait
         // nobody is going to use, and delay the operator's answer by it.
-        let exhausted = {
-            let mut attempts = self.restarts.lock().await;
-            match attempts.get_mut(key) {
-                Some(attempt) if attempt.spent < RESTART_MAX_ATTEMPTS => {
-                    attempt.due = Some(Instant::now() + RestartAttempts::backoff(attempt.spent));
-                    false
-                }
-                _ => true,
+        let exhausted = match inner.restarts.attempts.get_mut(key) {
+            Some(attempt) if attempt.spent < RESTART_MAX_ATTEMPTS => {
+                attempt.due = Some(Instant::now() + RestartAttempts::backoff(attempt.spent));
+                false
             }
+            _ => true,
         };
+
+        if !exhausted && let Some(entry) = inner.state.containers.get_mut(key) {
+            entry.status = ChildStatus::Restarting;
+        }
+        let snapshot = inner.state.clone();
+        drop(inner);
+        let _ = self.store.save(&snapshot);
 
         if exhausted {
             self.report_gave_up(key).await;
             self.cascade_failure(key, Self::exhausted_reason()).await;
-        } else {
-            self.mark(key, ChildStatus::Restarting, None).await;
         }
     }
 
@@ -435,7 +561,7 @@ impl Project {
     /// compose did for every unexpected exit before there was a policy, and
     /// what it still does once one has run out of attempts.
     async fn cascade_failure(&self, key: &str, reason: String) {
-        self.restarts.lock().await.remove(key);
+        self.inner.lock().await.restarts.remove(key);
 
         // Cascade through the same path a targeted `down` takes: it stops
         // the dependents first and ends on the dead container itself, which
@@ -468,38 +594,6 @@ impl Project {
             .containers
             .get(key)
             .map_or(RestartPolicy::No, |container| container.restart)
-    }
-
-    /// Takes one attempt from the budget. `false` means it is spent, which is
-    /// the supervisor's cue to stop and let the failure cascade.
-    async fn spend_attempt(&self, key: &str) -> bool {
-        let mut attempts = self.restarts.lock().await;
-        let attempt = attempts.entry(key.to_string()).or_insert(RestartAttempts {
-            spent: 0,
-            due: None,
-        });
-        if attempt.spent >= RESTART_MAX_ATTEMPTS {
-            return false;
-        }
-        attempt.spent += 1;
-        true
-    }
-
-    /// Refills the budget of a container that had held ready long enough to
-    /// count as recovered, so this crash starts a new run of failures rather
-    /// than continuing one the container already came back from.
-    async fn refill_budget_if_it_held(&self, key: &str) {
-        let held_for = {
-            let inner = self.inner.lock().await;
-            inner
-                .state
-                .containers
-                .get(key)
-                .map_or(0, |record| seconds_since(record.started_at))
-        };
-        if held_for >= RESTART_BUDGET_RESET_AFTER.as_secs() {
-            self.restarts.lock().await.remove(key);
-        }
     }
 
     fn exhausted_reason() -> String {
@@ -655,7 +749,10 @@ impl Project {
         let package_cache = self.package_cache();
         let vm_dir = self.vm_dir();
         let mut inner = self.inner.lock().await;
-        let Inner { children, state } = &mut *inner;
+        inner.restarts.operator_took_control(target);
+        let Inner {
+            children, state, ..
+        } = &mut *inner;
         let file = self.file.read().await;
 
         let ctx = LifecycleCtx {
@@ -690,7 +787,10 @@ impl Project {
         let package_cache = self.package_cache();
         let vm_dir = self.vm_dir();
         let mut inner = self.inner.lock().await;
-        let Inner { children, state } = &mut *inner;
+        inner.restarts.operator_took_control(target);
+        let Inner {
+            children, state, ..
+        } = &mut *inner;
         let file = self.file.read().await;
 
         let ctx = LifecycleCtx {
@@ -736,7 +836,10 @@ impl Project {
         let package_cache = self.package_cache();
         let vm_dir = self.vm_dir();
         let mut inner = self.inner.lock().await;
-        let Inner { children, state } = &mut *inner;
+        inner.restarts.operator_took_control(None);
+        let Inner {
+            children, state, ..
+        } = &mut *inner;
 
         {
             let mut current = self.file.write().await;
@@ -847,7 +950,12 @@ impl Project {
         let package_cache = self.package_cache();
         let vm_dir = self.vm_dir();
         let mut inner = self.inner.lock().await;
-        let Inner { children, state } = &mut *inner;
+        inner.restarts.operator_took_control(None);
+        let Inner {
+            children,
+            state,
+            restarts,
+        } = &mut *inner;
 
         let stopped = {
             let current = self.file.read().await;
@@ -875,6 +983,7 @@ impl Project {
                     )
                     .await,
                 );
+                restarts.remove(worker);
             }
             stopped
         };
@@ -915,13 +1024,29 @@ impl Project {
     /// Bounces one container. See [`lifecycle::restart_one`] for why this does
     /// not take the container's graph with it.
     pub async fn restart_one(&self, key: &str, operation_id: String) -> OpResult {
+        let mut inner = self.inner.lock().await;
+        inner.restarts.operator_took_control(Some(key));
+        let result = self.restart_one_locked(&mut inner, key, operation_id).await;
+
+        let snapshot = inner.state.clone();
+        drop(inner);
+        let _ = self.store.save(&snapshot);
+        result
+    }
+
+    async fn restart_one_locked(
+        &self,
+        inner: &mut Inner,
+        key: &str,
+        operation_id: String,
+    ) -> OpResult {
         let config_dir = self.config_dir();
         let package_cache = self.package_cache();
         let vm_dir = self.vm_dir();
-        let mut inner = self.inner.lock().await;
-        let Inner { children, state } = &mut *inner;
+        let Inner {
+            children, state, ..
+        } = inner;
         let file = self.file.read().await;
-
         let ctx = LifecycleCtx {
             file: &file,
             engine: &self.engine,
@@ -935,13 +1060,7 @@ impl Project {
             vm_dir: &vm_dir,
         };
 
-        let result =
-            lifecycle::restart_one(&ctx, children, &mut state.containers, key, operation_id).await;
-
-        let snapshot = state.clone();
-        drop(inner);
-        let _ = self.store.save(&snapshot);
-        result
+        lifecycle::restart_one(&ctx, children, &mut state.containers, key, operation_id).await
     }
 
     pub async fn down(&self, target: Option<&str>, operation_id: String) -> OpResult {
@@ -949,7 +1068,10 @@ impl Project {
         let package_cache = self.package_cache();
         let vm_dir = self.vm_dir();
         let mut inner = self.inner.lock().await;
-        let Inner { children, state } = &mut *inner;
+        inner.restarts.operator_took_control(target);
+        let Inner {
+            children, state, ..
+        } = &mut *inner;
         let file = self.file.read().await;
 
         let ctx = LifecycleCtx {
@@ -1137,7 +1259,10 @@ fn daemon_line(id: &str, message: &str, tone: Tone) {
 
 #[cfg(test)]
 mod restart_backoff_tests {
-    use super::{RESTART_BACKOFF_BASE, RESTART_BACKOFF_MAX, RESTART_MAX_ATTEMPTS, RestartAttempts};
+    use super::{
+        RESTART_BACKOFF_BASE, RESTART_BACKOFF_MAX, RESTART_MAX_ATTEMPTS, RestartAttempts,
+        RestartBookkeeping,
+    };
 
     /// The wait doubles per attempt and then stops doubling. A ceiling the
     /// budget can never reach would be a ceiling in name only, so this pins
@@ -1168,6 +1293,56 @@ mod restart_backoff_tests {
         assert!(
             total >= RESTART_BACKOFF_BASE,
             "attempts after the first always wait"
+        );
+    }
+
+    #[test]
+    fn operator_control_invalidates_a_supervisor_lease() {
+        let mut restarts = RestartBookkeeping::default();
+        let lease = restarts.claim("api").expect("claim restart");
+
+        restarts.operator_took_control(Some("api"));
+
+        assert!(!restarts.is_current("api", lease));
+    }
+
+    #[test]
+    fn operator_control_pauses_retries_without_refilling_the_budget() {
+        let mut restarts = RestartBookkeeping::default();
+        restarts.attempts.insert(
+            "api".to_string(),
+            RestartAttempts {
+                spent: 3,
+                due: Some(tokio::time::Instant::now()),
+            },
+        );
+
+        restarts.operator_took_control(Some("api"));
+
+        let attempt = restarts.attempts["api"];
+        assert_eq!((attempt.spent, attempt.due), (3, None));
+    }
+
+    #[test]
+    fn removing_a_container_forgets_its_restart_bookkeeping() {
+        let mut restarts = RestartBookkeeping::default();
+        restarts.attempts.insert(
+            "api".to_string(),
+            RestartAttempts {
+                spent: 3,
+                due: Some(tokio::time::Instant::now()),
+            },
+        );
+        let lease = restarts.claim("api").expect("claim restart");
+
+        restarts.remove("api");
+
+        assert_eq!(
+            (
+                restarts.attempts.contains_key("api"),
+                restarts.is_current("api", lease),
+            ),
+            (false, false)
         );
     }
 }

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -34,7 +34,7 @@ use crate::{
     config::{ComposeFile, RestartPolicy},
     engine::EngineClient,
     error::{ComposeError, Result},
-    lifecycle::{self, Children, LifecycleCtx, OpResult, OpStatus},
+    lifecycle::{self, Children, LifecycleCtx, OpResult},
     logs::{LogCursor, LogStore, LogStream, LogsOutcome},
     process::Supervised,
     state::{ChildStatus, DaemonState, Reconciliation, StateStore, reconcile},
@@ -395,7 +395,11 @@ impl Project {
         self.mark(key, ChildStatus::Restarting, None).await;
 
         let result = self.restart_one(key, format!("supervisor:{key}")).await;
-        if result.status == OpStatus::Ok {
+        let ready = result
+            .containers
+            .iter()
+            .any(|result| result.container == key && result.state == ChildStatus::Ready);
+        if ready {
             // The record is already `Ready` and nothing more is owed. The spent
             // count survives, so a worker that comes back for a moment each
             // time still runs out of attempts.

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -25,13 +25,16 @@ use std::{
     time::Duration,
 };
 
-use tokio::sync::{Mutex, RwLock};
+use tokio::{
+    sync::{Mutex, RwLock},
+    time::Instant,
+};
 
 use crate::{
-    config::ComposeFile,
+    config::{ComposeFile, RestartPolicy},
     engine::EngineClient,
     error::{ComposeError, Result},
-    lifecycle::{self, Children, LifecycleCtx, OpResult},
+    lifecycle::{self, Children, LifecycleCtx, OpResult, OpStatus},
     logs::{LogCursor, LogStore, LogStream, LogsOutcome},
     process::Supervised,
     state::{ChildStatus, DaemonState, Reconciliation, StateStore, reconcile},
@@ -56,12 +59,68 @@ pub struct Project {
     logs: LogStore,
     store: StateStore,
     inner: Mutex<Inner>,
+    /// Attempt bookkeeping for the containers the supervisor is currently
+    /// retrying, keyed by container.
+    ///
+    /// Deliberately not in [`DaemonState`], so not on disk. An attempt count
+    /// describes one supervisor's patience with one crash loop, and a daemon
+    /// that restarts re-reconciles from scratch: carrying the old count over
+    /// would let a project come back with its budget already spent.
+    restarts: Mutex<BTreeMap<String, RestartAttempts>>,
 }
 
 /// How often the supervisor checks whether a ready child is still alive.
 /// Fast enough that a crash is reported while the operator is still watching,
 /// slow enough that an idle project costs nothing.
 const SUPERVISION_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Wait before the second restart attempt. Each further attempt doubles it, up
+/// to [`RESTART_BACKOFF_MAX`]. The first attempt does not wait at all: a worker
+/// that died because of a transient is back before the operator looks up, and
+/// one that is genuinely broken has stopped being hammered within seconds.
+const RESTART_BACKOFF_BASE: Duration = Duration::from_millis(500);
+
+/// Ceiling on the wait between attempts. Past this, a longer backoff would only
+/// delay the operator's answer without giving the worker anything it needs.
+const RESTART_BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+/// Consecutive attempts before the supervisor gives up. On the last one it does
+/// what it would have done with no policy at all: fail the container and take
+/// its dependents down. A cap is what separates a restart policy from a busy
+/// loop.
+const RESTART_MAX_ATTEMPTS: u32 = 5;
+
+/// How long a container has to hold `Ready` before its attempt budget refills.
+/// Without it, a worker that crashes once an hour would spend five attempts
+/// over an afternoon and then never be restarted again, which is the opposite
+/// of what its file asked for.
+const RESTART_BUDGET_RESET_AFTER: Duration = Duration::from_secs(60);
+
+/// Where one container is in its restart budget.
+#[derive(Debug, Clone, Copy)]
+struct RestartAttempts {
+    /// Attempts already spent in this run of failures.
+    spent: u32,
+    /// When the next attempt becomes due, and `None` when none is owed — the
+    /// container came back, or an operator took it over. The supervision tick
+    /// is what makes an attempt due, so the backoff never blocks the loop.
+    ///
+    /// A container that is not owed an attempt still keeps its `spent` count.
+    /// Clearing it on every recovery would refill the budget for a worker that
+    /// comes back for a second each time, which is the busy loop wearing a
+    /// slower coat. Only [`Project::refill_budget_if_it_held`] clears it.
+    due: Option<Instant>,
+}
+
+impl RestartAttempts {
+    /// Backoff before the attempt after `spent` have been made: doubling from
+    /// [`RESTART_BACKOFF_BASE`], held at [`RESTART_BACKOFF_MAX`].
+    fn backoff(spent: u32) -> Duration {
+        RESTART_BACKOFF_BASE
+            .saturating_mul(2u32.saturating_pow(spent.saturating_sub(1)))
+            .min(RESTART_BACKOFF_MAX)
+    }
+}
 
 /// The parts that change together. One lock: a caller must never see the
 /// children and the records disagree.
@@ -115,6 +174,7 @@ impl Project {
                 children: BTreeMap::new(),
                 state,
             }),
+            restarts: Mutex::new(BTreeMap::new()),
         });
 
         project.reconcile_recovered().await;
@@ -247,33 +307,222 @@ impl Project {
                 Tone::Warn,
             );
 
-            // Cascade through the same path a targeted `down` takes: it stops
-            // the dependents first and ends on the dead container itself, which
-            // fires its `post_run` and drops it from the map. Leaving dependents
-            // running would leave them talking to something that is gone.
-            let file = self.file.read().await;
-            let dependents = crate::dag::transitive_dependents(&file, &key);
-            drop(file);
-            if !dependents.is_empty() {
-                daemon_line(
-                    &self.project_namespace,
-                    &format!("stopping what depended on {key}: {}", dependents.join(", ")),
-                    Tone::Warn,
-                );
+            // A container that asked to be restarted gets the first attempt
+            // immediately: its dependents stay up, and the exit only cascades
+            // once the budget below is spent.
+            if self.restart_policy(&key).await.wants_restart(code) {
+                self.refill_budget_if_it_held(&key).await;
+                if self.spend_attempt(&key).await {
+                    self.run_restart_attempt(&key).await;
+                    continue;
+                }
+                self.report_gave_up(&key).await;
+                self.cascade_failure(&key, Self::exhausted_reason()).await;
+                continue;
             }
-            self.down(Some(&key), format!("supervisor:{key}")).await;
 
-            // After the cascade, so `down` marking everything Stopped does not
-            // erase why this one went.
-            let mut inner = self.inner.lock().await;
-            if let Some(entry) = inner.state.containers.get_mut(&key) {
-                entry.status = ChildStatus::Failed;
-                entry.last_error = Some(reason);
-            }
-            let snapshot = inner.state.clone();
-            drop(inner);
-            let _ = self.store.save(&snapshot);
+            self.cascade_failure(&key, reason).await;
         }
+    }
+
+    /// Takes the attempts that came due since the last tick.
+    ///
+    /// The waiting happens here rather than in [`Self::run_restart_attempt`] so
+    /// a backoff never blocks the supervision loop, and so a project whose
+    /// worker is in a crash loop does not stop the daemon noticing anything
+    /// else. The tick interval is the granularity of the backoff.
+    pub(crate) async fn drive_restarts(&self) {
+        let now = Instant::now();
+        let due: Vec<String> = {
+            let attempts = self.restarts.lock().await;
+            attempts
+                .iter()
+                .filter(|(_, attempt)| attempt.due.is_some_and(|due| due <= now))
+                .map(|(key, _)| key.clone())
+                .collect()
+        };
+
+        for key in due {
+            // An operator who ran `up` or `restart` in the meantime has taken
+            // the container back, and the supervisor stops competing for it.
+            // The spent count stays: the operator changed who is driving, not
+            // whether this container has been crashing.
+            let still_waiting = {
+                let inner = self.inner.lock().await;
+                inner
+                    .state
+                    .containers
+                    .get(&key)
+                    .is_some_and(|record| record.status == ChildStatus::Restarting)
+            };
+            if !still_waiting {
+                if let Some(attempt) = self.restarts.lock().await.get_mut(&key) {
+                    attempt.due = None;
+                }
+                continue;
+            }
+
+            if self.spend_attempt(&key).await {
+                self.run_restart_attempt(&key).await;
+                continue;
+            }
+
+            self.report_gave_up(&key).await;
+            self.cascade_failure(&key, Self::exhausted_reason()).await;
+        }
+    }
+
+    /// One attempt: the same stop-then-start that `compose::restart` performs,
+    /// so a supervised restart and an operator's restart are the same act and
+    /// cannot drift apart. It also means the attempt inherits the rule that a
+    /// restart touches one container and not a graph, which is what keeps the
+    /// dependents up while this one is gone.
+    async fn run_restart_attempt(&self, key: &str) {
+        let spent = self
+            .restarts
+            .lock()
+            .await
+            .get(key)
+            .map_or(1, |attempt| attempt.spent);
+        daemon_line(
+            &self.project_namespace,
+            &format!("restarting {key} (attempt {spent} of {RESTART_MAX_ATTEMPTS})"),
+            Tone::Warn,
+        );
+
+        // Written before the start so a `compose::status` racing the attempt
+        // says `restarting` rather than the `failed` this is trying to undo.
+        self.mark(key, ChildStatus::Restarting, None).await;
+
+        let result = self.restart_one(key, format!("supervisor:{key}")).await;
+        if result.status == OpStatus::Ok {
+            // The record is already `Ready` and nothing more is owed. The spent
+            // count survives, so a worker that comes back for a moment each
+            // time still runs out of attempts.
+            if let Some(attempt) = self.restarts.lock().await.get_mut(key) {
+                attempt.due = None;
+            }
+            return;
+        }
+
+        // Only wait if there is something to wait for. Backing off after the
+        // last attempt would hold the container in `restarting` for a wait
+        // nobody is going to use, and delay the operator's answer by it.
+        let exhausted = {
+            let mut attempts = self.restarts.lock().await;
+            match attempts.get_mut(key) {
+                Some(attempt) if attempt.spent < RESTART_MAX_ATTEMPTS => {
+                    attempt.due = Some(Instant::now() + RestartAttempts::backoff(attempt.spent));
+                    false
+                }
+                _ => true,
+            }
+        };
+
+        if exhausted {
+            self.report_gave_up(key).await;
+            self.cascade_failure(key, Self::exhausted_reason()).await;
+        } else {
+            self.mark(key, ChildStatus::Restarting, None).await;
+        }
+    }
+
+    /// Fails the container and takes its transitive dependents with it: what
+    /// compose did for every unexpected exit before there was a policy, and
+    /// what it still does once one has run out of attempts.
+    async fn cascade_failure(&self, key: &str, reason: String) {
+        self.restarts.lock().await.remove(key);
+
+        // Cascade through the same path a targeted `down` takes: it stops
+        // the dependents first and ends on the dead container itself, which
+        // fires its `post_run` and drops it from the map. Leaving dependents
+        // running would leave them talking to something that is gone.
+        let file = self.file.read().await;
+        let dependents = crate::dag::transitive_dependents(&file, key);
+        drop(file);
+        if !dependents.is_empty() {
+            daemon_line(
+                &self.project_namespace,
+                &format!("stopping what depended on {key}: {}", dependents.join(", ")),
+                Tone::Warn,
+            );
+        }
+        self.down(Some(key), format!("supervisor:{key}")).await;
+
+        // After the cascade, so `down` marking everything Stopped does not
+        // erase why this one went.
+        self.mark(key, ChildStatus::Failed, Some(reason)).await;
+    }
+
+    /// This container's declared answer to exiting after it was ready. A
+    /// container the file no longer declares gets `no`, matching `is_required`:
+    /// the rule that stops is the one to fall back on.
+    async fn restart_policy(&self, key: &str) -> RestartPolicy {
+        self.file
+            .read()
+            .await
+            .containers
+            .get(key)
+            .map_or(RestartPolicy::No, |container| container.restart)
+    }
+
+    /// Takes one attempt from the budget. `false` means it is spent, which is
+    /// the supervisor's cue to stop and let the failure cascade.
+    async fn spend_attempt(&self, key: &str) -> bool {
+        let mut attempts = self.restarts.lock().await;
+        let attempt = attempts.entry(key.to_string()).or_insert(RestartAttempts {
+            spent: 0,
+            due: None,
+        });
+        if attempt.spent >= RESTART_MAX_ATTEMPTS {
+            return false;
+        }
+        attempt.spent += 1;
+        true
+    }
+
+    /// Refills the budget of a container that had held ready long enough to
+    /// count as recovered, so this crash starts a new run of failures rather
+    /// than continuing one the container already came back from.
+    async fn refill_budget_if_it_held(&self, key: &str) {
+        let held_for = {
+            let inner = self.inner.lock().await;
+            inner
+                .state
+                .containers
+                .get(key)
+                .map_or(0, |record| seconds_since(record.started_at))
+        };
+        if held_for >= RESTART_BUDGET_RESET_AFTER.as_secs() {
+            self.restarts.lock().await.remove(key);
+        }
+    }
+
+    fn exhausted_reason() -> String {
+        format!("did not stay up after {RESTART_MAX_ATTEMPTS} restart attempts")
+    }
+
+    async fn report_gave_up(&self, key: &str) {
+        daemon_line(
+            &self.project_namespace,
+            &format!("{key} {}: giving up", Self::exhausted_reason()),
+            Tone::Warn,
+        );
+    }
+
+    /// Writes a container's status and persists it on the same path, which is
+    /// the rule the whole module is built on.
+    async fn mark(&self, key: &str, status: ChildStatus, last_error: Option<String>) {
+        let mut inner = self.inner.lock().await;
+        if let Some(entry) = inner.state.containers.get_mut(key) {
+            entry.status = status;
+            if last_error.is_some() {
+                entry.last_error = last_error;
+            }
+        }
+        let snapshot = inner.state.clone();
+        drop(inner);
+        let _ = self.store.save(&snapshot);
     }
 
     /// Fatal registration rejection, if the engine refused this daemon —
@@ -855,6 +1104,15 @@ pub struct ContainerStatus {
     pub last_error: Option<String>,
 }
 
+/// How long ago a `started_at` was, in seconds. Saturating, so a clock that
+/// went backwards reads as "just now" rather than as a very old container.
+fn seconds_since(unix_secs: u64) -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|now| now.as_secs().saturating_sub(unix_secs))
+        .unwrap_or_default()
+}
+
 /// Severity of a project log line. Amber means "look at this", not "it broke".
 enum Tone {
     Plain,
@@ -870,5 +1128,42 @@ fn daemon_line(id: &str, message: &str, tone: Tone) {
     match tone {
         Tone::Plain => crate::report::line(&format!("{prefix} {message}")),
         Tone::Warn => crate::report::line(&format!("{prefix} {}", message.yellow())),
+    }
+}
+
+#[cfg(test)]
+mod restart_backoff_tests {
+    use super::{RESTART_BACKOFF_BASE, RESTART_BACKOFF_MAX, RESTART_MAX_ATTEMPTS, RestartAttempts};
+
+    /// The wait doubles per attempt and then stops doubling. A ceiling the
+    /// budget can never reach would be a ceiling in name only, so this pins
+    /// both halves.
+    #[test]
+    fn backoff_doubles_and_then_holds_at_the_ceiling() {
+        assert_eq!(RestartAttempts::backoff(1), RESTART_BACKOFF_BASE);
+        assert_eq!(RestartAttempts::backoff(2), RESTART_BACKOFF_BASE * 2);
+        assert_eq!(RestartAttempts::backoff(3), RESTART_BACKOFF_BASE * 4);
+        assert_eq!(
+            RestartAttempts::backoff(30),
+            RESTART_BACKOFF_MAX,
+            "a long-running loop must not overflow into an unbounded wait"
+        );
+    }
+
+    /// Without a cap the policy is a busy loop, which is what the issue this
+    /// field came from was written to avoid.
+    #[test]
+    fn the_budget_is_spent_in_bounded_time() {
+        let total: std::time::Duration = (1..=RESTART_MAX_ATTEMPTS)
+            .map(RestartAttempts::backoff)
+            .sum();
+        assert!(
+            total <= RESTART_BACKOFF_MAX * RESTART_MAX_ATTEMPTS,
+            "every attempt waits at most the ceiling"
+        );
+        assert!(
+            total >= RESTART_BACKOFF_BASE,
+            "attempts after the first always wait"
+        );
     }
 }

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -513,7 +513,7 @@ impl Project {
         let _ = self.store.save(&restarting);
 
         let result = self
-            .restart_one_locked(&mut inner, key, format!("supervisor:{key}"))
+            .restart_one_locked(&mut inner, key, format!("supervisor:{key}"), Some(spent))
             .await;
         let ready = result
             .containers
@@ -536,22 +536,27 @@ impl Project {
         // Only wait if there is something to wait for. Backing off after the
         // last attempt would hold the container in `restarting` for a wait
         // nobody is going to use, and delay the operator's answer by it.
-        let exhausted = match inner.restarts.attempts.get_mut(key) {
+        let next_retry = match inner.restarts.attempts.get_mut(key) {
             Some(attempt) if attempt.spent < RESTART_MAX_ATTEMPTS => {
-                attempt.due = Some(Instant::now() + RestartAttempts::backoff(attempt.spent));
-                false
+                let delay = RestartAttempts::backoff(attempt.spent);
+                attempt.due = Some(Instant::now() + delay);
+                Some((attempt.spent + 1, delay))
             }
-            _ => true,
+            _ => None,
         };
 
-        if !exhausted && let Some(entry) = inner.state.containers.get_mut(key) {
+        if next_retry.is_some()
+            && let Some(entry) = inner.state.containers.get_mut(key)
+        {
             entry.status = ChildStatus::Restarting;
         }
         let snapshot = inner.state.clone();
         drop(inner);
         let _ = self.store.save(&snapshot);
 
-        if exhausted {
+        if let Some((next_attempt, delay)) = next_retry {
+            crate::report::retry_waiting(key, next_attempt, RESTART_MAX_ATTEMPTS, delay);
+        } else {
             self.report_gave_up(key).await;
             self.cascade_failure(key, Self::exhausted_reason()).await;
         }
@@ -1026,7 +1031,9 @@ impl Project {
     pub async fn restart_one(&self, key: &str, operation_id: String) -> OpResult {
         let mut inner = self.inner.lock().await;
         inner.restarts.operator_took_control(Some(key));
-        let result = self.restart_one_locked(&mut inner, key, operation_id).await;
+        let result = self
+            .restart_one_locked(&mut inner, key, operation_id, None)
+            .await;
 
         let snapshot = inner.state.clone();
         drop(inner);
@@ -1039,6 +1046,7 @@ impl Project {
         inner: &mut Inner,
         key: &str,
         operation_id: String,
+        supervised_attempt: Option<u32>,
     ) -> OpResult {
         let config_dir = self.config_dir();
         let package_cache = self.package_cache();
@@ -1060,7 +1068,20 @@ impl Project {
             vm_dir: &vm_dir,
         };
 
-        lifecycle::restart_one(&ctx, children, &mut state.containers, key, operation_id).await
+        if let Some(attempt) = supervised_attempt {
+            lifecycle::restart_one_supervised(
+                &ctx,
+                children,
+                &mut state.containers,
+                key,
+                operation_id,
+                attempt,
+                RESTART_MAX_ATTEMPTS,
+            )
+            .await
+        } else {
+            lifecycle::restart_one(&ctx, children, &mut state.containers, key, operation_id).await
+        }
     }
 
     pub async fn down(&self, target: Option<&str>, operation_id: String) -> OpResult {

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -545,6 +545,7 @@ impl Project {
                 status: crate::lifecycle::OpStatus::Failed,
                 changed: false,
                 containers: Vec::new(),
+                primary_error: None,
             }
         } else if let Some(shutdown) = shutdown {
             let result = lifecycle::up_until_shutdown(
@@ -564,6 +565,7 @@ impl Project {
                 status: crate::lifecycle::OpStatus::Failed,
                 changed: false,
                 containers: Vec::new(),
+                primary_error: None,
             })
         } else {
             lifecycle::up(&ctx, children, &mut state.containers, None, up_operation_id).await

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -21,6 +21,7 @@
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
+    process::ExitStatus,
     sync::Arc,
     time::Duration,
 };
@@ -319,32 +320,39 @@ impl Project {
     /// observes the gaps between operations — a deliberate stop removes the
     /// child from the map before signalling it, and is never seen here.
     pub(crate) async fn reap_unexpected_exits(&self) {
-        let dead: Vec<(String, i32)> = {
+        let dead: Vec<(String, ExitStatus)> = {
             let inner = self.inner.lock().await;
             inner
                 .children
                 .iter()
                 .filter_map(|(key, child)| match child.poll() {
-                    crate::process::Outcome::Exited(status) => {
-                        Some((key.clone(), status.code().unwrap_or(-1)))
-                    }
+                    crate::process::Outcome::Exited(status) => Some((key.clone(), status)),
                     crate::process::Outcome::Running => None,
                 })
                 .collect()
         };
 
-        for (key, code) in dead {
-            let reason = format!("exited unexpectedly with {code}");
+        for (key, status) in dead {
+            let clean_exit = status.success();
+            let reason = if clean_exit {
+                format!("exited successfully ({status})")
+            } else {
+                format!("exited unexpectedly ({status})")
+            };
             daemon_line(
                 &self.project_namespace,
                 &format!("{key} {reason}"),
-                Tone::Warn,
+                if clean_exit { Tone::Plain } else { Tone::Warn },
             );
 
             // A container that asked to be restarted gets the first attempt
             // immediately: its dependents stay up, and the exit only cascades
             // once the budget below is spent.
-            if self.restart_config(&key).await.wants_restart(code) {
+            if self
+                .restart_config(&key)
+                .await
+                .wants_restart(status.code().unwrap_or(-1))
+            {
                 if let Some(lease) = self.claim_restart(&key, RestartCause::UnexpectedExit).await {
                     self.run_restart_attempt(&key, lease, RestartCause::UnexpectedExit)
                         .await;
@@ -352,7 +360,11 @@ impl Project {
                 continue;
             }
 
-            self.cascade_failure(&key, reason).await;
+            if clean_exit {
+                self.cascade_stop(&key).await;
+            } else {
+                self.cascade_failure(&key, reason).await;
+            }
         }
     }
 
@@ -548,6 +560,20 @@ impl Project {
     /// compose did for every unexpected exit before there was a policy, and
     /// what it still does once one has run out of attempts.
     async fn cascade_failure(&self, key: &str, reason: String) {
+        self.stop_with_dependents(key).await;
+
+        // After the cascade, so `down` marking everything Stopped does not
+        // erase why this one went.
+        self.mark(key, ChildStatus::Failed, Some(reason)).await;
+    }
+
+    /// Records a successful exit that its policy does not restart as stopped.
+    async fn cascade_stop(&self, key: &str) {
+        self.stop_with_dependents(key).await;
+        self.mark(key, ChildStatus::Stopped, None).await;
+    }
+
+    async fn stop_with_dependents(&self, key: &str) {
         self.inner.lock().await.restarts.remove(key);
 
         // Cascade through the same path a targeted `down` takes: it stops
@@ -565,10 +591,6 @@ impl Project {
             );
         }
         self.down(Some(key), format!("supervisor:{key}")).await;
-
-        // After the cascade, so `down` marking everything Stopped does not
-        // erase why this one went.
-        self.mark(key, ChildStatus::Failed, Some(reason)).await;
     }
 
     /// This container's declared answer to exiting after it was ready. A
@@ -602,9 +624,7 @@ impl Project {
         let mut inner = self.inner.lock().await;
         if let Some(entry) = inner.state.containers.get_mut(key) {
             entry.status = status;
-            if last_error.is_some() {
-                entry.last_error = last_error;
-            }
+            entry.last_error = last_error;
         }
         let snapshot = inner.state.clone();
         drop(inner);
@@ -1121,14 +1141,15 @@ impl Project {
                         matches!(child.poll(), crate::process::Outcome::Running)
                     })
                 });
+                let state = match (running, record.map(|record| record.status)) {
+                    (true, _) => ChildStatus::Ready,
+                    (false, Some(status)) => status,
+                    (false, None) => ChildStatus::Stopped,
+                };
                 ContainerStatus {
                     container: key.clone(),
-                    state: match (running, record.map(|record| record.status)) {
-                        (true, _) => ChildStatus::Ready,
-                        (false, Some(status)) => status,
-                        (false, None) => ChildStatus::Stopped,
-                    },
-                    pid: record.map(|record| record.pid),
+                    state,
+                    pid: record.filter(|_| running).map(|record| record.pid),
                     owned: inner
                         .as_ref()
                         .is_some_and(|inner| inner.children.contains_key(key)),

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -832,10 +832,11 @@ fn op_description(function_id: &str) -> &'static str {
     match function_id {
         "compose::up" => {
             "Start a compose project, or one container and its dependencies. \
-             Repeated calls leave ready containers running. Frozen mode requires \
-             declaring 'required: false' is named in not_required_failures \
-             when it fails, and the operation still returns ok. Frozen mode requires \
-             worker-compose.lock to match and skips package resolution."
+             Repeated calls leave ready containers running. A container whose \
+             effective required value is false is named in \
+             not_required_failures when it fails, and the operation still \
+             returns ok. Frozen mode requires worker-compose.lock to match and \
+             skips package resolution."
         }
         "compose::down" => {
             "Stop a compose project, or one container and its dependents, in \

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -833,6 +833,8 @@ fn op_description(function_id: &str) -> &'static str {
         "compose::up" => {
             "Start a compose project, or one container and its dependencies. \
              Repeated calls leave ready containers running. Frozen mode requires \
+             declaring 'required: false' is named in not_required_failures \
+             when it fails, and the operation still returns ok. Frozen mode requires \
              worker-compose.lock to match and skips package resolution."
         }
         "compose::down" => {

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -844,7 +844,9 @@ fn op_description(function_id: &str) -> &'static str {
         "compose::list" => "List every project loaded by this compose daemon.",
         "compose::status" => {
             "Report the project namespace, state directory, daemon pid, and \
-             current state of every declared container."
+             current state of every declared container. A container declaring \
+             a 'restart' policy reports as 'restarting' while it waits for the \
+             supervisor's next attempt."
         }
         "compose::logs" => {
             "Read bounded worker stdout and stderr. A cursor continues from the last response; \

--- a/crates/iii-compose/src/report.rs
+++ b/crates/iii-compose/src/report.rs
@@ -599,8 +599,9 @@ pub fn rolled_back(key: &str) {
     ));
 }
 
-/// Containers that failed and declared `required: false`. Printed before the
-/// closing line so a partial project does not read as a clean start.
+/// Containers that failed with an effective `required` value of `false`.
+/// Printed before the closing line so a partial project does not read as a
+/// clean start.
 pub fn not_required_failed(count: usize) {
     let body = if count == 1 {
         "1 container failed and is not required: the project is up without it".to_string()

--- a/crates/iii-compose/src/report.rs
+++ b/crates/iii-compose/src/report.rs
@@ -84,6 +84,11 @@ enum RowState {
         what: String,
         began: Instant,
     },
+    Retrying {
+        attempt: u32,
+        total: u32,
+        phase: RetryPhase,
+    },
     Ready {
         what: String,
         elapsed: Duration,
@@ -95,6 +100,12 @@ enum RowState {
     },
     /// Already running, or otherwise not this operation's to start.
     Skipped(String),
+}
+
+#[derive(Clone)]
+enum RetryPhase {
+    Waiting(Duration),
+    Starting(String),
 }
 
 struct StartupRows {
@@ -280,6 +291,11 @@ fn console() -> &'static Mutex<Console> {
 /// settles, which is what a log wants anyway.
 pub fn plan(rows: &[(String, usize)]) {
     if !animated() {
+        console()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .rows
+            .clear();
         return;
     }
     {
@@ -340,7 +356,9 @@ fn set(key: &str, to: RowState) -> bool {
     {
         *what = format!("Starting ({ready}/{total})");
     }
-    redraw(&mut state);
+    if animated() {
+        redraw(&mut state);
+    }
     true
 }
 
@@ -389,6 +407,24 @@ fn render_row(row: &Row, frame: usize, animate: bool) -> String {
             what.dimmed(),
             format!("({})", format_elapsed(began.elapsed())).dimmed(),
         ),
+        RowState::Retrying {
+            attempt,
+            total,
+            phase,
+        } => {
+            let phase = retry_label(*attempt, *total, phase);
+            format!(
+                "{indent}{} {} {}",
+                if animate {
+                    FRAMES[frame % FRAMES.len()]
+                } else {
+                    RUNNING
+                }
+                .cyan(),
+                row.key.bold(),
+                phase.dimmed(),
+            )
+        }
         RowState::Ready { what, elapsed } => format!(
             "{indent}{} {} {} {}",
             OK.green(),
@@ -476,10 +512,12 @@ fn ensure_ticker() {
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
                 let turning = state.startup.is_some()
-                    || state
-                        .rows
-                        .iter()
-                        .any(|row| matches!(row.state, RowState::Starting { .. }));
+                    || state.rows.iter().any(|row| {
+                        matches!(
+                            row.state,
+                            RowState::Starting { .. } | RowState::Retrying { .. }
+                        )
+                    });
                 if turning {
                     state.frame = state.frame.wrapping_add(1);
                     redraw(&mut state);
@@ -492,6 +530,18 @@ fn ensure_ticker() {
 /// A container is being worked on. On a terminal this spins until the container
 /// settles; anywhere else it is a plain line.
 pub fn starting(key: &str, what: &str) {
+    let retry = {
+        let state = console().lock().unwrap_or_else(|p| p.into_inner());
+        state.rows.iter().find_map(|row| match &row.state {
+            RowState::Retrying { attempt, total, .. } if row.key == key => Some((*attempt, *total)),
+            _ => None,
+        })
+    };
+    if let Some((attempt, total)) = retry {
+        show_retry(key, attempt, total, RetryPhase::Starting(what.to_string()));
+        return;
+    }
+
     let began = {
         let state = console().lock().unwrap_or_else(|p| p.into_inner());
         state
@@ -518,6 +568,86 @@ pub fn starting(key: &str, what: &str) {
         key.bold(),
         what.dimmed()
     ));
+}
+
+/// Keeps a supervised restart visible while its next attempt is backing off.
+pub(crate) fn retry_waiting(key: &str, attempt: u32, total: u32, delay: Duration) {
+    show_retry(key, attempt, total, RetryPhase::Waiting(delay));
+}
+
+/// Starts one supervised attempt on the row created during its backoff.
+pub(crate) fn retry_starting(key: &str, attempt: u32, total: u32) {
+    show_retry(
+        key,
+        attempt,
+        total,
+        RetryPhase::Starting("starting".to_string()),
+    );
+}
+
+/// Leaves the final supervised attempt as a completed terminal line.
+pub(crate) fn retry_recovered(key: &str, attempt: u32, total: u32, elapsed: Duration) {
+    let row = Row {
+        key: key.to_string(),
+        depth: 0,
+        state: RowState::Ready {
+            what: recovered_label(attempt, total),
+            elapsed,
+        },
+    };
+    show_retry_row(row);
+}
+
+fn show_retry(key: &str, attempt: u32, total: u32, phase: RetryPhase) {
+    let row = Row {
+        key: key.to_string(),
+        depth: 0,
+        state: RowState::Retrying {
+            attempt,
+            total,
+            phase,
+        },
+    };
+    show_retry_row(row);
+}
+
+fn show_retry_row(row: Row) {
+    let animate = animated();
+    let static_line = {
+        let mut state = console()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.rows = vec![row];
+        state.frame = 0;
+        if animate {
+            redraw(&mut state);
+            None
+        } else {
+            state.rows.first().map(|row| render_row(row, 0, false))
+        }
+    };
+
+    if let Some(static_line) = static_line {
+        line(&static_line);
+    } else {
+        ensure_ticker();
+    }
+}
+
+fn retry_label(attempt: u32, total: u32, phase: &RetryPhase) -> String {
+    match phase {
+        RetryPhase::Waiting(delay) => {
+            format!(
+                "Retrying {attempt}/{total}, waiting {}",
+                format_elapsed(*delay)
+            )
+        }
+        RetryPhase::Starting(what) => format!("Retrying {attempt}/{total}, {what}"),
+    }
+}
+
+fn recovered_label(attempt: u32, total: u32) -> String {
+    format!("Recovered on attempt {attempt}/{total}")
 }
 
 pub fn ready(key: &str, elapsed: Duration) {
@@ -812,6 +942,65 @@ mod tests {
         // The finished panel must not be redrawn over subsequent output.
         line("after startup");
         tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+
+    #[test]
+    fn redirected_retry_reports_transitions_without_animation() {
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--ignored",
+                "--exact",
+                "report::tests::retry_panel_fixture",
+                "--nocapture",
+            ])
+            .env_remove("CLICOLOR_FORCE")
+            .env("NO_COLOR", "1")
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{output:?}");
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        let waiting = stderr.find("api Retrying 2/5, waiting 1.0s").unwrap();
+        let configuring = stderr.find("api Retrying 2/5, configuring").unwrap();
+        let recovered = stderr.find("api Recovered on attempt 2/5 (1.8s)").unwrap();
+        assert!(waiting < configuring && configuring < recovered, "{stderr}");
+        assert!(
+            !stderr.contains('\x1b') && !FRAMES.iter().any(|frame| stderr.contains(frame)),
+            "{stderr}"
+        );
+    }
+
+    /// Also usable under a PTY to inspect the retry redraws.
+    #[tokio::test]
+    #[ignore = "subprocess fixture for the retry progress renderer"]
+    async fn retry_panel_fixture() {
+        retry_waiting("api", 2, 5, Duration::from_secs(1));
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        retry_starting("api", 2, 5);
+        starting("api", "configuring");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        retry_recovered("api", 2, 5, Duration::from_millis(1800));
+        plan_done();
+    }
+
+    #[test]
+    fn waiting_retry_names_the_next_attempt_and_delay() {
+        assert_eq!(
+            retry_label(2, 5, &RetryPhase::Waiting(Duration::from_secs(1))),
+            "Retrying 2/5, waiting 1.0s"
+        );
+    }
+
+    #[test]
+    fn active_retry_names_the_attempt_and_phase() {
+        assert_eq!(
+            retry_label(2, 5, &RetryPhase::Starting("configuring".to_string())),
+            "Retrying 2/5, configuring"
+        );
+    }
+
+    #[test]
+    fn recovered_retry_names_the_successful_attempt() {
+        assert_eq!(recovered_label(2, 5), "Recovered on attempt 2/5");
     }
 
     /// A container keeps its colour once it has one, and red is never handed

--- a/crates/iii-compose/src/report.rs
+++ b/crates/iii-compose/src/report.rs
@@ -613,6 +613,13 @@ fn show_retry(key: &str, attempt: u32, total: u32, phase: RetryPhase) {
 
 fn show_retry_row(row: Row) {
     let animate = animated();
+    // During `up`, keep this row inside the dependency tree and preserve its
+    // depth. A run-time retry has no active plan, so it falls through and owns
+    // a one-row block as before.
+    if animate && set(&row.key, row.state.clone()) {
+        return;
+    }
+
     let static_line = {
         let mut state = console()
             .lock()

--- a/crates/iii-compose/src/report.rs
+++ b/crates/iii-compose/src/report.rs
@@ -533,11 +533,22 @@ pub fn starting(key: &str, what: &str) {
     let retry = {
         let state = console().lock().unwrap_or_else(|p| p.into_inner());
         state.rows.iter().find_map(|row| match &row.state {
-            RowState::Retrying { attempt, total, .. } if row.key == key => Some((*attempt, *total)),
+            RowState::Retrying {
+                attempt,
+                total,
+                phase,
+            } if row.key == key => Some((
+                *attempt,
+                *total,
+                matches!(phase, RetryPhase::Starting(current) if current == what),
+            )),
             _ => None,
         })
     };
-    if let Some((attempt, total)) = retry {
+    if let Some((_, _, true)) = retry {
+        return;
+    }
+    if let Some((attempt, total, false)) = retry {
         show_retry(key, attempt, total, RetryPhase::Starting(what.to_string()));
         return;
     }
@@ -739,11 +750,16 @@ pub fn rolled_back(key: &str) {
 /// Containers that failed with an effective `required` value of `false`.
 /// Printed before the closing line so a partial project does not read as a
 /// clean start.
-pub fn not_required_failed(count: usize) {
-    let body = if count == 1 {
-        "1 container failed and is not required: the project is up without it".to_string()
+pub fn not_required_failed(containers: &[String]) {
+    let names = containers
+        .iter()
+        .map(|container| format!("'{container}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let body = if containers.len() == 1 {
+        format!("container {names} failed and is not required: the project is up without it")
     } else {
-        format!("{count} containers failed and are not required: the project is up without them")
+        format!("containers {names} failed and are not required: the project is up without them")
     };
     line(&body.yellow().to_string());
 }
@@ -967,9 +983,18 @@ mod tests {
         assert!(output.status.success(), "{output:?}");
         let stderr = String::from_utf8(output.stderr).unwrap();
         let waiting = stderr.find("api Retrying 2/5, waiting 1.0s").unwrap();
+        let starting = stderr.find("api Retrying 2/5, starting").unwrap();
         let configuring = stderr.find("api Retrying 2/5, configuring").unwrap();
         let recovered = stderr.find("api Recovered on attempt 2/5 (1.8s)").unwrap();
-        assert!(waiting < configuring && configuring < recovered, "{stderr}");
+        assert!(
+            waiting < starting && starting < configuring && configuring < recovered,
+            "{stderr}"
+        );
+        assert_eq!(
+            stderr.matches("api Retrying 2/5, starting").count(),
+            1,
+            "{stderr}"
+        );
         assert!(
             !stderr.contains('\x1b') && !FRAMES.iter().any(|frame| stderr.contains(frame)),
             "{stderr}"
@@ -980,9 +1005,11 @@ mod tests {
     #[tokio::test]
     #[ignore = "subprocess fixture for the retry progress renderer"]
     async fn retry_panel_fixture() {
+        plan(&[("api".to_string(), 0)]);
         retry_waiting("api", 2, 5, Duration::from_secs(1));
         tokio::time::sleep(Duration::from_millis(100)).await;
         retry_starting("api", 2, 5);
+        starting("api", "starting");
         starting("api", "configuring");
         tokio::time::sleep(Duration::from_millis(100)).await;
         retry_recovered("api", 2, 5, Duration::from_millis(1800));

--- a/crates/iii-compose/src/report.rs
+++ b/crates/iii-compose/src/report.rs
@@ -599,6 +599,17 @@ pub fn rolled_back(key: &str) {
     ));
 }
 
+/// Containers that failed and declared `required: false`. Printed before the
+/// closing line so a partial project does not read as a clean start.
+pub fn not_required_failed(count: usize) {
+    let body = if count == 1 {
+        "1 container failed and is not required: the project is up without it".to_string()
+    } else {
+        format!("{count} containers failed and are not required: the project is up without them")
+    };
+    line(&body.yellow().to_string());
+}
+
 /// Closing line of an operation.
 pub fn summary_ok(action: &str, changed: usize, total: usize, elapsed: Duration) {
     let body = if changed == 0 {

--- a/crates/iii-compose/src/restart.rs
+++ b/crates/iii-compose/src/restart.rs
@@ -1,0 +1,58 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Retry limits shared by initial starts and supervised replacements.
+
+use std::time::Duration;
+
+/// Wait before the second restart attempt. Each further attempt doubles it.
+pub(crate) const BACKOFF_BASE: Duration = Duration::from_millis(500);
+
+/// Longest wait between two restart attempts.
+pub(crate) const BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+/// Replacement attempts available after a failed start or unexpected exit.
+pub(crate) const MAX_ATTEMPTS: u32 = 5;
+
+/// Time a container must hold `Ready` before the run-time budget refills.
+pub(crate) const BUDGET_RESET_AFTER: Duration = Duration::from_secs(60);
+
+/// Backoff before the attempt after `spent` attempts have failed.
+pub(crate) fn backoff(spent: u32) -> Duration {
+    BACKOFF_BASE
+        .saturating_mul(2u32.saturating_pow(spent.saturating_sub(1)))
+        .min(BACKOFF_MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_doubles_and_then_holds_at_the_ceiling() {
+        assert_eq!(backoff(1), BACKOFF_BASE);
+        assert_eq!(backoff(2), BACKOFF_BASE * 2);
+        assert_eq!(backoff(3), BACKOFF_BASE * 4);
+        assert_eq!(
+            backoff(30),
+            BACKOFF_MAX,
+            "a long-running loop must not overflow into an unbounded wait"
+        );
+    }
+
+    #[test]
+    fn the_budget_is_spent_in_bounded_time() {
+        let total: Duration = (1..=MAX_ATTEMPTS).map(backoff).sum();
+        assert!(
+            total <= BACKOFF_MAX * MAX_ATTEMPTS,
+            "every attempt waits at most the ceiling"
+        );
+        assert!(
+            total >= BACKOFF_BASE,
+            "attempts after the first always wait"
+        );
+    }
+}

--- a/crates/iii-compose/src/restart.rs
+++ b/crates/iii-compose/src/restart.rs
@@ -4,27 +4,18 @@
 // This software is patent protected. We welcome discussions - reach out at team@iii.dev
 // See LICENSE and PATENTS files for details.
 
-//! Retry limits shared by initial starts and supervised replacements.
+//! Exponential backoff shared by initial starts and supervised replacements.
 
 use std::time::Duration;
 
-/// Wait before the second restart attempt. Each further attempt doubles it.
-pub(crate) const BACKOFF_BASE: Duration = Duration::from_millis(500);
-
-/// Longest wait between two restart attempts.
-pub(crate) const BACKOFF_MAX: Duration = Duration::from_secs(30);
-
-/// Replacement attempts available after a failed start or unexpected exit.
-pub(crate) const MAX_ATTEMPTS: u32 = 5;
-
-/// Time a container must hold `Ready` before the run-time budget refills.
-pub(crate) const BUDGET_RESET_AFTER: Duration = Duration::from_secs(60);
+use crate::config::RestartConfig;
 
 /// Backoff before the attempt after `spent` attempts have failed.
-pub(crate) fn backoff(spent: u32) -> Duration {
-    BACKOFF_BASE
+pub(crate) fn backoff(config: &RestartConfig, spent: u32) -> Duration {
+    config
+        .delay
         .saturating_mul(2u32.saturating_pow(spent.saturating_sub(1)))
-        .min(BACKOFF_MAX)
+        .min(config.max_delay)
 }
 
 #[cfg(test)]
@@ -33,26 +24,42 @@ mod tests {
 
     #[test]
     fn backoff_doubles_and_then_holds_at_the_ceiling() {
-        assert_eq!(backoff(1), BACKOFF_BASE);
-        assert_eq!(backoff(2), BACKOFF_BASE * 2);
-        assert_eq!(backoff(3), BACKOFF_BASE * 4);
+        let config = RestartConfig::default();
+
+        assert_eq!(backoff(&config, 1), config.delay);
+        assert_eq!(backoff(&config, 2), config.delay * 2);
+        assert_eq!(backoff(&config, 3), config.delay * 4);
         assert_eq!(
-            backoff(30),
-            BACKOFF_MAX,
+            backoff(&config, 30),
+            config.max_delay,
             "a long-running loop must not overflow into an unbounded wait"
         );
     }
 
     #[test]
     fn the_budget_is_spent_in_bounded_time() {
-        let total: Duration = (1..=MAX_ATTEMPTS).map(backoff).sum();
+        let config = RestartConfig::default();
+        let total: Duration = (1..=config.max_attempts)
+            .map(|spent| backoff(&config, spent))
+            .sum();
         assert!(
-            total <= BACKOFF_MAX * MAX_ATTEMPTS,
+            total <= config.max_delay * config.max_attempts,
             "every attempt waits at most the ceiling"
         );
         assert!(
-            total >= BACKOFF_BASE,
+            total >= config.delay,
             "attempts after the first always wait"
         );
+    }
+
+    #[test]
+    fn backoff_uses_the_container_limits() {
+        let config = RestartConfig {
+            delay: Duration::from_secs(2),
+            max_delay: Duration::from_secs(3),
+            ..RestartConfig::default()
+        };
+
+        assert_eq!(backoff(&config, 2), Duration::from_secs(3));
     }
 }

--- a/crates/iii-compose/src/state.rs
+++ b/crates/iii-compose/src/state.rs
@@ -64,6 +64,12 @@ pub enum ChildStatus {
     Starting,
     /// Registered in the engine under `(namespace, container)`.
     Ready,
+    /// Exited after it was ready, declared a `restart` policy, and is inside
+    /// the wait before the supervisor's next attempt. Nothing is running under
+    /// this name right now, which is what separates it from `Ready`, and the
+    /// supervisor has not given up on it, which is what separates it from
+    /// `Failed`.
+    Restarting,
     /// Exited unexpectedly, or a hook failed.
     Failed,
     /// Stopped on purpose by this daemon.

--- a/crates/iii-compose/src/state.rs
+++ b/crates/iii-compose/src/state.rs
@@ -70,9 +70,11 @@ pub enum ChildStatus {
     /// supervisor has not given up on it, which is what separates it from
     /// `Failed`.
     Restarting,
-    /// Exited unexpectedly, or a hook failed.
+    /// Exited unsuccessfully with no eligible retry, exhausted its retries, or
+    /// a hook failed.
     Failed,
-    /// Stopped on purpose by this daemon.
+    /// Stopped by the daemon, or exited successfully without an eligible
+    /// restart.
     Stopped,
 }
 

--- a/crates/iii-compose/tests/config_validation.rs
+++ b/crates/iii-compose/tests/config_validation.rs
@@ -562,6 +562,46 @@ containers:
     );
 }
 
+/// A file written before the field existed keeps the strict rule, and a
+/// container opts out one at a time rather than for the project.
+#[test]
+fn required_defaults_to_true_and_is_declared_per_container() {
+    let file = parse(
+        r#"
+namespace: orders
+containers:
+  api:
+    worker: path://./workers/api
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+"#,
+    )
+    .expect("required is part of the container schema");
+
+    assert!(
+        file.containers["api"].required,
+        "a container that says nothing is required"
+    );
+    assert!(!file.containers["mailer"].required);
+}
+
+#[test]
+fn rejects_a_non_boolean_required() {
+    assert_eq!(
+        code(
+            r#"
+namespace: orders
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: "no"
+"#
+        ),
+        "INVALID_COMPOSE_FILE"
+    );
+}
+
 #[test]
 fn rejects_a_user_environment_that_shadows_the_reserved_contract() {
     // Silently dropping it would look like it took effect.

--- a/crates/iii-compose/tests/config_validation.rs
+++ b/crates/iii-compose/tests/config_validation.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use iii_compose::ComposeFile;
+use iii_compose::{ComposeFile, RestartPolicy};
 
 fn parse(text: &str) -> Result<ComposeFile, iii_compose::ComposeError> {
     ComposeFile::parse(text, PathBuf::from("/srv/app/worker-compose.yaml"))
@@ -600,6 +600,78 @@ containers:
         ),
         "INVALID_COMPOSE_FILE"
     );
+}
+
+/// A file written before the field existed keeps the behaviour it was written
+/// against, which is that a ready container that exits stays down.
+///
+/// `no` is spelled unquoted on purpose. YAML 1.1 reads it as `false`, and a
+/// parser that agreed would turn the default spelling into a type error the
+/// first time anyone wrote it out.
+#[test]
+fn restart_defaults_to_no_and_is_declared_per_container() {
+    let file = parse(
+        r#"
+namespace: orders
+containers:
+  api:
+    worker: path://./workers/api
+  mailer:
+    worker: path://./workers/mailer
+    restart: on-failure
+  clock:
+    worker: path://./workers/clock
+    restart: always
+  batch:
+    worker: path://./workers/batch
+    restart: no
+"#,
+    )
+    .expect("restart is part of the container schema");
+
+    assert_eq!(
+        file.containers["api"].restart,
+        RestartPolicy::No,
+        "a container that says nothing keeps the old behaviour"
+    );
+    assert_eq!(file.containers["mailer"].restart, RestartPolicy::OnFailure);
+    assert_eq!(file.containers["clock"].restart, RestartPolicy::Always);
+    assert_eq!(
+        file.containers["batch"].restart,
+        RestartPolicy::No,
+        "an unquoted `no` is the policy, not the boolean false"
+    );
+}
+
+#[test]
+fn rejects_an_unknown_restart_policy() {
+    assert_eq!(
+        code(
+            r#"
+namespace: orders
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    restart: unless-stopped
+"#
+        ),
+        "INVALID_COMPOSE_FILE"
+    );
+}
+
+/// The policies differ only on a clean exit. `on-failure` treats exit 0 as the
+/// worker having finished; `always` treats it as an outage either way.
+#[test]
+fn restart_policies_differ_only_on_a_clean_exit() {
+    assert!(!RestartPolicy::No.wants_restart(1));
+    assert!(!RestartPolicy::No.wants_restart(0));
+
+    assert!(RestartPolicy::OnFailure.wants_restart(1));
+    assert!(RestartPolicy::OnFailure.wants_restart(-1));
+    assert!(!RestartPolicy::OnFailure.wants_restart(0));
+
+    assert!(RestartPolicy::Always.wants_restart(1));
+    assert!(RestartPolicy::Always.wants_restart(0));
 }
 
 #[test]

--- a/crates/iii-compose/tests/config_validation.rs
+++ b/crates/iii-compose/tests/config_validation.rs
@@ -3,7 +3,7 @@
 //! Every rejection asserts the stable error code, not the prose: the codes are
 //! the contract `compose::*` callers match on.
 
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 use iii_compose::{ComposeFile, RestartPolicy};
 
@@ -712,16 +712,108 @@ containers:
     .expect("restart is part of the container schema");
 
     assert_eq!(
-        file.containers["api"].restart,
+        file.containers["api"].restart.condition,
         RestartPolicy::No,
         "a container that says nothing keeps the old behaviour"
     );
-    assert_eq!(file.containers["mailer"].restart, RestartPolicy::OnFailure);
-    assert_eq!(file.containers["clock"].restart, RestartPolicy::Always);
     assert_eq!(
-        file.containers["batch"].restart,
+        file.containers["mailer"].restart.condition,
+        RestartPolicy::OnFailure
+    );
+    assert_eq!(
+        file.containers["clock"].restart.condition,
+        RestartPolicy::Always
+    );
+    assert_eq!(
+        file.containers["batch"].restart.condition,
         RestartPolicy::No,
         "an unquoted `no` is the policy, not the boolean false"
+    );
+}
+
+#[test]
+fn restart_object_configures_backoff_attempts_and_window() {
+    let file = parse(
+        r#"
+namespace: orders
+containers:
+  api:
+    worker: path://./workers/api
+    restart:
+      condition: on-failure
+      delay: 750ms
+      max_delay: 20s
+      max_attempts: 8
+      window: 2m
+"#,
+    )
+    .expect("restart accepts the configurable object form");
+
+    let restart = &file.containers["api"].restart;
+    assert_eq!(
+        (
+            restart.condition,
+            restart.delay,
+            restart.max_delay,
+            restart.max_attempts,
+            restart.window,
+        ),
+        (
+            RestartPolicy::OnFailure,
+            Duration::from_millis(750),
+            Duration::from_secs(20),
+            8,
+            Duration::from_secs(120),
+        )
+    );
+}
+
+#[test]
+fn restart_object_uses_existing_defaults_for_omitted_limits() {
+    let file = parse(
+        r#"
+namespace: orders
+containers:
+  api:
+    worker: path://./workers/api
+    restart:
+      condition: always
+"#,
+    )
+    .expect("restart limits are optional");
+
+    let restart = &file.containers["api"].restart;
+    assert_eq!(
+        (
+            restart.delay,
+            restart.max_delay,
+            restart.max_attempts,
+            restart.window,
+        ),
+        (
+            Duration::from_millis(500),
+            Duration::from_secs(30),
+            5,
+            Duration::from_secs(60),
+        )
+    );
+}
+
+#[test]
+fn rejects_an_invalid_restart_duration() {
+    assert_eq!(
+        code(
+            r#"
+namespace: orders
+containers:
+  api:
+    worker: path://./workers/api
+    restart:
+      condition: on-failure
+      delay: soon
+"#
+        ),
+        "INVALID_DURATION"
     );
 }
 

--- a/crates/iii-compose/tests/config_validation.rs
+++ b/crates/iii-compose/tests/config_validation.rs
@@ -562,28 +562,78 @@ containers:
     );
 }
 
-/// A file written before the field existed keeps the strict rule, and a
-/// container opts out one at a time rather than for the project.
 #[test]
-fn required_defaults_to_true_and_is_declared_per_container() {
+fn required_defaults_to_false() {
     let file = parse(
         r#"
 namespace: orders
 containers:
   api:
     worker: path://./workers/api
-  mailer:
-    worker: path://./workers/mailer
-    required: false
 "#,
     )
     .expect("required is part of the container schema");
 
-    assert!(
-        file.containers["api"].required,
-        "a container that says nothing is required"
+    assert_eq!(
+        (file.required_default, file.containers["api"].required),
+        (false, false)
     );
-    assert!(!file.containers["mailer"].required);
+}
+
+#[test]
+fn containers_inherit_required_default_unless_they_override_it() {
+    let file = parse(
+        r#"
+namespace: default
+startup_timeout: 360s
+stop_timeout: 10s
+required_default: true
+
+engine:
+  url: ws://127.0.0.1:49134
+
+containers:
+  queue:
+    worker: package://queue
+    version: "0.21.9"
+    required: false
+
+  state:
+    worker: package://state
+    version: "0.22.5-rc.1"
+
+  session-manager:
+    worker: package://session-manager
+    version: "1.0.14-rc.4"
+"#,
+    )
+    .expect("required_default is part of the compose schema");
+
+    assert_eq!(
+        (
+            file.required_default,
+            file.containers["queue"].required,
+            file.containers["state"].required,
+            file.containers["session-manager"].required,
+        ),
+        (true, false, true, true)
+    );
+}
+
+#[test]
+fn explicit_required_true_overrides_the_false_default() {
+    let file = parse(
+        r#"
+namespace: orders
+containers:
+  api:
+    worker: path://./workers/api
+    required: true
+"#,
+    )
+    .expect("required is part of the container schema");
+
+    assert!(file.containers["api"].required);
 }
 
 #[test]
@@ -596,6 +646,38 @@ containers:
   mailer:
     worker: path://./workers/mailer
     required: "no"
+"#
+        ),
+        "INVALID_COMPOSE_FILE"
+    );
+}
+
+#[test]
+fn rejects_a_null_required() {
+    assert_eq!(
+        code(
+            r#"
+namespace: orders
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: null
+"#
+        ),
+        "INVALID_COMPOSE_FILE"
+    );
+}
+
+#[test]
+fn rejects_a_non_boolean_required_default() {
+    assert_eq!(
+        code(
+            r#"
+namespace: orders
+required_default: "yes"
+containers:
+  api:
+    worker: path://./workers/api
 "#
         ),
         "INVALID_COMPOSE_FILE"

--- a/docs/next/understanding-iii/compose.mdx
+++ b/docs/next/understanding-iii/compose.mdx
@@ -158,30 +158,43 @@ So a `mailer` that nothing depends on would end the whole start if it failed dur
 contained if it failed a minute later. The same declaration, the same container, two blast radii
 separated only by timing.
 
-Each rule is defensible where it stands. An `up` that reported success over a half-started project
-would be worse than one that refuses, and a supervisor that tore down a whole project because one
-leaf died would be worse than one that contains it. What was missing was a way for the compose file
-to say which it wants, so the choice was compose's rather than the operator's.
+Each rule is useful for a different project. Compose therefore makes the start-time choice part of
+the file instead of assuming that every container has the same blast radius.
 
 ### Saying it in the file
 
-A container declares whether its failure fails the operation:
+A container is not required by default. Its failed start is reported against that container,
+nothing is rolled back, and the operation carries on. Set `required: true` when one container must
+make the operation fail:
 
 ```yaml
 containers:
-  mailer:
-    worker: path://./workers/mailer
-    required: false
+  database:
+    worker: path://./workers/database
+    required: true
 ```
 
-`required: true` is the default and the strict rule above, so a file written before this field
-existed keeps the behavior it was written against. `required: false` narrows the start-time blast
-radius to the one container that declared it: the failure is reported against `mailer`, nothing is
-rolled back, and the operation carries on.
+Use `required_default` to set the fallback for every container in a file. A container-level value
+always wins:
 
-Its dependents carry on too. A container that names `mailer` in `start_after` starts as if it had
-come up, because `start_after` is a start order rather than a claim that the dependent cannot run
-without it. A dependent that genuinely cannot run without `mailer` says so by failing on its own.
+```yaml
+required_default: true
+
+containers:
+  queue:
+    worker: path://./workers/queue
+    required: false
+  state:
+    worker: path://./workers/state
+```
+
+Here, `state` inherits `true`, while `queue` remains false. When neither `required` nor
+`required_default` is present, the effective value is false.
+
+Dependents of a non-required container carry on too. A container that names it in `start_after`
+starts as if it had come up, because `start_after` is a start order rather than a claim that the
+dependent cannot run without it. A dependent that genuinely cannot run without it says so by
+failing on its own.
 
 That moves what `status: ok` means. It used to say every planned container is up; it now says every
 required one is, so the return names the rest in `not_required_failures` rather than leaving a
@@ -207,10 +220,10 @@ the exit status was non-zero. `always` asks for one whatever the status, which i
 worker that is only correct while it is running, where exiting cleanly is still an outage.
 
 A supervised restart is the same act as `compose::restart`: one container stops and starts, and the
-graph around it is left alone. So its dependents stay up while it is gone. That is the reasoning
-`required: false` already uses: `start_after` is a start order rather than a claim that the
-dependent cannot run without it. What that costs is a dependent holding a connection that drops and
-has to reconnect, which is the cost the file asked for by declaring a policy at all.
+graph around it is left alone. So its dependents stay up while it is gone. This is the same reasoning
+that non-required starts use: `start_after` is a start order rather than a claim that the dependent
+cannot run without it. What that costs is a dependent holding a connection that drops and has to
+reconnect, which is the cost the file asked for by declaring a policy at all.
 
 Attempts are capped at five, and each one waits longer than the last, from 500ms up to a ceiling of
 30 seconds. Both halves are load-bearing: a policy with no backoff turns a crash loop into a busy

--- a/docs/next/understanding-iii/compose.mdx
+++ b/docs/next/understanding-iii/compose.mdx
@@ -198,7 +198,7 @@ failing on its own.
 
 That moves what `status: ok` means. It used to say every planned container is up; it now says every
 required one is, so the return names the rest in `not_required_failures` rather than leaving a
-caller to compare the plan against a later status call.
+caller to compare the plan against a later status call. A successful result has no top-level error.
 
 `required` controls the result after Compose finishes trying. A second field controls whether
 Compose retries before it accepts that result.
@@ -217,8 +217,8 @@ containers:
 
 `no` is the default. A failed first start settles immediately, and an exit after `Ready` takes the
 container's transitive dependents down. `on-failure` retries a failed start or a non-zero run-time
-exit. `always` also retries a clean run-time exit, which is the answer for a worker that is only
-correct while it is running.
+exit. A clean run-time exit with `on-failure` is recorded as `stopped`. `always` retries a clean
+run-time exit, which is the answer for a worker that is only correct while it is running.
 
 A supervised restart is the same act as `compose::restart`: one container stops and starts, and the
 graph around it is left alone. So its dependents stay up while it is gone. This is the same reasoning
@@ -236,10 +236,10 @@ When the budget runs out the supervisor does what it would have done with no pol
 the container, takes its dependents down, and says which in the log. That is the shape worth
 keeping: `restart` changes how many times compose tries, and never what happens when trying is over.
 
-`compose::status` reports a ready container waiting on a run-time replacement as `restarting`. It is
+`compose::status` reports a container waiting on a run-time replacement as `restarting`. It is
 not `ready`, because nothing is running under that name, and not `failed`, because the supervisor
-has not given up on it. During `up`, the active progress row shows the retry attempt, its wait, and
-the successful recovery.
+has not given up on it. It has no PID until the next process starts. During `up`, the active progress
+row shows the retry attempt, its wait, and the successful recovery.
 
 ## Related
 

--- a/docs/next/understanding-iii/compose.mdx
+++ b/docs/next/understanding-iii/compose.mdx
@@ -187,12 +187,48 @@ That moves what `status: ok` means. It used to say every planned container is up
 required one is, so the return names the rest in `not_required_failures` rather than leaving a
 caller to compare the plan against a later status call.
 
-The field answers the start-time question and only that one. Once a container is ready, the
-supervisor still takes its transitive dependents down when it exits, whatever the container
-declared, and a project still cannot ask for a dead container to be restarted, because there is no
-restart policy at all. So the two blast radii have narrowed rather than met. The property worth
-keeping is that the answer reads the same at start time and at run time, and the run-time half is
-the restart policy that does not exist yet.
+The field answers the start-time question and only that one. What happens once a container is ready
+is a second question, and it has its own field.
+
+### The run-time half
+
+A container declares what the supervisor does when it exits after it was ready:
+
+```yaml
+containers:
+  api:
+    worker: path://./workers/api
+    restart: on-failure
+```
+
+`no` is the default and the behaviour above: the exit takes the container's transitive dependents
+with it and nothing comes back until someone runs `up` again. `on-failure` asks for a restart when
+the exit status was non-zero. `always` asks for one whatever the status, which is the answer for a
+worker that is only correct while it is running, where exiting cleanly is still an outage.
+
+A supervised restart is the same act as `compose::restart`: one container stops and starts, and the
+graph around it is left alone. So its dependents stay up while it is gone. That is the reasoning
+`required: false` already uses: `start_after` is a start order rather than a claim that the
+dependent cannot run without it. What that costs is a dependent holding a connection that drops and
+has to reconnect, which is the cost the file asked for by declaring a policy at all.
+
+Attempts are capped at five, and each one waits longer than the last, from 500ms up to a ceiling of
+30 seconds. Both halves are load-bearing: a policy with no backoff turns a crash loop into a busy
+loop, and a policy with no cap never lets the operator find out. A container that holds ready for a
+minute has recovered, so its budget refills. A worker that crashes once an hour is therefore
+restarted every time, rather than five times ever.
+
+When the budget runs out the supervisor does what it would have done with no policy at all. It fails
+the container, takes its dependents down, and says which in the log. That is the shape worth
+keeping: `restart` changes how many times compose tries, and never what happens when trying is over.
+
+`compose::status` reports a container waiting on its next attempt as `restarting`. It is not
+`ready`, because nothing is running under that name, and not `failed`, because the supervisor has
+not given up on it.
+
+The policy is deliberately silent about a container that never became ready. That is the start-time
+question, and `required` already answers it. Keeping them apart is what stops one field from
+carrying two blast radii again, which is the thing this whole section exists to fix.
 
 ## Related
 

--- a/docs/next/understanding-iii/compose.mdx
+++ b/docs/next/understanding-iii/compose.mdx
@@ -200,12 +200,13 @@ That moves what `status: ok` means. It used to say every planned container is up
 required one is, so the return names the rest in `not_required_failures` rather than leaving a
 caller to compare the plan against a later status call.
 
-The field answers the start-time question and only that one. What happens once a container is ready
-is a second question, and it has its own field.
+`required` controls the result after Compose finishes trying. A second field controls whether
+Compose retries before it accepts that result.
 
-### The run-time half
+### Retry policy
 
-A container declares what the supervisor does when it exits after it was ready:
+A container declares what Compose does when its first start fails or when it exits after it was
+ready:
 
 ```yaml
 containers:
@@ -214,10 +215,10 @@ containers:
     restart: on-failure
 ```
 
-`no` is the default and the behaviour above: the exit takes the container's transitive dependents
-with it and nothing comes back until someone runs `up` again. `on-failure` asks for a restart when
-the exit status was non-zero. `always` asks for one whatever the status, which is the answer for a
-worker that is only correct while it is running, where exiting cleanly is still an outage.
+`no` is the default. A failed first start settles immediately, and an exit after `Ready` takes the
+container's transitive dependents down. `on-failure` retries a failed start or a non-zero run-time
+exit. `always` also retries a clean run-time exit, which is the answer for a worker that is only
+correct while it is running.
 
 A supervised restart is the same act as `compose::restart`: one container stops and starts, and the
 graph around it is left alone. So its dependents stay up while it is gone. This is the same reasoning
@@ -225,23 +226,20 @@ that non-required starts use: `start_after` is a start order rather than a claim
 cannot run without it. What that costs is a dependent holding a connection that drops and has to
 reconnect, which is the cost the file asked for by declaring a policy at all.
 
-Attempts are capped at five, and each one waits longer than the last, from 500ms up to a ceiling of
-30 seconds. Both halves are load-bearing: a policy with no backoff turns a crash loop into a busy
-loop, and a policy with no cap never lets the operator find out. A container that holds ready for a
-minute has recovered, so its budget refills. A worker that crashes once an hour is therefore
-restarted every time, rather than five times ever.
+Replacement attempts are capped at five. The first retry is immediate. Later retries wait from
+500ms up to a ceiling of 30 seconds. Both limits are load-bearing: a policy with no backoff turns a
+crash loop into a busy loop, and a policy with no cap never lets the operator find out. A container
+that holds ready for a minute has recovered, so its run-time budget refills. A worker that crashes
+once an hour is therefore restarted every time, rather than five times ever.
 
 When the budget runs out the supervisor does what it would have done with no policy at all. It fails
 the container, takes its dependents down, and says which in the log. That is the shape worth
 keeping: `restart` changes how many times compose tries, and never what happens when trying is over.
 
-`compose::status` reports a container waiting on its next attempt as `restarting`. It is not
-`ready`, because nothing is running under that name, and not `failed`, because the supervisor has
-not given up on it.
-
-The policy is deliberately silent about a container that never became ready. That is the start-time
-question, and `required` already answers it. Keeping them apart is what stops one field from
-carrying two blast radii again, which is the thing this whole section exists to fix.
+`compose::status` reports a ready container waiting on a run-time replacement as `restarting`. It is
+not `ready`, because nothing is running under that name, and not `failed`, because the supervisor
+has not given up on it. During `up`, the active progress row shows the retry attempt, its wait, and
+the successful recovery.
 
 ## Related
 

--- a/docs/next/understanding-iii/compose.mdx
+++ b/docs/next/understanding-iii/compose.mdx
@@ -154,21 +154,45 @@ started is rolled back, and everything after it in the start order is never atte
 containers that have nothing to do with it. Once a container is ready, the supervisor is narrower:
 it takes that container's transitive dependents down and leaves the rest alone.
 
-So a `mailer` that nothing depends on ends the whole start if it fails during `up`, and is contained
-if it fails a minute later. The same declaration, the same container, two blast radii separated only
-by timing.
+So a `mailer` that nothing depends on would end the whole start if it failed during `up`, and be
+contained if it failed a minute later. The same declaration, the same container, two blast radii
+separated only by timing.
 
 Each rule is defensible where it stands. An `up` that reported success over a half-started project
 would be worse than one that refuses, and a supervisor that tore down a whole project because one
-leaf died would be worse than one that contains it. What is missing is a way for the compose file to
-say which it wants, so the choice is compose's rather than the operator's. That is a v1 limitation
-rather than a decision: a project cannot mark a container as non-essential, and it cannot ask for a
-dead one to be restarted, because there is no restart policy at all.
+leaf died would be worse than one that contains it. What was missing was a way for the compose file
+to say which it wants, so the choice was compose's rather than the operator's.
 
-Both belong in the file rather than in compose's judgement, and they are two separate questions:
-whether a container's failure fails the operation, and what happens when a ready container exits.
-Whatever those grow into, the property worth keeping is that the answer reads the same at start time
-and at run time.
+### Saying it in the file
+
+A container declares whether its failure fails the operation:
+
+```yaml
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+```
+
+`required: true` is the default and the strict rule above, so a file written before this field
+existed keeps the behavior it was written against. `required: false` narrows the start-time blast
+radius to the one container that declared it: the failure is reported against `mailer`, nothing is
+rolled back, and the operation carries on.
+
+Its dependents carry on too. A container that names `mailer` in `start_after` starts as if it had
+come up, because `start_after` is a start order rather than a claim that the dependent cannot run
+without it. A dependent that genuinely cannot run without `mailer` says so by failing on its own.
+
+That moves what `status: ok` means. It used to say every planned container is up; it now says every
+required one is, so the return names the rest in `not_required_failures` rather than leaving a
+caller to compare the plan against a later status call.
+
+The field answers the start-time question and only that one. Once a container is ready, the
+supervisor still takes its transitive dependents down when it exits, whatever the container
+declared, and a project still cannot ask for a dead container to be restarted, because there is no
+restart policy at all. So the two blast radii have narrowed rather than met. The property worth
+keeping is that the answer reads the same at start time and at run time, and the run-time half is
+the restart policy that does not exist yet.
 
 ## Related
 

--- a/docs/next/understanding-iii/compose.mdx.skill.md
+++ b/docs/next/understanding-iii/compose.mdx.skill.md
@@ -194,7 +194,7 @@ failing on its own.
 
 That moves what `status: ok` means. It used to say every planned container is up; it now says every
 required one is, so the return names the rest in `not_required_failures` rather than leaving a
-caller to compare the plan against a later status call.
+caller to compare the plan against a later status call. A successful result has no top-level error.
 
 `required` controls the result after Compose finishes trying. A second field controls whether
 Compose retries before it accepts that result.
@@ -213,8 +213,8 @@ containers:
 
 `no` is the default. A failed first start settles immediately, and an exit after `Ready` takes the
 container's transitive dependents down. `on-failure` retries a failed start or a non-zero run-time
-exit. `always` also retries a clean run-time exit, which is the answer for a worker that is only
-correct while it is running.
+exit. A clean run-time exit with `on-failure` is recorded as `stopped`. `always` retries a clean
+run-time exit, which is the answer for a worker that is only correct while it is running.
 
 A supervised restart is the same act as `compose::restart`: one container stops and starts, and the
 graph around it is left alone. So its dependents stay up while it is gone. This is the same reasoning
@@ -232,10 +232,10 @@ When the budget runs out the supervisor does what it would have done with no pol
 the container, takes its dependents down, and says which in the log. That is the shape worth
 keeping: `restart` changes how many times compose tries, and never what happens when trying is over.
 
-`compose::status` reports a ready container waiting on a run-time replacement as `restarting`. It is
+`compose::status` reports a container waiting on a run-time replacement as `restarting`. It is
 not `ready`, because nothing is running under that name, and not `failed`, because the supervisor
-has not given up on it. During `up`, the active progress row shows the retry attempt, its wait, and
-the successful recovery.
+has not given up on it. It has no PID until the next process starts. During `up`, the active progress
+row shows the retry attempt, its wait, and the successful recovery.
 
 ## Related
 

--- a/docs/next/understanding-iii/compose.mdx.skill.md
+++ b/docs/next/understanding-iii/compose.mdx.skill.md
@@ -150,21 +150,45 @@ started is rolled back, and everything after it in the start order is never atte
 containers that have nothing to do with it. Once a container is ready, the supervisor is narrower:
 it takes that container's transitive dependents down and leaves the rest alone.
 
-So a `mailer` that nothing depends on ends the whole start if it fails during `up`, and is contained
-if it fails a minute later. The same declaration, the same container, two blast radii separated only
-by timing.
+So a `mailer` that nothing depends on would end the whole start if it failed during `up`, and be
+contained if it failed a minute later. The same declaration, the same container, two blast radii
+separated only by timing.
 
 Each rule is defensible where it stands. An `up` that reported success over a half-started project
 would be worse than one that refuses, and a supervisor that tore down a whole project because one
-leaf died would be worse than one that contains it. What is missing is a way for the compose file to
-say which it wants, so the choice is compose's rather than the operator's. That is a v1 limitation
-rather than a decision: a project cannot mark a container as non-essential, and it cannot ask for a
-dead one to be restarted, because there is no restart policy at all.
+leaf died would be worse than one that contains it. What was missing was a way for the compose file
+to say which it wants, so the choice was compose's rather than the operator's.
 
-Both belong in the file rather than in compose's judgement, and they are two separate questions:
-whether a container's failure fails the operation, and what happens when a ready container exits.
-Whatever those grow into, the property worth keeping is that the answer reads the same at start time
-and at run time.
+### Saying it in the file
+
+A container declares whether its failure fails the operation:
+
+```yaml
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+```
+
+`required: true` is the default and the strict rule above, so a file written before this field
+existed keeps the behavior it was written against. `required: false` narrows the start-time blast
+radius to the one container that declared it: the failure is reported against `mailer`, nothing is
+rolled back, and the operation carries on.
+
+Its dependents carry on too. A container that names `mailer` in `start_after` starts as if it had
+come up, because `start_after` is a start order rather than a claim that the dependent cannot run
+without it. A dependent that genuinely cannot run without `mailer` says so by failing on its own.
+
+That moves what `status: ok` means. It used to say every planned container is up; it now says every
+required one is, so the return names the rest in `not_required_failures` rather than leaving a
+caller to compare the plan against a later status call.
+
+The field answers the start-time question and only that one. Once a container is ready, the
+supervisor still takes its transitive dependents down when it exits, whatever the container
+declared, and a project still cannot ask for a dead container to be restarted, because there is no
+restart policy at all. So the two blast radii have narrowed rather than met. The property worth
+keeping is that the answer reads the same at start time and at run time, and the run-time half is
+the restart policy that does not exist yet.
 
 ## Related
 

--- a/docs/next/understanding-iii/compose.mdx.skill.md
+++ b/docs/next/understanding-iii/compose.mdx.skill.md
@@ -154,30 +154,43 @@ So a `mailer` that nothing depends on would end the whole start if it failed dur
 contained if it failed a minute later. The same declaration, the same container, two blast radii
 separated only by timing.
 
-Each rule is defensible where it stands. An `up` that reported success over a half-started project
-would be worse than one that refuses, and a supervisor that tore down a whole project because one
-leaf died would be worse than one that contains it. What was missing was a way for the compose file
-to say which it wants, so the choice was compose's rather than the operator's.
+Each rule is useful for a different project. Compose therefore makes the start-time choice part of
+the file instead of assuming that every container has the same blast radius.
 
 ### Saying it in the file
 
-A container declares whether its failure fails the operation:
+A container is not required by default. Its failed start is reported against that container,
+nothing is rolled back, and the operation carries on. Set `required: true` when one container must
+make the operation fail:
 
 ```yaml
 containers:
-  mailer:
-    worker: path://./workers/mailer
-    required: false
+  database:
+    worker: path://./workers/database
+    required: true
 ```
 
-`required: true` is the default and the strict rule above, so a file written before this field
-existed keeps the behavior it was written against. `required: false` narrows the start-time blast
-radius to the one container that declared it: the failure is reported against `mailer`, nothing is
-rolled back, and the operation carries on.
+Use `required_default` to set the fallback for every container in a file. A container-level value
+always wins:
 
-Its dependents carry on too. A container that names `mailer` in `start_after` starts as if it had
-come up, because `start_after` is a start order rather than a claim that the dependent cannot run
-without it. A dependent that genuinely cannot run without `mailer` says so by failing on its own.
+```yaml
+required_default: true
+
+containers:
+  queue:
+    worker: path://./workers/queue
+    required: false
+  state:
+    worker: path://./workers/state
+```
+
+Here, `state` inherits `true`, while `queue` remains false. When neither `required` nor
+`required_default` is present, the effective value is false.
+
+Dependents of a non-required container carry on too. A container that names it in `start_after`
+starts as if it had come up, because `start_after` is a start order rather than a claim that the
+dependent cannot run without it. A dependent that genuinely cannot run without it says so by
+failing on its own.
 
 That moves what `status: ok` means. It used to say every planned container is up; it now says every
 required one is, so the return names the rest in `not_required_failures` rather than leaving a
@@ -203,10 +216,10 @@ the exit status was non-zero. `always` asks for one whatever the status, which i
 worker that is only correct while it is running, where exiting cleanly is still an outage.
 
 A supervised restart is the same act as `compose::restart`: one container stops and starts, and the
-graph around it is left alone. So its dependents stay up while it is gone. That is the reasoning
-`required: false` already uses: `start_after` is a start order rather than a claim that the
-dependent cannot run without it. What that costs is a dependent holding a connection that drops and
-has to reconnect, which is the cost the file asked for by declaring a policy at all.
+graph around it is left alone. So its dependents stay up while it is gone. This is the same reasoning
+that non-required starts use: `start_after` is a start order rather than a claim that the dependent
+cannot run without it. What that costs is a dependent holding a connection that drops and has to
+reconnect, which is the cost the file asked for by declaring a policy at all.
 
 Attempts are capped at five, and each one waits longer than the last, from 500ms up to a ceiling of
 30 seconds. Both halves are load-bearing: a policy with no backoff turns a crash loop into a busy

--- a/docs/next/understanding-iii/compose.mdx.skill.md
+++ b/docs/next/understanding-iii/compose.mdx.skill.md
@@ -196,12 +196,13 @@ That moves what `status: ok` means. It used to say every planned container is up
 required one is, so the return names the rest in `not_required_failures` rather than leaving a
 caller to compare the plan against a later status call.
 
-The field answers the start-time question and only that one. What happens once a container is ready
-is a second question, and it has its own field.
+`required` controls the result after Compose finishes trying. A second field controls whether
+Compose retries before it accepts that result.
 
-### The run-time half
+### Retry policy
 
-A container declares what the supervisor does when it exits after it was ready:
+A container declares what Compose does when its first start fails or when it exits after it was
+ready:
 
 ```yaml
 containers:
@@ -210,10 +211,10 @@ containers:
     restart: on-failure
 ```
 
-`no` is the default and the behaviour above: the exit takes the container's transitive dependents
-with it and nothing comes back until someone runs `up` again. `on-failure` asks for a restart when
-the exit status was non-zero. `always` asks for one whatever the status, which is the answer for a
-worker that is only correct while it is running, where exiting cleanly is still an outage.
+`no` is the default. A failed first start settles immediately, and an exit after `Ready` takes the
+container's transitive dependents down. `on-failure` retries a failed start or a non-zero run-time
+exit. `always` also retries a clean run-time exit, which is the answer for a worker that is only
+correct while it is running.
 
 A supervised restart is the same act as `compose::restart`: one container stops and starts, and the
 graph around it is left alone. So its dependents stay up while it is gone. This is the same reasoning
@@ -221,23 +222,20 @@ that non-required starts use: `start_after` is a start order rather than a claim
 cannot run without it. What that costs is a dependent holding a connection that drops and has to
 reconnect, which is the cost the file asked for by declaring a policy at all.
 
-Attempts are capped at five, and each one waits longer than the last, from 500ms up to a ceiling of
-30 seconds. Both halves are load-bearing: a policy with no backoff turns a crash loop into a busy
-loop, and a policy with no cap never lets the operator find out. A container that holds ready for a
-minute has recovered, so its budget refills. A worker that crashes once an hour is therefore
-restarted every time, rather than five times ever.
+Replacement attempts are capped at five. The first retry is immediate. Later retries wait from
+500ms up to a ceiling of 30 seconds. Both limits are load-bearing: a policy with no backoff turns a
+crash loop into a busy loop, and a policy with no cap never lets the operator find out. A container
+that holds ready for a minute has recovered, so its run-time budget refills. A worker that crashes
+once an hour is therefore restarted every time, rather than five times ever.
 
 When the budget runs out the supervisor does what it would have done with no policy at all. It fails
 the container, takes its dependents down, and says which in the log. That is the shape worth
 keeping: `restart` changes how many times compose tries, and never what happens when trying is over.
 
-`compose::status` reports a container waiting on its next attempt as `restarting`. It is not
-`ready`, because nothing is running under that name, and not `failed`, because the supervisor has
-not given up on it.
-
-The policy is deliberately silent about a container that never became ready. That is the start-time
-question, and `required` already answers it. Keeping them apart is what stops one field from
-carrying two blast radii again, which is the thing this whole section exists to fix.
+`compose::status` reports a ready container waiting on a run-time replacement as `restarting`. It is
+not `ready`, because nothing is running under that name, and not `failed`, because the supervisor
+has not given up on it. During `up`, the active progress row shows the retry attempt, its wait, and
+the successful recovery.
 
 ## Related
 

--- a/docs/next/understanding-iii/compose.mdx.skill.md
+++ b/docs/next/understanding-iii/compose.mdx.skill.md
@@ -183,12 +183,48 @@ That moves what `status: ok` means. It used to say every planned container is up
 required one is, so the return names the rest in `not_required_failures` rather than leaving a
 caller to compare the plan against a later status call.
 
-The field answers the start-time question and only that one. Once a container is ready, the
-supervisor still takes its transitive dependents down when it exits, whatever the container
-declared, and a project still cannot ask for a dead container to be restarted, because there is no
-restart policy at all. So the two blast radii have narrowed rather than met. The property worth
-keeping is that the answer reads the same at start time and at run time, and the run-time half is
-the restart policy that does not exist yet.
+The field answers the start-time question and only that one. What happens once a container is ready
+is a second question, and it has its own field.
+
+### The run-time half
+
+A container declares what the supervisor does when it exits after it was ready:
+
+```yaml
+containers:
+  api:
+    worker: path://./workers/api
+    restart: on-failure
+```
+
+`no` is the default and the behaviour above: the exit takes the container's transitive dependents
+with it and nothing comes back until someone runs `up` again. `on-failure` asks for a restart when
+the exit status was non-zero. `always` asks for one whatever the status, which is the answer for a
+worker that is only correct while it is running, where exiting cleanly is still an outage.
+
+A supervised restart is the same act as `compose::restart`: one container stops and starts, and the
+graph around it is left alone. So its dependents stay up while it is gone. That is the reasoning
+`required: false` already uses: `start_after` is a start order rather than a claim that the
+dependent cannot run without it. What that costs is a dependent holding a connection that drops and
+has to reconnect, which is the cost the file asked for by declaring a policy at all.
+
+Attempts are capped at five, and each one waits longer than the last, from 500ms up to a ceiling of
+30 seconds. Both halves are load-bearing: a policy with no backoff turns a crash loop into a busy
+loop, and a policy with no cap never lets the operator find out. A container that holds ready for a
+minute has recovered, so its budget refills. A worker that crashes once an hour is therefore
+restarted every time, rather than five times ever.
+
+When the budget runs out the supervisor does what it would have done with no policy at all. It fails
+the container, takes its dependents down, and says which in the log. That is the shape worth
+keeping: `restart` changes how many times compose tries, and never what happens when trying is over.
+
+`compose::status` reports a container waiting on its next attempt as `restarting`. It is not
+`ready`, because nothing is running under that name, and not `failed`, because the supervisor has
+not given up on it.
+
+The policy is deliberately silent about a container that never became ready. That is the start-time
+question, and `required` already answers it. Keeping them apart is what stops one field from
+carrying two blast radii again, which is the thing this whole section exists to fix.
 
 ## Related
 

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -191,7 +191,8 @@ A worker is not required by default. If it fails to start, its failure is report
 worker, nothing is rolled back, and the operation still returns `ok`. Workers that name it in
 `start_after` start anyway, because `start_after` is a start order and not a claim that the dependent
 cannot run without it. The response lists every worker that failed this way in
-`not_required_failures`, and `error` carries the first reason.
+`not_required_failures`. A response with `status: ok` has no top-level `error`; that field is present
+only when the operation returns `status: failed`.
 
 Set `required: true` when a worker must fail the operation:
 
@@ -454,18 +455,20 @@ the next time the worker is restarted.
 
 ### Checking status
 
-`compose::status` reports each declared worker with its `state`, its `pid`, an `owned` flag, its
-rotating `log_path`, and `last_error` when there is one. `owned` is `false` for a worker this daemon
-has knowledge of but does not manage (ie. was not started by the compose daemon).
+`compose::status` reports each declared worker with its `state`, the active process `pid` when one
+exists, an `owned` flag, its rotating `log_path`, and `last_error` when there is one. `owned` is
+`false` for a worker this daemon has knowledge of but does not manage (ie. was not started by the
+compose daemon).
 
 #### Worker states
 
-| State      | Meaning                                                    |
-| ---------- | ---------------------------------------------------------- |
-| `starting` | Spawned. The engine has not registered it yet.             |
-| `ready`    | Registered in the engine under `(namespace, container)`.   |
-| `failed`   | Exited without being asked to, or one of its hooks failed. |
-| `stopped`  | Stopped by this daemon.                                    |
+| State        | Meaning                                                                                       |
+| ------------ | --------------------------------------------------------------------------------------------- |
+| `starting`   | Spawned. The engine has not registered it yet.                                                |
+| `ready`      | Registered in the engine under `(namespace, container)`.                                      |
+| `restarting` | Waiting for the next configured retry. No process or PID is active.                           |
+| `failed`     | Exited unsuccessfully with no eligible retry, exhausted its retries, or one of its hooks failed. |
+| `stopped`    | Stopped by the daemon, or exited successfully without an eligible restart.                    |
 
 ### Viewing logs
 
@@ -809,10 +812,12 @@ Compose polls `engine::workers::list` every 200 ms until the worker's `startup_t
 | Its functions landed outside the project's namespace.          | `FUNCTIONS_IN_WRONG_NAMESPACE`     |
 | A worker already held that name in the namespace.              | `CONTAINER_NAME_TAKEN`             |
 
-After a worker is ready, the daemon checks it every 250 ms. A worker that exits takes its transitive
-dependents down with it and is recorded as `failed`. Automatic restarts are not performed. When the
-engine connection drops and comes back, every running worker gets its `startup_timeout` to register
-again.
+After a worker is ready, the daemon checks it every 250 ms. Its restart policy determines what
+happens after it exits. An eligible retry keeps its dependents running and reports `restarting`
+between attempts. A successful exit without an eligible retry is recorded as `stopped`. An
+unsuccessful exit without an eligible retry, or one that exhausts its retries, is recorded as
+`failed`. When no retry remains, its transitive dependents stop. When the engine connection drops
+and comes back, every running worker gets its `startup_timeout` to register again.
 
 Dependency shutdown is dependent upon when a shutdown happens:
 

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -190,6 +190,21 @@ ready stay as they are.
 A project that fails to start due to a project-related issue ends the command with
 `PROJECT_DID_NOT_START`. Partial starts are rolled back in reverse dependency order.
 
+A worker that declares `required: false` is the exception:
+
+```yaml
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+```
+
+Its failure is reported against that worker, nothing is rolled back, and the operation still returns
+`ok`. Workers that name it in `start_after` start anyway, because `start_after` is a start order and
+not a claim that the dependent cannot run without it. The response lists every worker that failed
+this way in `not_required_failures`, so an `ok` still says which workers are down, and `error`
+carries the first reason.
+
 ### Stopping a project
 
 `compose::down` stops the project in reverse dependency order.
@@ -579,6 +594,7 @@ Each key under `containers` is the name the worker registers under.
 | `environment`     | map            | empty                | Environment variables for this worker.                                                                     |
 | `env_file`        | array of paths | empty                | Read at start time, in declaration order. A later file wins on conflicting entries.                        |
 | `startup_timeout` | string         | the file's value     | Readiness budget for this worker.                                                                          |
+| `required`        | boolean        | `true`               | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
 | `scripts`         | mapping        | absent               | See below.                                                                                                 |
 
 `path://` directories resolve against the compose file's directory. A missing directory fails with

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -224,10 +224,10 @@ containers:
 In this example, `state` inherits `required_default: true`, while `queue` remains false. If both
 fields are absent, the effective value is false.
 
-#### Restarting a worker that exits
+#### Retrying a worker that fails
 
-A worker that exits after it was ready takes its dependents down with it and stays down. To ask for
-it back instead, declare a restart policy:
+By default, a failed first start settles immediately. A worker that exits after it was ready takes
+its dependents down with it and stays down. To retry either case, declare a restart policy:
 
 ```yaml
 containers:
@@ -236,18 +236,17 @@ containers:
     restart: on-failure
 ```
 
-`no` is the default. `on-failure` restarts the worker when it exited with a non-zero status, and
-`always` restarts it whatever the status.
+`no` is the default. `on-failure` retries a failed start or a worker that exits with a non-zero
+status. `always` also restarts it when it exits successfully after it was ready.
 
-The supervisor tries five times, waiting longer before each attempt, from 500ms up to 30 seconds.
-Only the named worker bounces: workers that name it in `start_after` keep running and see their
+Compose tries five replacements. The first retry is immediate. Later retries wait from 500ms up to
+30 seconds. During `up`, the progress row shows the current attempt and wait. For a run-time exit,
+only the named worker bounces: workers that name it in `start_after` keep running and see their
 connection drop and reconnect. `compose::status` reports the worker as `restarting` while it waits
-for the next attempt. Once the five are spent, the worker is marked `failed`, its dependents are
-stopped, and `last_error` says the supervisor gave up. A worker that stays ready for a minute counts
-as recovered, so its next crash starts the five over.
-
-The policy covers exits only. A worker that never becomes ready in the first place is `required`'s
-question, not this one.
+for a run-time replacement. Once the five are spent, `required` controls whether the startup
+operation fails. At run time, the worker is marked `failed`, its dependents are stopped, and
+`last_error` says the supervisor gave up. A worker that stays ready for a minute counts as recovered,
+so its next run-time crash starts the five over.
 
 ### Stopping a project
 
@@ -641,7 +640,7 @@ Each key under `containers` is the name the worker registers under.
 | `env_file`        | array of paths | empty                | Read at start time, in declaration order. A later file wins on conflicting entries.                        |
 | `startup_timeout` | string         | the file's value     | Readiness budget for this worker.                                                                          |
 | `required`        | boolean        | `false`              | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
-| `restart`         | string         | `no`                 | What happens when the worker exits after it was ready. `no`, `on-failure`, or `always`.                    |
+| `restart`         | string         | `no`                 | What happens after a failed start or a run-time exit. `no`, `on-failure`, or `always`.                     |
 | `scripts`         | mapping        | absent               | See below.                                                                                                 |
 
 `path://` directories resolve against the compose file's directory. A missing directory fails with

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -205,6 +205,31 @@ not a claim that the dependent cannot run without it. The response lists every w
 this way in `not_required_failures`, so an `ok` still says which workers are down, and `error`
 carries the first reason.
 
+#### Restarting a worker that exits
+
+A worker that exits after it was ready takes its dependents down with it and stays down. To ask for
+it back instead, declare a restart policy:
+
+```yaml
+containers:
+  api:
+    worker: path://./workers/api
+    restart: on-failure
+```
+
+`no` is the default. `on-failure` restarts the worker when it exited with a non-zero status, and
+`always` restarts it whatever the status.
+
+The supervisor tries five times, waiting longer before each attempt, from 500ms up to 30 seconds.
+Only the named worker bounces: workers that name it in `start_after` keep running and see their
+connection drop and reconnect. `compose::status` reports the worker as `restarting` while it waits
+for the next attempt. Once the five are spent, the worker is marked `failed`, its dependents are
+stopped, and `last_error` says the supervisor gave up. A worker that stays ready for a minute counts
+as recovered, so its next crash starts the five over.
+
+The policy covers exits only. A worker that never becomes ready in the first place is `required`'s
+question, not this one.
+
 ### Stopping a project
 
 `compose::down` stops the project in reverse dependency order.
@@ -595,6 +620,7 @@ Each key under `containers` is the name the worker registers under.
 | `env_file`        | array of paths | empty                | Read at start time, in declaration order. A later file wins on conflicting entries.                        |
 | `startup_timeout` | string         | the file's value     | Readiness budget for this worker.                                                                          |
 | `required`        | boolean        | `true`               | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
+| `restart`         | string         | `no`                 | What happens when the worker exits after it was ready. `no`, `on-failure`, or `always`.                    |
 | `scripts`         | mapping        | absent               | See below.                                                                                                 |
 
 `path://` directories resolve against the compose file's directory. A missing directory fails with

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -598,13 +598,14 @@ containers:
 
 ### Top-level fields
 
-| Field             | Type   | Default | Description                                                                                   |
-| ----------------- | ------ | ------- | --------------------------------------------------------------------------------------------- |
-| `namespace`       | string | absent  | Namespace the project's workers register in. A project that declares none lands in `default`. |
-| `startup_timeout` | string | `60s`   | Readiness budget for every worker. A worker may override it.                                  |
-| `stop_timeout`    | string | `10s`   | Grace between the polite stop and the forced kill.                                            |
-| `engine`          | map    | absent  | Present when this Compose invocation owns and configures the engine.                          |
-| `containers`      | map    | empty   | Project workers. May be empty only when `engine:` is present.                                 |
+| Field              | Type    | Default | Description                                                                                         |
+| ------------------ | ------- | ------- | --------------------------------------------------------------------------------------------------- |
+| `namespace`        | string  | absent  | Namespace the project's workers register in. A project that declares none lands in `default`.       |
+| `startup_timeout`  | string  | `60s`   | Readiness budget for every worker. A worker may override it.                                        |
+| `stop_timeout`     | string  | `10s`   | Grace between the polite stop and the forced kill.                                                  |
+| `required_default` | boolean | `false` | Fallback for workers that omit `required`. An explicit worker value wins.                            |
+| `engine`           | map     | absent  | Present when this Compose invocation owns and configures the engine.                                |
+| `containers`       | map     | empty   | Project workers. May be empty only when `engine:` is present.                                       |
 
 ### Engine fields
 
@@ -638,7 +639,7 @@ Each key under `containers` is the name the worker registers under.
 | `environment`     | map            | empty                | Environment variables for this worker.                                                                     |
 | `env_file`        | array of paths | empty                | Read at start time, in declaration order. A later file wins on conflicting entries.                        |
 | `startup_timeout` | string         | the file's value     | Readiness budget for this worker.                                                                          |
-| `required`        | boolean        | `true`               | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
+| `required`        | boolean        | `false`              | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
 | `restart`         | string         | `no`                 | What happens when the worker exits after it was ready. `no`, `on-failure`, or `always`.                    |
 | `scripts`         | mapping        | absent               | See below.                                                                                                 |
 

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -617,8 +617,9 @@ containers:
 
 Allowed worker keys are `configuration`, `iii-worker-manager`, `iii-http-functions`, `iii-stream`,
 and `iii-sandbox`. Use `#instance` for another instance of an allowed type, for example
-`iii-worker-manager#rbac`. The engine starts `iii-engine-functions`, `iii-telemetry`, and
-`iii-observability` automatically. Do not declare these workers in the compose file.
+`iii-worker-manager#rbac`. The engine injects `iii-engine-functions`, `iii-telemetry` for anonymous
+usage analytics, and `iii-observability` for OpenTelemetry traces, metrics, and logs. Do not declare
+these workers.
 
 <Note>
   Changes to these worker configurations take effect only after the engine restarts.

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -535,17 +535,11 @@ iii trigger compose::schema --namespace dev function_id=compose::up
 iii trigger compose::schema --namespace dev function_id=worker-compose.yaml
 ```
 
-## Namespaces
+## Configure a namespace
 
-Namespaces are used to allow advanced architectures that require more than one running copy of a
-given worker, multi-tenancy, some multi-agent workflows, and various isolation schemes between
-different parts of a iii application.
-
-Namespaces are arbitrary and their usage depends largely on the given usecase. They do not prescribe
-a specific way of constructing your iii application.
-
-The two primary points where Namespaces are used are during Worker registration via Compose and
-during Trigger and Function interactions. All have ways of declaring which namespace to use.
+Set the namespace in `worker-compose.yaml` or pass `--namespace` when starting Compose. Use the same
+namespace in Trigger and Function calls that target the project's workers. For the daemon namespace,
+project namespace, and routing model, see [Compose architecture](../understanding-iii/compose).
 
 ### Precedence
 
@@ -555,7 +549,7 @@ during Trigger and Function interactions. All have ways of declaring which names
 | `namespace:` in the file | The daemon namespace when `--namespace` is absent, and the project namespace. |
 | Neither                  | `default`.                                                                    |
 
-`namespace` is commonly defined in `worker-compose.yaml` but can be overriden on compose daemon
+`namespace` is commonly defined in `worker-compose.yaml` but can be overridden on compose daemon
 startup with the `--namespace` flag.
 
 Likewise, compose's own `compose::*` functions will exist within the same declared namespace.

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -239,14 +239,36 @@ containers:
 `no` is the default. `on-failure` retries a failed start or a worker that exits with a non-zero
 status. `always` also restarts it when it exits successfully after it was ready.
 
-Compose tries five replacements. The first retry is immediate. Later retries wait from 500ms up to
-30 seconds. During `up`, the progress row shows the current attempt and wait. For a run-time exit,
-only the named worker bounces: workers that name it in `start_after` keep running and see their
-connection drop and reconnect. `compose::status` reports the worker as `restarting` while it waits
-for a run-time replacement. Once the five are spent, `required` controls whether the startup
-operation fails. At run time, the worker is marked `failed`, its dependents are stopped, and
-`last_error` says the supervisor gave up. A worker that stays ready for a minute counts as recovered,
-so its next run-time crash starts the five over.
+The short form uses five attempts, a 500ms base delay, a 30-second maximum delay, and a 60-second
+stability window. Use the object form to change these values for one worker:
+
+```yaml
+containers:
+  api:
+    worker: path://./workers/api
+    restart:
+      condition: on-failure
+      delay: 500ms
+      max_delay: 30s
+      max_attempts: 5
+      window: 60s
+```
+
+| Field | Description | Default |
+| ----- | ----------- | ------- |
+| `condition` | Required in the object form. Accepts `no`, `on-failure`, or `always`. | `no` in the short form |
+| `delay` | Base delay for exponential backoff after a replacement fails. | `500ms` |
+| `max_delay` | Maximum delay between replacement attempts. | `30s` |
+| `max_attempts` | Maximum replacement attempts after the original process fails. | `5` |
+| `window` | Time a ready worker must stay active before its run-time attempt budget resets. | `60s` |
+
+The first replacement is immediate. If it fails, later attempts use exponential backoff from
+`delay` up to `max_delay`. During `up`, the progress row shows the current attempt and wait. For a
+run-time exit, only the named worker bounces: workers that name it in `start_after` keep running and
+see their connection drop and reconnect. `compose::status` reports the worker as `restarting` while
+it waits for a run-time replacement. Once `max_attempts` is spent, `required` controls whether the
+startup operation fails. At run time, the worker is marked `failed`, its dependents are stopped, and
+`last_error` says the supervisor gave up.
 
 ### Stopping a project
 

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -187,23 +187,42 @@ ready stay as they are.
 
 #### compose::up failures
 
-A project that fails to start due to a project-related issue ends the command with
-`PROJECT_DID_NOT_START`. Partial starts are rolled back in reverse dependency order.
+A worker is not required by default. If it fails to start, its failure is reported against that
+worker, nothing is rolled back, and the operation still returns `ok`. Workers that name it in
+`start_after` start anyway, because `start_after` is a start order and not a claim that the dependent
+cannot run without it. The response lists every worker that failed this way in
+`not_required_failures`, and `error` carries the first reason.
 
-A worker that declares `required: false` is the exception:
+Set `required: true` when a worker must fail the operation:
 
 ```yaml
 containers:
-  mailer:
-    worker: path://./workers/mailer
-    required: false
+  database:
+    worker: path://./workers/database
+    required: true
 ```
 
-Its failure is reported against that worker, nothing is rolled back, and the operation still returns
-`ok`. Workers that name it in `start_after` start anyway, because `start_after` is a start order and
-not a claim that the dependent cannot run without it. The response lists every worker that failed
-this way in `not_required_failures`, so an `ok` still says which workers are down, and `error`
-carries the first reason.
+A required failure ends the command with `PROJECT_DID_NOT_START`. Partial starts are rolled back in
+reverse dependency order.
+
+Use `required_default` to change the fallback for all containers in the file. An explicit container
+value wins over the file value:
+
+```yaml
+required_default: true
+
+containers:
+  queue:
+    worker: package://queue
+    version: "0.21.9"
+    required: false
+  state:
+    worker: package://state
+    version: "0.22.5-rc.1"
+```
+
+In this example, `state` inherits `required_default: true`, while `queue` remains false. If both
+fields are absent, the effective value is false.
 
 #### Restarting a worker that exits
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -199,6 +199,31 @@ not a claim that the dependent cannot run without it. The response lists every w
 this way in `not_required_failures`, so an `ok` still says which workers are down, and `error`
 carries the first reason.
 
+#### Restarting a worker that exits
+
+A worker that exits after it was ready takes its dependents down with it and stays down. To ask for
+it back instead, declare a restart policy:
+
+```yaml
+containers:
+  api:
+    worker: path://./workers/api
+    restart: on-failure
+```
+
+`no` is the default. `on-failure` restarts the worker when it exited with a non-zero status, and
+`always` restarts it whatever the status.
+
+The supervisor tries five times, waiting longer before each attempt, from 500ms up to 30 seconds.
+Only the named worker bounces: workers that name it in `start_after` keep running and see their
+connection drop and reconnect. `compose::status` reports the worker as `restarting` while it waits
+for the next attempt. Once the five are spent, the worker is marked `failed`, its dependents are
+stopped, and `last_error` says the supervisor gave up. A worker that stays ready for a minute counts
+as recovered, so its next crash starts the five over.
+
+The policy covers exits only. A worker that never becomes ready in the first place is `required`'s
+question, not this one.
+
 ### Stopping a project
 
 `compose::down` stops the project in reverse dependency order.
@@ -589,6 +614,7 @@ Each key under `containers` is the name the worker registers under.
 | `env_file`        | array of paths | empty                | Read at start time, in declaration order. A later file wins on conflicting entries.                        |
 | `startup_timeout` | string         | the file's value     | Readiness budget for this worker.                                                                          |
 | `required`        | boolean        | `true`               | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
+| `restart`         | string         | `no`                 | What happens when the worker exits after it was ready. `no`, `on-failure`, or `always`.                    |
 | `scripts`         | mapping        | absent               | See below.                                                                                                 |
 
 `path://` directories resolve against the compose file's directory. A missing directory fails with

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -529,17 +529,11 @@ iii trigger compose::schema --namespace dev function_id=compose::up
 iii trigger compose::schema --namespace dev function_id=worker-compose.yaml
 ```
 
-## Namespaces
+## Configure a namespace
 
-Namespaces are used to allow advanced architectures that require more than one running copy of a
-given worker, multi-tenancy, some multi-agent workflows, and various isolation schemes between
-different parts of a iii application.
-
-Namespaces are arbitrary and their usage depends largely on the given usecase. They do not prescribe
-a specific way of constructing your iii application.
-
-The two primary points where Namespaces are used are during Worker registration via Compose and
-during Trigger and Function interactions. All have ways of declaring which namespace to use.
+Set the namespace in `worker-compose.yaml` or pass `--namespace` when starting Compose. Use the same
+namespace in Trigger and Function calls that target the project's workers. For the daemon namespace,
+project namespace, and routing model, see [Compose architecture](../understanding-iii/compose).
 
 ### Precedence
 
@@ -549,7 +543,7 @@ during Trigger and Function interactions. All have ways of declaring which names
 | `namespace:` in the file | The daemon namespace when `--namespace` is absent, and the project namespace. |
 | Neither                  | `default`.                                                                    |
 
-`namespace` is commonly defined in `worker-compose.yaml` but can be overriden on compose daemon
+`namespace` is commonly defined in `worker-compose.yaml` but can be overridden on compose daemon
 startup with the `--namespace` flag.
 
 Likewise, compose's own `compose::*` functions will exist within the same declared namespace.

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -184,6 +184,21 @@ ready stay as they are.
 A project that fails to start due to a project-related issue ends the command with
 `PROJECT_DID_NOT_START`. Partial starts are rolled back in reverse dependency order.
 
+A worker that declares `required: false` is the exception:
+
+```yaml
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+```
+
+Its failure is reported against that worker, nothing is rolled back, and the operation still returns
+`ok`. Workers that name it in `start_after` start anyway, because `start_after` is a start order and
+not a claim that the dependent cannot run without it. The response lists every worker that failed
+this way in `not_required_failures`, so an `ok` still says which workers are down, and `error`
+carries the first reason.
+
 ### Stopping a project
 
 `compose::down` stops the project in reverse dependency order.
@@ -573,6 +588,7 @@ Each key under `containers` is the name the worker registers under.
 | `environment`     | map            | empty                | Environment variables for this worker.                                                                     |
 | `env_file`        | array of paths | empty                | Read at start time, in declaration order. A later file wins on conflicting entries.                        |
 | `startup_timeout` | string         | the file's value     | Readiness budget for this worker.                                                                          |
+| `required`        | boolean        | `true`               | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
 | `scripts`         | mapping        | absent               | See below.                                                                                                 |
 
 `path://` directories resolve against the compose file's directory. A missing directory fails with

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -611,8 +611,9 @@ containers:
 
 Allowed worker keys are `configuration`, `iii-worker-manager`, `iii-http-functions`, `iii-stream`,
 and `iii-sandbox`. Use `#instance` for another instance of an allowed type, for example
-`iii-worker-manager#rbac`. The engine starts `iii-engine-functions`, `iii-telemetry`, and
-`iii-observability` automatically. Do not declare these workers in the compose file.
+`iii-worker-manager#rbac`. The engine injects `iii-engine-functions`, `iii-telemetry` for anonymous
+usage analytics, and `iii-observability` for OpenTelemetry traces, metrics, and logs. Do not declare
+these workers.
 
 <Note>
   Changes to these worker configurations take effect only after the engine restarts.

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -181,23 +181,42 @@ ready stay as they are.
 
 #### compose::up failures
 
-A project that fails to start due to a project-related issue ends the command with
-`PROJECT_DID_NOT_START`. Partial starts are rolled back in reverse dependency order.
+A worker is not required by default. If it fails to start, its failure is reported against that
+worker, nothing is rolled back, and the operation still returns `ok`. Workers that name it in
+`start_after` start anyway, because `start_after` is a start order and not a claim that the dependent
+cannot run without it. The response lists every worker that failed this way in
+`not_required_failures`, and `error` carries the first reason.
 
-A worker that declares `required: false` is the exception:
+Set `required: true` when a worker must fail the operation:
 
 ```yaml
 containers:
-  mailer:
-    worker: path://./workers/mailer
-    required: false
+  database:
+    worker: path://./workers/database
+    required: true
 ```
 
-Its failure is reported against that worker, nothing is rolled back, and the operation still returns
-`ok`. Workers that name it in `start_after` start anyway, because `start_after` is a start order and
-not a claim that the dependent cannot run without it. The response lists every worker that failed
-this way in `not_required_failures`, so an `ok` still says which workers are down, and `error`
-carries the first reason.
+A required failure ends the command with `PROJECT_DID_NOT_START`. Partial starts are rolled back in
+reverse dependency order.
+
+Use `required_default` to change the fallback for all containers in the file. An explicit container
+value wins over the file value:
+
+```yaml
+required_default: true
+
+containers:
+  queue:
+    worker: package://queue
+    version: "0.21.9"
+    required: false
+  state:
+    worker: package://state
+    version: "0.22.5-rc.1"
+```
+
+In this example, `state` inherits `required_default: true`, while `queue` remains false. If both
+fields are absent, the effective value is false.
 
 #### Restarting a worker that exits
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -233,14 +233,36 @@ containers:
 `no` is the default. `on-failure` retries a failed start or a worker that exits with a non-zero
 status. `always` also restarts it when it exits successfully after it was ready.
 
-Compose tries five replacements. The first retry is immediate. Later retries wait from 500ms up to
-30 seconds. During `up`, the progress row shows the current attempt and wait. For a run-time exit,
-only the named worker bounces: workers that name it in `start_after` keep running and see their
-connection drop and reconnect. `compose::status` reports the worker as `restarting` while it waits
-for a run-time replacement. Once the five are spent, `required` controls whether the startup
-operation fails. At run time, the worker is marked `failed`, its dependents are stopped, and
-`last_error` says the supervisor gave up. A worker that stays ready for a minute counts as recovered,
-so its next run-time crash starts the five over.
+The short form uses five attempts, a 500ms base delay, a 30-second maximum delay, and a 60-second
+stability window. Use the object form to change these values for one worker:
+
+```yaml
+containers:
+  api:
+    worker: path://./workers/api
+    restart:
+      condition: on-failure
+      delay: 500ms
+      max_delay: 30s
+      max_attempts: 5
+      window: 60s
+```
+
+| Field | Description | Default |
+| ----- | ----------- | ------- |
+| `condition` | Required in the object form. Accepts `no`, `on-failure`, or `always`. | `no` in the short form |
+| `delay` | Base delay for exponential backoff after a replacement fails. | `500ms` |
+| `max_delay` | Maximum delay between replacement attempts. | `30s` |
+| `max_attempts` | Maximum replacement attempts after the original process fails. | `5` |
+| `window` | Time a ready worker must stay active before its run-time attempt budget resets. | `60s` |
+
+The first replacement is immediate. If it fails, later attempts use exponential backoff from
+`delay` up to `max_delay`. During `up`, the progress row shows the current attempt and wait. For a
+run-time exit, only the named worker bounces: workers that name it in `start_after` keep running and
+see their connection drop and reconnect. `compose::status` reports the worker as `restarting` while
+it waits for a run-time replacement. Once `max_attempts` is spent, `required` controls whether the
+startup operation fails. At run time, the worker is marked `failed`, its dependents are stopped, and
+`last_error` says the supervisor gave up.
 
 ### Stopping a project
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -218,10 +218,10 @@ containers:
 In this example, `state` inherits `required_default: true`, while `queue` remains false. If both
 fields are absent, the effective value is false.
 
-#### Restarting a worker that exits
+#### Retrying a worker that fails
 
-A worker that exits after it was ready takes its dependents down with it and stays down. To ask for
-it back instead, declare a restart policy:
+By default, a failed first start settles immediately. A worker that exits after it was ready takes
+its dependents down with it and stays down. To retry either case, declare a restart policy:
 
 ```yaml
 containers:
@@ -230,18 +230,17 @@ containers:
     restart: on-failure
 ```
 
-`no` is the default. `on-failure` restarts the worker when it exited with a non-zero status, and
-`always` restarts it whatever the status.
+`no` is the default. `on-failure` retries a failed start or a worker that exits with a non-zero
+status. `always` also restarts it when it exits successfully after it was ready.
 
-The supervisor tries five times, waiting longer before each attempt, from 500ms up to 30 seconds.
-Only the named worker bounces: workers that name it in `start_after` keep running and see their
+Compose tries five replacements. The first retry is immediate. Later retries wait from 500ms up to
+30 seconds. During `up`, the progress row shows the current attempt and wait. For a run-time exit,
+only the named worker bounces: workers that name it in `start_after` keep running and see their
 connection drop and reconnect. `compose::status` reports the worker as `restarting` while it waits
-for the next attempt. Once the five are spent, the worker is marked `failed`, its dependents are
-stopped, and `last_error` says the supervisor gave up. A worker that stays ready for a minute counts
-as recovered, so its next crash starts the five over.
-
-The policy covers exits only. A worker that never becomes ready in the first place is `required`'s
-question, not this one.
+for a run-time replacement. Once the five are spent, `required` controls whether the startup
+operation fails. At run time, the worker is marked `failed`, its dependents are stopped, and
+`last_error` says the supervisor gave up. A worker that stays ready for a minute counts as recovered,
+so its next run-time crash starts the five over.
 
 ### Stopping a project
 
@@ -635,7 +634,7 @@ Each key under `containers` is the name the worker registers under.
 | `env_file`        | array of paths | empty                | Read at start time, in declaration order. A later file wins on conflicting entries.                        |
 | `startup_timeout` | string         | the file's value     | Readiness budget for this worker.                                                                          |
 | `required`        | boolean        | `false`              | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
-| `restart`         | string         | `no`                 | What happens when the worker exits after it was ready. `no`, `on-failure`, or `always`.                    |
+| `restart`         | string         | `no`                 | What happens after a failed start or a run-time exit. `no`, `on-failure`, or `always`.                     |
 | `scripts`         | mapping        | absent               | See below.                                                                                                 |
 
 `path://` directories resolve against the compose file's directory. A missing directory fails with

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -592,13 +592,14 @@ containers:
 
 ### Top-level fields
 
-| Field             | Type   | Default | Description                                                                                   |
-| ----------------- | ------ | ------- | --------------------------------------------------------------------------------------------- |
-| `namespace`       | string | absent  | Namespace the project's workers register in. A project that declares none lands in `default`. |
-| `startup_timeout` | string | `60s`   | Readiness budget for every worker. A worker may override it.                                  |
-| `stop_timeout`    | string | `10s`   | Grace between the polite stop and the forced kill.                                            |
-| `engine`          | map    | absent  | Present when this Compose invocation owns and configures the engine.                          |
-| `containers`      | map    | empty   | Project workers. May be empty only when `engine:` is present.                                 |
+| Field              | Type    | Default | Description                                                                                         |
+| ------------------ | ------- | ------- | --------------------------------------------------------------------------------------------------- |
+| `namespace`        | string  | absent  | Namespace the project's workers register in. A project that declares none lands in `default`.       |
+| `startup_timeout`  | string  | `60s`   | Readiness budget for every worker. A worker may override it.                                        |
+| `stop_timeout`     | string  | `10s`   | Grace between the polite stop and the forced kill.                                                  |
+| `required_default` | boolean | `false` | Fallback for workers that omit `required`. An explicit worker value wins.                            |
+| `engine`           | map     | absent  | Present when this Compose invocation owns and configures the engine.                                |
+| `containers`       | map     | empty   | Project workers. May be empty only when `engine:` is present.                                       |
 
 ### Engine fields
 
@@ -632,7 +633,7 @@ Each key under `containers` is the name the worker registers under.
 | `environment`     | map            | empty                | Environment variables for this worker.                                                                     |
 | `env_file`        | array of paths | empty                | Read at start time, in declaration order. A later file wins on conflicting entries.                        |
 | `startup_timeout` | string         | the file's value     | Readiness budget for this worker.                                                                          |
-| `required`        | boolean        | `true`               | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
+| `required`        | boolean        | `false`              | Whether a failed start fails the operation. `false` reports the failure and lets the operation carry on.   |
 | `restart`         | string         | `no`                 | What happens when the worker exits after it was ready. `no`, `on-failure`, or `always`.                    |
 | `scripts`         | mapping        | absent               | See below.                                                                                                 |
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -185,7 +185,8 @@ A worker is not required by default. If it fails to start, its failure is report
 worker, nothing is rolled back, and the operation still returns `ok`. Workers that name it in
 `start_after` start anyway, because `start_after` is a start order and not a claim that the dependent
 cannot run without it. The response lists every worker that failed this way in
-`not_required_failures`, and `error` carries the first reason.
+`not_required_failures`. A response with `status: ok` has no top-level `error`; that field is present
+only when the operation returns `status: failed`.
 
 Set `required: true` when a worker must fail the operation:
 
@@ -448,18 +449,20 @@ the next time the worker is restarted.
 
 ### Checking status
 
-`compose::status` reports each declared worker with its `state`, its `pid`, an `owned` flag, its
-rotating `log_path`, and `last_error` when there is one. `owned` is `false` for a worker this daemon
-has knowledge of but does not manage (ie. was not started by the compose daemon).
+`compose::status` reports each declared worker with its `state`, the active process `pid` when one
+exists, an `owned` flag, its rotating `log_path`, and `last_error` when there is one. `owned` is
+`false` for a worker this daemon has knowledge of but does not manage (ie. was not started by the
+compose daemon).
 
 #### Worker states
 
-| State      | Meaning                                                    |
-| ---------- | ---------------------------------------------------------- |
-| `starting` | Spawned. The engine has not registered it yet.             |
-| `ready`    | Registered in the engine under `(namespace, container)`.   |
-| `failed`   | Exited without being asked to, or one of its hooks failed. |
-| `stopped`  | Stopped by this daemon.                                    |
+| State        | Meaning                                                                                       |
+| ------------ | --------------------------------------------------------------------------------------------- |
+| `starting`   | Spawned. The engine has not registered it yet.                                                |
+| `ready`      | Registered in the engine under `(namespace, container)`.                                      |
+| `restarting` | Waiting for the next configured retry. No process or PID is active.                           |
+| `failed`     | Exited unsuccessfully with no eligible retry, exhausted its retries, or one of its hooks failed. |
+| `stopped`    | Stopped by the daemon, or exited successfully without an eligible restart.                    |
 
 ### Viewing logs
 
@@ -803,10 +806,12 @@ Compose polls `engine::workers::list` every 200 ms until the worker's `startup_t
 | Its functions landed outside the project's namespace.          | `FUNCTIONS_IN_WRONG_NAMESPACE`     |
 | A worker already held that name in the namespace.              | `CONTAINER_NAME_TAKEN`             |
 
-After a worker is ready, the daemon checks it every 250 ms. A worker that exits takes its transitive
-dependents down with it and is recorded as `failed`. Automatic restarts are not performed. When the
-engine connection drops and comes back, every running worker gets its `startup_timeout` to register
-again.
+After a worker is ready, the daemon checks it every 250 ms. Its restart policy determines what
+happens after it exits. An eligible retry keeps its dependents running and reports `restarting`
+between attempts. A successful exit without an eligible retry is recorded as `stopped`. An
+unsuccessful exit without an eligible retry, or one that exhausts its retries, is recorded as
+`failed`. When no retry remains, its transitive dependents stop. When the engine connection drops
+and comes back, every running worker gets its `startup_timeout` to register again.
 
 Dependency shutdown is dependent upon when a shutdown happens:
 

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -1216,6 +1216,54 @@ containers:
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn a_required_failure_is_reported_after_a_not_required_failure() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: optional
+startup_timeout: 2s
+stop_timeout: 100ms
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+    scripts:
+      run: "sleep 30"
+  api:
+    worker: path://./workers/api
+    start_after: [mailer]
+    required: true
+    scripts:
+      run: "exit 9"
+"#,
+        &["mailer", "api"],
+    );
+
+    let up = call(
+        port,
+        "compose::up",
+        json!({ "file": file.to_str().unwrap() }),
+    )
+    .await
+    .expect("compose::up should answer");
+
+    assert_eq!(
+        up["status"], "failed",
+        "a container that is required must fail the operation: {up}"
+    );
+    assert_eq!(
+        up["error"]["code"], "CHILD_EXITED_BEFORE_REGISTRATION",
+        "the required container error must be reported: {up}"
+    );
+    daemon.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn logs_continue_from_a_cursor_after_the_worker_is_ready() {
     isolate_state();
     let port = spawn_engine().await;

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -1278,6 +1278,10 @@ containers:
         "a failed restart of a container that is not required must not fail: {restart}"
     );
     assert_eq!(
+        restart["changed"], true,
+        "stopping the old worker must report a state change: {restart}"
+    );
+    assert_eq!(
         restart["not_required_failures"],
         json!(["mailer"]),
         "the failed restart must name the optional container: {restart}"

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -343,6 +343,7 @@ const TWO_WORKERS: &str = r#"
 namespace: orders
 startup_timeout: 2s
 stop_timeout: 1s
+required_default: true
 containers:
   database:
     worker: path://./workers/database
@@ -1178,12 +1179,12 @@ async fn a_child_that_never_registers_times_out_and_rolls_back() {
     daemon.shutdown().await;
 }
 
-/// `required: false` moves the blast radius of a failed start from the whole
-/// operation to the one container that declared it, and a dependent starts on
-/// the same declaration: `start_after` is a start order, not a claim that the
-/// dependent cannot run without it.
+/// The default `required: false` moves the blast radius of a failed start from
+/// the whole operation to the one container that failed, and a dependent
+/// starts on the same declaration: `start_after` is a start order, not a claim
+/// that the dependent cannot run without it.
 #[tokio::test(flavor = "multi_thread")]
-async fn a_container_that_is_not_required_fails_alone_and_its_dependent_still_starts() {
+async fn a_container_uses_the_false_required_default_and_its_dependent_still_starts() {
     isolate_state();
     let port = spawn_engine().await;
     let daemon = start_daemon(port).await;
@@ -1199,7 +1200,6 @@ stop_timeout: 100ms
 containers:
   mailer:
     worker: path://./workers/mailer
-    required: false
     scripts:
       run: "sleep 30"
   api:
@@ -1559,7 +1559,7 @@ containers:
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn a_required_failure_is_reported_after_a_not_required_failure() {
+async fn an_inherited_required_failure_is_reported_after_an_explicit_optional_failure() {
     isolate_state();
     let port = spawn_engine().await;
     let daemon = start_daemon(port).await;
@@ -1571,6 +1571,7 @@ async fn a_required_failure_is_reported_after_a_not_required_failure() {
 namespace: optional
 startup_timeout: 2s
 stop_timeout: 100ms
+required_default: true
 containers:
   mailer:
     worker: path://./workers/mailer
@@ -1580,7 +1581,6 @@ containers:
   api:
     worker: path://./workers/api
     start_after: [mailer]
-    required: true
     scripts:
       run: "exit 9"
 "#,
@@ -1845,6 +1845,7 @@ async fn a_configuration_that_cannot_be_read_stops_the_container() {
 namespace: orders
 startup_timeout: 2s
 stop_timeout: 1s
+required_default: true
 containers:
   database:
     worker: path://./workers/database

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -1373,11 +1373,12 @@ containers:
     daemon.shutdown().await;
 }
 
-/// The cap is what separates a restart policy from a busy loop. Once it is
-/// spent the supervisor does what it would have done with no policy at all:
-/// fails the container and takes its dependents down.
+/// `required` controls startup only, so a non-required container still spends
+/// its restart budget after it had become ready. Once the budget is spent the
+/// supervisor does what it would have done with no policy at all: fails the
+/// container and takes its dependents down.
 #[tokio::test(flavor = "multi_thread")]
-async fn a_container_that_never_stays_up_exhausts_its_attempts_and_cascades() {
+async fn a_not_required_container_that_never_stays_up_exhausts_attempts_and_cascades() {
     isolate_state();
     let port = spawn_engine().await;
     let daemon = start_daemon(port).await;
@@ -1398,6 +1399,7 @@ stop_timeout: 100ms
 containers:
   api:
     worker: path://./workers/api
+    required: false
     restart: on-failure
     scripts:
       run: "echo up >> attempts; while [ ! -f die ]; do sleep 0.05; done; exit 1"

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -188,6 +188,60 @@ async fn wait_for_start_markers(paths: &[&std::path::Path]) {
     .expect("children did not reach their start barriers");
 }
 
+/// Waits until a child has recorded at least `wanted` incarnations.
+///
+/// One line per start, so the count is how many times the supervisor has
+/// spawned the container rather than how many times it crashed.
+async fn wait_for_attempts(path: &std::path::Path, wanted: usize) {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let seen = std::fs::read_to_string(path)
+                .map(|text| text.lines().count())
+                .unwrap_or(0);
+            if seen >= wanted {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("{} did not reach {wanted} starts", path.display()));
+}
+
+/// Waits until `compose::status` reports a container in `wanted`.
+///
+/// The engine seeing a registration and compose having recorded the container
+/// as ready are two different facts, and a supervised restart is where they
+/// come apart: the replacement registers a moment before the start that is
+/// waiting on it returns.
+async fn wait_for_container_state(port: u16, file: &std::path::Path, key: &str, wanted: &str) {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let status = call(
+                port,
+                "compose::status",
+                json!({ "file": file.to_str().unwrap() }),
+            )
+            .await
+            .expect("compose::status should answer");
+            let seen = status["containers"]
+                .as_array()
+                .and_then(|containers| {
+                    containers
+                        .iter()
+                        .find(|container| container["container"] == key)
+                })
+                .map(|container| container["state"].clone());
+            if seen.as_ref().and_then(|state| state.as_str()) == Some(wanted) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("{key} did not reach state {wanted}"));
+}
+
 /// Waits for the engine to observe a worker registration or its removal.
 async fn wait_for_worker_state(daemon: &Daemon, namespace: &str, name: &str, registered: bool) {
     tokio::time::timeout(Duration::from_secs(15), async {
@@ -1212,6 +1266,214 @@ containers:
     );
 
     api.shutdown_async().await;
+    daemon.shutdown().await;
+}
+
+/// `restart: on-failure` answers the run-time half of the same question
+/// `required` answers at start time: a ready container that exits comes back
+/// instead of taking its dependents down with it.
+///
+/// The dependent staying up is the point. A restart is one container bouncing,
+/// so `web` sees its dependency drop and reconnect, which is the cost the file
+/// asked for by declaring the policy at all.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_ready_container_that_exits_is_restarted_and_its_dependent_stays_up() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let attempts = tmp.path().join("workers/api/attempts");
+    let die = tmp.path().join("workers/api/die");
+    let web_started = tmp.path().join("workers/web/started");
+
+    // `api` records every incarnation, then exits non-zero the moment `die`
+    // appears. It removes the file on its way out so the replacement survives
+    // and the test controls exactly how many times it crashes.
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: restarts
+startup_timeout: 5s
+stop_timeout: 100ms
+containers:
+  api:
+    worker: path://./workers/api
+    restart: on-failure
+    scripts:
+      run: "echo up >> attempts; while [ ! -f die ]; do sleep 0.05; done; rm -f die; exit 1"
+  web:
+    worker: path://./workers/web
+    start_after: [api]
+    scripts:
+      run: "touch started && sleep 30"
+"#,
+        &["api", "web"],
+    );
+
+    let up = call(
+        port,
+        "compose::up",
+        json!({ "file": file.to_str().unwrap() }),
+    );
+    let ready = async {
+        wait_for_start_markers(&[attempts.as_path()]).await;
+        let api = register_test_worker(port, "restarts", "api");
+        wait_for_worker_state(&daemon, "restarts", "api", true).await;
+        wait_for_start_markers(&[web_started.as_path()]).await;
+        let web = register_test_worker(port, "restarts", "web");
+        wait_for_worker_state(&daemon, "restarts", "web", true).await;
+        (api, web)
+    };
+    let (up, (api, web)) = tokio::join!(up, ready);
+    let up = up.expect("compose::up should answer");
+    assert_eq!(up["status"], "ok", "the project should start: {up}");
+
+    // Kill the ready container. A real worker's registration dies with its
+    // process; here the test holds that identity, so it has to let go for the
+    // replacement to be able to take the name.
+    std::fs::write(&die, "").expect("ask api to exit");
+    api.shutdown_async().await;
+    wait_for_worker_state(&daemon, "restarts", "api", false).await;
+
+    // The supervisor spawns a replacement, which reaches the same barrier.
+    wait_for_attempts(&attempts, 2).await;
+    let api = register_test_worker(port, "restarts", "api");
+    wait_for_container_state(port, &file, "api", "ready").await;
+
+    let status = call(
+        port,
+        "compose::status",
+        json!({ "file": file.to_str().unwrap() }),
+    )
+    .await
+    .expect("status after a supervised restart");
+    let state = |key: &str| {
+        status["containers"]
+            .as_array()
+            .expect("containers")
+            .iter()
+            .find(|container| container["container"] == key)
+            .unwrap_or_else(|| panic!("missing {key}: {status}"))["state"]
+            .clone()
+    };
+    assert_eq!(
+        state("api"),
+        "ready",
+        "the restarted container should be ready again: {status}"
+    );
+    assert_eq!(
+        state("web"),
+        "ready",
+        "a restart must not cascade to dependents: {status}"
+    );
+
+    api.shutdown_async().await;
+    web.shutdown_async().await;
+    daemon.shutdown().await;
+}
+
+/// The cap is what separates a restart policy from a busy loop. Once it is
+/// spent the supervisor does what it would have done with no policy at all:
+/// fails the container and takes its dependents down.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_container_that_never_stays_up_exhausts_its_attempts_and_cascades() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let attempts = tmp.path().join("workers/api/attempts");
+    let die = tmp.path().join("workers/api/die");
+    let web_started = tmp.path().join("workers/web/started");
+
+    // Unlike the test above, `api` leaves `die` in place, so every replacement
+    // exits the moment it starts and none of them ever becomes ready.
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: exhausted
+startup_timeout: 2s
+stop_timeout: 100ms
+containers:
+  api:
+    worker: path://./workers/api
+    restart: on-failure
+    scripts:
+      run: "echo up >> attempts; while [ ! -f die ]; do sleep 0.05; done; exit 1"
+  web:
+    worker: path://./workers/web
+    start_after: [api]
+    scripts:
+      run: "touch started && sleep 30"
+"#,
+        &["api", "web"],
+    );
+
+    let up = call(
+        port,
+        "compose::up",
+        json!({ "file": file.to_str().unwrap() }),
+    );
+    let ready = async {
+        wait_for_start_markers(&[attempts.as_path()]).await;
+        let api = register_test_worker(port, "exhausted", "api");
+        wait_for_worker_state(&daemon, "exhausted", "api", true).await;
+        wait_for_start_markers(&[web_started.as_path()]).await;
+        let web = register_test_worker(port, "exhausted", "web");
+        wait_for_worker_state(&daemon, "exhausted", "web", true).await;
+        (api, web)
+    };
+    let (up, (api, web)) = tokio::join!(up, ready);
+    assert_eq!(
+        up.expect("compose::up should answer")["status"],
+        "ok",
+        "the project should start before anything crashes"
+    );
+
+    std::fs::write(&die, "").expect("ask api to exit");
+    api.shutdown_async().await;
+
+    // Every attempt is spent, and only then does the failure cascade.
+    wait_for_container_state(port, &file, "api", "failed").await;
+
+    let status = call(
+        port,
+        "compose::status",
+        json!({ "file": file.to_str().unwrap() }),
+    )
+    .await
+    .expect("status after the budget is spent");
+    let container = |key: &str| {
+        status["containers"]
+            .as_array()
+            .expect("containers")
+            .iter()
+            .find(|container| container["container"] == key)
+            .unwrap_or_else(|| panic!("missing {key}: {status}"))
+            .clone()
+    };
+    assert_ne!(
+        container("web")["state"],
+        "ready",
+        "a container that ran out of attempts must take its dependents down: {status}"
+    );
+    assert!(
+        container("api")["last_error"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("restart attempts")),
+        "the record should say the supervisor gave up: {status}"
+    );
+
+    let starts = std::fs::read_to_string(&attempts)
+        .map(|text| text.lines().count())
+        .unwrap_or(0);
+    assert_eq!(
+        starts, 6,
+        "one original start plus a capped five attempts, not a busy loop"
+    );
+
+    web.shutdown_async().await;
     daemon.shutdown().await;
 }
 

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -1216,6 +1216,81 @@ containers:
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn restarting_a_not_required_container_reports_its_failed_start_without_failing() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let started = tmp.path().join("workers/mailer/started");
+    let manifest = tmp.path().join("workers/mailer/iii.worker.yaml");
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: optional-restart
+startup_timeout: 2s
+stop_timeout: 100ms
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+"#,
+        &["mailer"],
+    );
+    std::fs::write(
+        &manifest,
+        "scripts:\n  start: \"touch started && sleep 30\"\n",
+    )
+    .expect("write initial worker manifest");
+
+    let up = call(
+        port,
+        "compose::up",
+        json!({ "file": file.to_str().unwrap() }),
+    );
+    let ready = async {
+        wait_for_start_markers(&[started.as_path()]).await;
+        let mailer = register_test_worker(port, "optional-restart", "mailer");
+        wait_for_worker_state(&daemon, "optional-restart", "mailer", true).await;
+        mailer
+    };
+    let (up, mailer) = tokio::join!(up, ready);
+    let up = up.expect("compose::up should answer");
+    assert_eq!(up["status"], "ok", "initial start failed: {up}");
+
+    mailer.shutdown_async().await;
+    std::fs::write(&manifest, "scripts:\n  start: \"exit 9\"\n")
+        .expect("replace worker start command");
+
+    let restart = call(
+        port,
+        "compose::restart",
+        json!({
+            "file": file.to_str().unwrap(),
+            "container": "mailer",
+        }),
+    )
+    .await
+    .expect("compose::restart should answer");
+
+    assert_eq!(
+        restart["status"], "ok",
+        "a failed restart of a container that is not required must not fail: {restart}"
+    );
+    assert_eq!(
+        restart["not_required_failures"],
+        json!(["mailer"]),
+        "the failed restart must name the optional container: {restart}"
+    );
+    assert_eq!(
+        restart["error"]["code"], "CHILD_EXITED_BEFORE_REGISTRATION",
+        "the failed restart must retain its error: {restart}"
+    );
+
+    daemon.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn a_required_failure_is_reported_after_a_not_required_failure() {
     isolate_state();
     let port = spawn_engine().await;

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -1236,9 +1236,9 @@ containers:
         json!(["mailer"]),
         "the return has to name what is down under an ok: {up}"
     );
-    assert_eq!(
-        up["error"]["code"], "STARTUP_TIMEOUT",
-        "the reason for the contained failure is still reported: {up}"
+    assert!(
+        up.get("error").is_none(),
+        "a successful operation must not carry a top-level error: {up}"
     );
 
     // Rollback is what `required: true` buys, so nothing may have been undone.
@@ -1431,6 +1431,93 @@ containers:
     daemon.shutdown().await;
 }
 
+/// `on-failure` does not restart a successful run-time exit. The worker is
+/// stopped, has no live PID, and does not retain an error from an earlier
+/// state.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_clean_exit_with_on_failure_stops_without_retrying() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let attempts = tmp.path().join("workers/api/attempts");
+    let done = tmp.path().join("workers/api/done");
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: clean-exit
+startup_timeout: 5s
+stop_timeout: 100ms
+containers:
+  api:
+    worker: path://./workers/api
+    restart: on-failure
+    scripts:
+      run: "echo up >> attempts; while [ ! -f done ]; do sleep 0.05; done; exit 0"
+"#,
+        &["api"],
+    );
+
+    let up = call(
+        port,
+        "compose::up",
+        json!({ "file": file.to_str().unwrap() }),
+    );
+    let ready = async {
+        wait_for_start_markers(&[attempts.as_path()]).await;
+        let api = register_test_worker(port, "clean-exit", "api");
+        wait_for_worker_state(&daemon, "clean-exit", "api", true).await;
+        api
+    };
+    let (up, api) = tokio::join!(up, ready);
+    assert_eq!(
+        up.expect("compose::up should answer")["status"],
+        "ok",
+        "the project should start before the clean exit"
+    );
+
+    std::fs::write(&done, "").expect("ask api to exit cleanly");
+    api.shutdown_async().await;
+    wait_for_container_state(port, &file, "api", "stopped").await;
+
+    let status = call(
+        port,
+        "compose::status",
+        json!({ "file": file.to_str().unwrap() }),
+    )
+    .await
+    .expect("status after a clean exit");
+    let api = status["containers"]
+        .as_array()
+        .expect("containers")
+        .iter()
+        .find(|container| container["container"] == "api")
+        .unwrap_or_else(|| panic!("missing api: {status}"));
+    assert_eq!(
+        api["state"], "stopped",
+        "clean exit was reported as failed: {status}"
+    );
+    assert!(
+        api.get("pid").is_none(),
+        "stopped worker retained a PID: {status}"
+    );
+    assert!(
+        api.get("last_error").is_none(),
+        "clean exit retained an error: {status}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&attempts)
+            .expect("read attempts")
+            .lines()
+            .count(),
+        1,
+        "on-failure restarted a successful exit"
+    );
+
+    daemon.shutdown().await;
+}
+
 /// `required` controls startup only, so a non-required container still spends
 /// its restart budget after it had become ready. Once the budget is spent the
 /// supervisor does what it would have done with no policy at all: fails the
@@ -1493,6 +1580,28 @@ containers:
 
     std::fs::write(&die, "").expect("ask api to exit");
     api.shutdown_async().await;
+
+    // The old process has exited while the supervisor waits for its next
+    // attempt, so status must not expose that process's PID.
+    wait_for_container_state(port, &file, "api", "restarting").await;
+    let restarting = call(
+        port,
+        "compose::status",
+        json!({ "file": file.to_str().unwrap() }),
+    )
+    .await
+    .expect("status during retry backoff");
+    let restarting_api = restarting["containers"]
+        .as_array()
+        .expect("containers")
+        .iter()
+        .find(|container| container["container"] == "api")
+        .unwrap_or_else(|| panic!("missing api: {restarting}"));
+    assert_eq!(restarting_api["state"], "restarting", "{restarting}");
+    assert!(
+        restarting_api.get("pid").is_none(),
+        "a restarting worker exposed its dead PID: {restarting}"
+    );
 
     // Every attempt is spent, and only then does the failure cascade.
     wait_for_container_state(port, &file, "api", "failed").await;
@@ -1608,9 +1717,9 @@ containers:
         json!(["mailer"]),
         "the failed restart must name the optional container: {restart}"
     );
-    assert_eq!(
-        restart["error"]["code"], "CHILD_EXITED_BEFORE_REGISTRATION",
-        "the failed restart must retain its error: {restart}"
+    assert!(
+        restart.get("error").is_none(),
+        "a successful restart must not carry a top-level error: {restart}"
     );
 
     daemon.shutdown().await;

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -1124,6 +1124,97 @@ async fn a_child_that_never_registers_times_out_and_rolls_back() {
     daemon.shutdown().await;
 }
 
+/// `required: false` moves the blast radius of a failed start from the whole
+/// operation to the one container that declared it, and a dependent starts on
+/// the same declaration: `start_after` is a start order, not a claim that the
+/// dependent cannot run without it.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_container_that_is_not_required_fails_alone_and_its_dependent_still_starts() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let api_started = tmp.path().join("workers/api/started");
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: optional
+startup_timeout: 2s
+stop_timeout: 100ms
+containers:
+  mailer:
+    worker: path://./workers/mailer
+    required: false
+    scripts:
+      run: "sleep 30"
+  api:
+    worker: path://./workers/api
+    start_after: [mailer]
+    scripts:
+      run: "touch started && sleep 30"
+"#,
+        &["mailer", "api"],
+    );
+
+    // `mailer` never registers, so it times out. `api` waits behind it and is
+    // started anyway once that failure is recorded.
+    let up = call(
+        port,
+        "compose::up",
+        json!({ "file": file.to_str().unwrap() }),
+    );
+    let ready = async {
+        wait_for_start_markers(&[api_started.as_path()]).await;
+        let api = register_test_worker(port, "optional", "api");
+        wait_for_worker_state(&daemon, "optional", "api", true).await;
+        api
+    };
+    let (up, api) = tokio::join!(up, ready);
+    let up = up.expect("compose::up should answer");
+
+    assert_eq!(
+        up["status"], "ok",
+        "a container that is not required must not fail the operation: {up}"
+    );
+    assert_eq!(
+        up["not_required_failures"],
+        json!(["mailer"]),
+        "the return has to name what is down under an ok: {up}"
+    );
+    assert_eq!(
+        up["error"]["code"], "STARTUP_TIMEOUT",
+        "the reason for the contained failure is still reported: {up}"
+    );
+
+    // Rollback is what `required: true` buys, so nothing may have been undone.
+    let status = call(
+        port,
+        "compose::status",
+        json!({ "file": file.to_str().unwrap() }),
+    )
+    .await
+    .expect("status after a contained failure");
+    let state = |key: &str| {
+        status["containers"]
+            .as_array()
+            .expect("containers")
+            .iter()
+            .find(|container| container["container"] == key)
+            .unwrap_or_else(|| panic!("missing {key}: {status}"))["state"]
+            .clone()
+    };
+    assert_eq!(state("api"), "ready", "dependent was rolled back: {status}");
+    assert_ne!(
+        state("mailer"),
+        "ready",
+        "the failed container must not report ready: {status}"
+    );
+
+    api.shutdown_async().await;
+    daemon.shutdown().await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn logs_continue_from_a_cursor_after_the_worker_is_ready() {
     isolate_state();

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -1269,9 +1269,67 @@ containers:
     daemon.shutdown().await;
 }
 
-/// `restart: on-failure` answers the run-time half of the same question
-/// `required` answers at start time: a ready container that exits comes back
-/// instead of taking its dependents down with it.
+/// A restart policy also covers the first start. This worker rejects two
+/// `pre_run` attempts and accepts the third, so `up` must keep the operation
+/// open through retry 2/5 and return only after the worker is ready.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_pre_run_failure_is_retried_before_up_settles() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let attempts = tmp.path().join("workers/api/attempts");
+    let started = tmp.path().join("workers/api/started");
+    let file = project(
+        tmp.path(),
+        r#"
+namespace: startup-retry
+startup_timeout: 5s
+stop_timeout: 100ms
+containers:
+  api:
+    worker: path://./workers/api
+    required: true
+    restart: on-failure
+    scripts:
+      pre_run: "printf 'attempt\\n' >> attempts; [ $(wc -l < attempts) -ge 3 ]"
+      run: "touch started && sleep 30"
+"#,
+        &["api"],
+    );
+
+    let up = call(
+        port,
+        "compose::up",
+        json!({ "file": file.to_str().unwrap() }),
+    );
+    let ready = async {
+        wait_for_attempts(&attempts, 3).await;
+        wait_for_start_markers(&[started.as_path()]).await;
+        let api = register_test_worker(port, "startup-retry", "api");
+        wait_for_worker_state(&daemon, "startup-retry", "api", true).await;
+        api
+    };
+    let (up, api) = tokio::join!(up, ready);
+    let up = up.expect("compose::up should answer");
+
+    assert_eq!(up["status"], "ok", "the retried worker did not start: {up}");
+    assert_eq!(
+        std::fs::read_to_string(&attempts)
+            .expect("read attempts")
+            .lines()
+            .count(),
+        3,
+        "the original start and two replacements should run"
+    );
+
+    api.shutdown_async().await;
+    daemon.shutdown().await;
+}
+
+/// A ready container that exits comes back instead of taking its dependents
+/// down with it when it declares `restart: on-failure`.
 ///
 /// The dependent staying up is the point. A restart is one container bouncing,
 /// so `web` sees its dependency drop and reconnect, which is the cost the file


### PR DESCRIPTION
## Summary

- make containers optional by default when no `required` setting is provided
- add top-level `required_default`, with per-container `required` values taking precedence
- report optional startup failures through `not_required_failures` without a top-level error on successful operations
- add per-container restart policies with retry limits and backoff
- report clean exits as stopped and omit inactive PIDs while a worker is restarting
- name optional failures and emit one plain transition per retry phase in redirected output
- document the required-value precedence, restart behavior, and status contract
- add unit and end-to-end regression coverage

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p iii-compose --all-targets --all-features --locked -- -D warnings`
- `cargo test -p iii-compose`
- `SKIP_UI_BUILD=1 cargo test -p iii --test compose_daemon_e2e`
- `SKIP_UI_BUILD=1 cargo check --workspace`

<!-- cli-demos:start -->
## CLI demos

### Restart recovery

```sh
iii compose --up
```

![Compose retry progress and successful recovery](https://vhs.charm.sh/vhs-2AhP2wKjlRjRGSy0mFE5O1.gif)
<!-- cli-demos:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable container restart policies: `no`, `on-failure`, and `always`, with supervised retries and status updates while restarting.
  - Containers are now optional by default; configure `required_default` or per-container `required: true` for strict startup behavior.
  - Optional container failures are reported without failing the overall operation, including affected container names.

- **Bug Fixes**
  - Improved restart coordination and retry handling during concurrent lifecycle operations.
  - Failure reporting now preserves primary operation errors and accurately reflects recovered or repeated failures.

- **Documentation**
  - Updated Compose guidance for required containers, restart policies, retry behavior, and status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

