### PR TITLE
fix(engine): normalize OpenAPI brace parameters in HttpTriggerConfig (#2097)

### DIFF
--- a/engine/src/trigger_formats.rs
+++ b/engine/src/trigger_formats.rs
@@ -25,10 +25,15 @@ fn normalize_api_path(path: &str) -> String {
     let mut normalized = String::with_capacity(path.len());
     let mut in_brace = false;
     let mut param_buf = String::new();
+    let mut malformed = false;
 
     for ch in path.chars() {
         match ch {
             '{' => {
+                if in_brace {
+                    malformed = true;
+                    break;
+                }
                 in_brace = true;
                 param_buf.clear();
             }
@@ -44,6 +49,9 @@ fn normalize_api_path(path: &str) -> String {
                 normalized.push(c);
             }
         }
+    }
+    if malformed {
+        return path.to_string();
     }
     if in_brace {
         normalized.push('{');
@@ -411,6 +419,12 @@ mod tests {
         );
         assert_eq!(normalize_api_path("/tasks/:tid"), "/tasks/:tid");
         assert_eq!(normalize_api_path("/tasks/toggle"), "/tasks/toggle");
+    }
+
+    #[test]
+    fn test_normalize_api_path_malformed_braces_preserved() {
+        assert_eq!(normalize_api_path("/tasks/{tid{foo"), "/tasks/{tid{foo");
+        assert_eq!(normalize_api_path("/tasks/{tid"), "/tasks/{tid");
     }
 
     #[test]

--- a/engine/src/trigger_formats.rs
+++ b/engine/src/trigger_formats.rs
@@ -21,9 +21,49 @@ use serde_json::Value;
 
 // ── HTTP ────────────────────────────────────────────────────────────────
 
+fn normalize_api_path(path: &str) -> String {
+    let mut normalized = String::with_capacity(path.len());
+    let mut in_brace = false;
+    let mut param_buf = String::new();
+
+    for ch in path.chars() {
+        match ch {
+            '{' => {
+                in_brace = true;
+                param_buf.clear();
+            }
+            '}' if in_brace => {
+                in_brace = false;
+                normalized.push(':');
+                normalized.push_str(&param_buf);
+            }
+            c if in_brace => {
+                param_buf.push(c);
+            }
+            c => {
+                normalized.push(c);
+            }
+        }
+    }
+    if in_brace {
+        normalized.push('{');
+        normalized.push_str(&param_buf);
+    }
+    normalized
+}
+
+fn deserialize_api_path<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    Ok(normalize_api_path(&s))
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct HttpTriggerConfig {
-    /// HTTP endpoint path (e.g. `/users/:id`)
+    /// HTTP endpoint path (e.g. `/users/:id` or `/users/{id}`)
+    #[serde(deserialize_with = "deserialize_api_path")]
     pub api_path: String,
     /// HTTP method (defaults to GET)
     #[serde(default = "default_http_method")]
@@ -356,4 +396,27 @@ pub struct TraceTriggerConfig {
 pub struct TraceCallRequest {
     /// Distinct trace ids that had span activity in this coalesced window.
     pub trace_ids: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_api_path_braces() {
+        assert_eq!(normalize_api_path("/tasks/{tid}"), "/tasks/:tid");
+        assert_eq!(
+            normalize_api_path("/users/{userId}/items/{itemId}"),
+            "/users/:userId/items/:itemId"
+        );
+        assert_eq!(normalize_api_path("/tasks/:tid"), "/tasks/:tid");
+        assert_eq!(normalize_api_path("/tasks/toggle"), "/tasks/toggle");
+    }
+
+    #[test]
+    fn test_http_trigger_config_deserialization_normalizes_braces() {
+        let json_str = r#"{"api_path": "/tasks/{tid}", "http_method": "GET"}"#;
+        let config: HttpTriggerConfig = serde_json::from_str(json_str).unwrap();
+        assert_eq!(config.api_path, "/tasks/:tid");
+    }
 }

--- a/engine/src/trigger_formats.rs
+++ b/engine/src/trigger_formats.rs
@@ -65,6 +65,9 @@ where
     D: serde::Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
+    if !s.starts_with('/') {
+        return Err(serde::de::Error::custom("api_path must start with '/'"));
+    }
     Ok(normalize_api_path(&s))
 }
 
@@ -432,5 +435,11 @@ mod tests {
         let json_str = r#"{"api_path": "/tasks/{tid}", "http_method": "GET"}"#;
         let config: HttpTriggerConfig = serde_json::from_str(json_str).unwrap();
         assert_eq!(config.api_path, "/tasks/:tid");
+    }
+
+    #[test]
+    fn test_http_trigger_config_deserialization_requires_leading_slash() {
+        let json_str = r#"{"api_path": "tasks/{tid}", "http_method": "GET"}"#;
+        assert!(serde_json::from_str::<HttpTriggerConfig>(json_str).is_err());
     }
 }


### PR DESCRIPTION
### Summary of Changes

Fixes #2097.

When registering HTTP trigger configurations with OpenAPI / JSON-Schema style path parameters (e.g. \/tasks/{tid}\), the \pi_path\ string was preserved with raw curly braces instead of converting to the internal parameter syntax (\/tasks/:tid\). As a result, incoming requests to parameterized routes like \/tasks/123\ failed route matching and returned \<no route>\.

This PR adds a custom deserializer helper \deserialize_api_path\ on \HttpTriggerConfig.api_path\ in \ngine/src/trigger_formats.rs\ that normalizes \{param}\ brace placeholders to \:param\ colon format during trigger config deserialization.

### Tests Executed
- Added unit test \	est_normalize_api_path_braces\ in \ngine/src/trigger_formats.rs\.
- Added unit test \	est_http_trigger_config_deserialization_normalizes_braces\ in \ngine/src/trigger_formats.rs\.

- [x] I license my contributions to this repository under Apache 2.0, and I have all necessary rights over the code I am contributing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - HTTP trigger API paths are now normalized consistently during configuration processing.
  - Brace-style parameters such as `{id}` are converted to colon-style parameters such as `:id`.
  - Existing colon-style paths and malformed or unterminated brace patterns are preserved correctly.
  - API paths that do not begin with `/` are now rejected with a clear configuration error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->