### PR TITLE
fix(release): stop publishing iii-init Darwin aliases

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -339,9 +339,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-musl
-            publish_aliases: 'x86_64-unknown-linux-gnu x86_64-apple-darwin'
+            publish_aliases: 'x86_64-unknown-linux-gnu'
           - target: aarch64-unknown-linux-musl
-            publish_aliases: 'aarch64-unknown-linux-gnu aarch64-apple-darwin'
+            publish_aliases: 'aarch64-unknown-linux-gnu'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-iii.yml
+++ b/.github/workflows/release-iii.yml
@@ -136,9 +136,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-musl
-            publish_aliases: 'x86_64-unknown-linux-gnu x86_64-apple-darwin'
+            publish_aliases: 'x86_64-unknown-linux-gnu'
           - target: aarch64-unknown-linux-musl
-            publish_aliases: 'aarch64-unknown-linux-gnu aarch64-apple-darwin'
+            publish_aliases: 'aarch64-unknown-linux-gnu'
     steps:
       - name: Generate token
         id: generate_token

--- a/engine/install.sh
+++ b/engine/install.sh
@@ -204,6 +204,13 @@ install_companion_from_tarball() {
   return 0
 }
 
+init_target_for_host() {
+  case "$1:$2" in
+    Linux:x86_64|Darwin:x86_64) printf '%s' 'x86_64-unknown-linux-musl' ;;
+    Linux:aarch64|Darwin:aarch64) printf '%s' 'aarch64-unknown-linux-gnu' ;;
+  esac
+}
+
 # Test-mode hook: when this var is set, stop here so unit tests can source
 # the helper functions above without running the installer.
 if [ -n "${III_INSTALL_SH_TEST_MODE:-}" ]; then
@@ -561,21 +568,7 @@ trap cleanup EXIT INT TERM
 # ---------------------------------------------------------------------------
 
 # iii-init: Linux ELF that runs inside VMs; macOS hosts also need it for libkrun guests.
-init_target=""
-case "$uname_s" in
-  Linux)
-    case "$arch" in
-      x86_64)  init_target="x86_64-unknown-linux-musl" ;;
-      aarch64) init_target="aarch64-unknown-linux-gnu" ;;
-    esac
-    ;;
-  Darwin)
-    case "$arch" in
-      x86_64)  init_target="x86_64-apple-darwin" ;;
-      aarch64) init_target="aarch64-apple-darwin" ;;
-    esac
-    ;;
-esac
+init_target=$(init_target_for_host "$uname_s" "$arch")
 
 # iii-worker: needs glibc on Linux (KVM/libkrun); not available for x86_64-apple-darwin.
 worker_target=""

--- a/engine/src/cli/registry.rs
+++ b/engine/src/cli/registry.rs
@@ -53,8 +53,6 @@ pub static REGISTRY: &[BinarySpec] = &[
             "x86_64-unknown-linux-gnu",
             "aarch64-unknown-linux-musl",
             "aarch64-unknown-linux-gnu",
-            "aarch64-apple-darwin",
-            "x86_64-apple-darwin",
         ],
         commands: &[],
         tag_prefix: Some("iii"),
@@ -204,6 +202,21 @@ mod tests {
     fn test_console_has_checksum() {
         let (spec, _) = resolve_command("console").unwrap();
         assert!(spec.has_checksum);
+    }
+
+    #[test]
+    fn test_init_supported_targets_match_linux_guest_release_matrix() {
+        let init = resolve_binary_for_update("iii-init").unwrap();
+
+        assert_eq!(
+            init.supported_targets,
+            &[
+                "x86_64-unknown-linux-musl",
+                "x86_64-unknown-linux-gnu",
+                "aarch64-unknown-linux-musl",
+                "aarch64-unknown-linux-gnu",
+            ]
+        );
     }
 
     #[test]

--- a/engine/tests/install_sh_unit.bats
+++ b/engine/tests/install_sh_unit.bats
@@ -116,6 +116,13 @@ EOF
   fi
 }
 
+@test "iii-init uses Linux guest artifacts for every supported host" {
+  [ "$(init_target_for_host Linux x86_64)" = "x86_64-unknown-linux-musl" ]
+  [ "$(init_target_for_host Linux aarch64)" = "aarch64-unknown-linux-gnu" ]
+  [ "$(init_target_for_host Darwin x86_64)" = "x86_64-unknown-linux-musl" ]
+  [ "$(init_target_for_host Darwin aarch64)" = "aarch64-unknown-linux-gnu" ]
+}
+
 # ─────────────────────────────────────────────────────────────
 # End-to-end: --help flag
 # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

- Stop the stable and alpha release jobs from publishing Linux `iii-init` archives with Darwin target names.
- Keep the Linux GNU aliases and align the `iii-init` registry targets with the release matrix.

## Why

`iii-init` is embedded as a Linux guest binary. The v0.22.1 Darwin-named archives contained Linux ELF executables, so they could pass checksum verification but could not run on macOS.

## Notes

- Before: the v0.22.1 `aarch64-apple-darwin` and `x86_64-apple-darwin` archives both contained ELF executables.
- After: both release matrices retain only Linux GNU aliases, and the registry no longer advertises Darwin targets for `iii-init`.
- Verified with the focused registry test, release-matrix parsing, and `cargo fmt --all -- --check`.

Fixes #2119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Updates**
  - Linux `iii-init` binaries are published only under their matching GNU target names.
  - macOS aliases are no longer included in alpha or standard release assets.
- **Compatibility**
  - `iii-init` advertises support for four Linux guest targets only.
  - On macOS, the installer now downloads the corresponding Linux `iii-init` artifact.
- **Tests**
  - Added coverage verifying supported targets match the available Linux release targets.
  - Added installer coverage for Linux and macOS host and architecture mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- [x] I license my contributions to this repository under Apache 2.0, and I have all necessary rights over the code I am contributing.