### PR TITLE
feat(compose): support full container settings in compose::add

### DIFF
--- a/crates/iii-compose/src/config.rs
+++ b/crates/iii-compose/src/config.rs
@@ -708,12 +708,12 @@ where
 
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-struct RawContainer {
-    worker: String,
+pub(crate) struct RawContainer {
+    pub(crate) worker: String,
     #[serde(default)]
-    version: Option<String>,
+    pub(crate) version: Option<String>,
     #[serde(default)]
-    start_after: Vec<String>,
+    pub(crate) start_after: Vec<String>,
     #[serde(default)]
     config_name: Option<String>,
     #[serde(default)]

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -141,7 +141,7 @@ fn coalesce_containers(
                     spec: container.key.clone(),
                     reason: format!(
                         "the requested workers resolve container '{}' to conflicting sources, \
-                         versions, or dependencies",
+                         versions, dependencies, or settings",
                         container.key
                     ),
                 });
@@ -383,6 +383,21 @@ impl Daemon {
         workers: &[String],
         operation_id: String,
     ) -> Result<MutationOutcome> {
+        let workers = workers
+            .iter()
+            .cloned()
+            .map(crate::edit::WorkerInput::Spec)
+            .collect::<Vec<_>>();
+        self.add_configured(file, &workers, operation_id).await
+    }
+
+    /// Adds worker specs or full container declarations in one atomic file edit.
+    pub async fn add_configured(
+        &self,
+        file: Option<&Path>,
+        workers: &[crate::edit::WorkerInput],
+        operation_id: String,
+    ) -> Result<MutationOutcome> {
         if workers.is_empty() {
             return Err(ComposeError::InvalidWorkerSpec {
                 spec: String::new(),
@@ -394,7 +409,7 @@ impl Daemon {
         let path = self.resolve_file(file)?;
         self.validate_engine_policy_file(path)?;
         let declared = ComposeFile::load(path)?;
-        let path_workers: BTreeSet<String> = declared
+        let mut path_workers: BTreeSet<String> = declared
             .containers
             .iter()
             .filter(|(_, container)| {
@@ -404,8 +419,15 @@ impl Daemon {
             .collect();
         let asked = workers
             .iter()
-            .map(|worker| crate::edit::parse_worker(worker))
+            .map(crate::edit::WorkerInput::parse)
             .collect::<Result<Vec<_>>>()?;
+        let declarations = coalesce_containers(asked.clone())?;
+        path_workers.extend(
+            declarations
+                .iter()
+                .filter(|worker| matches!(worker.source, crate::edit::Source::Path { .. }))
+                .map(|worker| worker.key.clone()),
+        );
         // A worker is not useful alone: its manifest names what it calls, and
         // the registry answers with that whole graph already pinned to versions
         // that satisfy each other. They are declared rather than started
@@ -416,7 +438,11 @@ impl Daemon {
         // after the things it calls.
         let path_workers = &path_workers;
         let mut expanded = futures::stream::iter(asked.clone().into_iter().enumerate().map(
-            |(index, worker)| async move {
+            |(index, mut worker)| async move {
+                // Coalesce registry graphs before applying explicit settings.
+                // A requested worker can also be another worker's dependency.
+                worker.fields.clear();
+                worker.start_after.clear();
                 let graph = self.expand(&worker, path_workers).await;
                 (index, graph)
             },
@@ -429,7 +455,17 @@ impl Daemon {
         for (_, graph) in expanded {
             wanted.extend(graph?);
         }
-        let wanted = coalesce_containers(wanted)?;
+        let mut wanted = coalesce_containers(wanted)?;
+        for worker in &mut wanted {
+            if let Some(declaration) = declarations.iter().find(|item| item.key == worker.key) {
+                worker.fields = declaration.fields.clone();
+                worker
+                    .start_after
+                    .extend(declaration.start_after.iter().cloned());
+                worker.start_after.sort();
+                worker.start_after.dedup();
+            }
+        }
 
         // Acquire registry artifacts before taking either the file mutation lock
         // or the project's runtime lock. `lifecycle::start_one` calls install
@@ -686,6 +722,7 @@ impl Daemon {
                     version: Some(version),
                 },
                 start_after: container.start_after.clone(),
+                fields: serde_yaml::Mapping::new(),
             });
         }
 
@@ -1344,6 +1381,7 @@ fn expand_graph(
             version: Some(node.version.clone()),
         },
         start_after: needs(&node.name),
+        fields: serde_yaml::Mapping::new(),
     };
 
     // Registry nodes are a set, not an ordered plan. Derive a deterministic
@@ -1435,6 +1473,7 @@ mod tests {
                 version: None,
             },
             start_after: Vec::new(),
+            fields: serde_yaml::Mapping::new(),
         }
     }
 
@@ -1610,6 +1649,7 @@ mod tests {
                     version: Some("1.0.0".to_string()),
                 },
                 start_after: vec!["console".to_string()],
+                fields: serde_yaml::Mapping::new(),
             }]
         );
     }
@@ -1653,6 +1693,7 @@ mod tests {
                     version: Some("1.0.0".to_string()),
                 },
                 start_after: vec!["console".to_string()],
+                fields: serde_yaml::Mapping::new(),
             }]
         );
     }

--- a/crates/iii-compose/src/edit.rs
+++ b/crates/iii-compose/src/edit.rs
@@ -34,6 +34,7 @@ pub enum WorkerInput {
     ),
 }
 
+/// Validate container field types while retaining explicit empty and null values.
 fn deserialize_definition<'de, D>(
     deserializer: D,
 ) -> std::result::Result<serde_json::Map<String, serde_json::Value>, D::Error>
@@ -749,6 +750,7 @@ fn rewrite(entry: &[&str], changes: &Mapping, indent: &str) -> Result<String> {
     Ok(out)
 }
 
+/// Serialize one field as indented YAML, keeping version strings quoted.
 fn render_field(key: &str, value: &Value, indent: &str) -> Result<String> {
     let yaml = if key == "version" && value.is_string() {
         format!(

--- a/crates/iii-compose/src/edit.rs
+++ b/crates/iii-compose/src/edit.rs
@@ -17,7 +17,94 @@
 //! `start_after` fields, because a dangling edge would make the file impossible
 //! to start. Every caller parses the result before it is written.
 
+use serde::Deserialize;
+use serde_yaml::{Mapping, Value};
+
 use crate::error::{ComposeError, Result};
+
+/// An add request accepts the short worker spec or a container declaration.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum WorkerInput {
+    Spec(String),
+    Definition(
+        #[serde(deserialize_with = "deserialize_definition")]
+        #[schemars(with = "crate::config::RawContainer")]
+        serde_json::Map<String, serde_json::Value>,
+    ),
+}
+
+fn deserialize_definition<'de, D>(
+    deserializer: D,
+) -> std::result::Result<serde_json::Map<String, serde_json::Value>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    crate::config::RawContainer::deserialize(&value).map_err(serde::de::Error::custom)?;
+    // Keep field presence: an omitted map must not clear an existing map.
+    match value {
+        serde_json::Value::Object(fields) => Ok(fields),
+        _ => Err(serde::de::Error::custom("expected a container object")),
+    }
+}
+
+impl WorkerInput {
+    /// Validates the declaration with the same field types as the compose file.
+    pub fn parse(&self) -> Result<NewContainer> {
+        let fields = match self {
+            Self::Spec(spec) => return parse_worker(spec),
+            Self::Definition(fields) => fields,
+        };
+        let raw: crate::config::RawContainer =
+            serde_json::from_value(serde_json::Value::Object(fields.clone()))
+                .map_err(|err| invalid("container", &err.to_string()))?;
+        let mut new = parse_worker(&raw.worker)?;
+        if let Some(version) = raw.version {
+            match &mut new.source {
+                Source::Package {
+                    version: pinned, ..
+                } => {
+                    if pinned.as_ref().is_some_and(|pinned| pinned != &version) {
+                        return Err(invalid(
+                            &raw.worker,
+                            "worker and version specify different versions",
+                        ));
+                    }
+                    *pinned = Some(version);
+                }
+                Source::Path { .. } => {
+                    new.fields
+                        .insert(Value::from("version"), Value::from(version));
+                }
+            }
+        }
+        new.start_after = raw.start_after;
+        new.start_after.sort();
+        new.start_after.dedup();
+        for (key, value) in fields {
+            if key != "worker" && key != "version" {
+                new.fields.insert(
+                    Value::from(key.clone()),
+                    serde_yaml::to_value(value)
+                        .map_err(|err| invalid(&raw.worker, &err.to_string()))?,
+                );
+            }
+        }
+        if fields.contains_key("version") && matches!(new.source, Source::Path { .. }) {
+            new.fields
+                .entry(Value::from("version"))
+                .or_insert(Value::Null);
+        }
+        if fields.contains_key("start_after") {
+            new.fields.insert(
+                Value::from("start_after"),
+                Value::Sequence(new.start_after.iter().cloned().map(Value::from).collect()),
+            );
+        }
+        Ok(new)
+    }
+}
 
 /// Registry a bare worker name resolves against, spelled as a reference host.
 const DEFAULT_REGISTRY_HOST: &str = "api.workers.iii.dev";
@@ -56,20 +143,21 @@ pub struct NewContainer {
     /// Containers this one calls. Two workers may need the same one, so the
     /// shared worker is declared once and named here by both.
     pub start_after: Vec<String>,
+    /// Explicit fields to replace. Omitted fields keep their existing values.
+    pub fields: Mapping,
 }
 
 /// What the edit did, so the caller can report it and decide whether to restart.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Outcome {
     Added(String),
-    /// Same key, different version: an upgrade or a downgrade, both wanted.
+    /// The source, version, dependencies, or explicit settings changed.
     Replaced {
         text: String,
         from: String,
         to: String,
     },
-    /// Same key, same version. Nothing to do, and saying so beats a no-op
-    /// restart of a project that is already what was asked for.
+    /// The declaration already has the requested source and settings.
     Unchanged,
 }
 
@@ -81,11 +169,17 @@ pub enum Outcome {
 /// misread those as directories.
 pub fn parse_worker(spec: &str) -> Result<NewContainer> {
     let spec = spec.trim();
+    let explicit_path = spec.starts_with("path://");
+    let explicit_package = spec.starts_with("package://");
+    let spec = spec
+        .strip_prefix("path://")
+        .or_else(|| spec.strip_prefix("package://"))
+        .unwrap_or(spec);
     if spec.is_empty() {
         return Err(invalid(spec, "it is empty"));
     }
 
-    if spec.starts_with('.') || spec.starts_with('/') {
+    if explicit_path || (!explicit_package && (spec.starts_with('.') || spec.starts_with('/'))) {
         let key = spec
             .trim_end_matches('/')
             .rsplit('/')
@@ -98,6 +192,7 @@ pub fn parse_worker(spec: &str) -> Result<NewContainer> {
                 path: spec.to_string(),
             },
             start_after: Vec::new(),
+            fields: Mapping::new(),
         });
     }
 
@@ -130,6 +225,7 @@ pub fn parse_worker(spec: &str) -> Result<NewContainer> {
         key: key.to_string(),
         source: Source::Package { reference, version },
         start_after: Vec::new(),
+        fields: Mapping::new(),
     })
 }
 
@@ -152,7 +248,7 @@ pub fn upsert_container(text: &str, new: &NewContainer) -> Result<Outcome> {
     let containers = find_containers(&lines)?;
 
     let indent = entry_indent(&lines, &containers);
-    let block = render(new, &indent);
+    let block = render(new, &indent)?;
 
     match find_entry(&lines, &containers, &indent, &new.key) {
         Some(entry) => {
@@ -160,7 +256,13 @@ pub fn upsert_container(text: &str, new: &NewContainer) -> Result<Outcome> {
             // Without this the version comparison below reads `unpinned` for a
             // `path://` entry, calls a resolved package a version change, and
             // rewrites the operator's local worker away.
-            let declared = declared_kind(&lines[entry.clone()]);
+            let existing_fields = entry_fields(text, &new.key)?;
+            let declared_source = existing_fields
+                .get("worker")
+                .and_then(Value::as_str)
+                .map(parse_worker)
+                .transpose()?;
+            let declared = declared_source.as_ref().map(|worker| worker.source.kind());
             let wanted_kind = new.source.kind();
             if let Some(declared) = declared
                 && declared != wanted_kind
@@ -173,20 +275,33 @@ pub fn upsert_container(text: &str, new: &NewContainer) -> Result<Outcome> {
                 });
             }
 
-            let existing = declared_version(&lines[entry.clone()]);
+            let existing = existing_fields
+                .get("version")
+                .and_then(Value::as_str)
+                .map(str::to_string);
             let wanted = wanted_version(new);
-            // Version alone is not the whole declaration. An entry written
-            // before its dependencies were known carries the right version and
-            // no `start_after`, and leaving it would start the worker by where
-            // its line happens to sit rather than after what it calls.
-            let mut needs = new.start_after.clone();
-            needs.sort();
-            if existing == wanted && declared_needs(&lines[entry.clone()]) == needs {
+            let mut changes = declaration_fields(new, Some(&existing_fields))?;
+            if declared_source.as_ref().is_some_and(|declared| {
+                match (&declared.source, &new.source) {
+                    (
+                        Source::Package {
+                            reference: from, ..
+                        },
+                        Source::Package { reference: to, .. },
+                    ) => from == to,
+                    (Source::Path { path: from }, Source::Path { path: to }) => from == to,
+                    _ => false,
+                }
+            }) {
+                changes.remove("worker");
+            }
+            changes.retain(|key, value| existing_fields.get(key) != Some(value));
+            if changes.is_empty() {
                 return Ok(Outcome::Unchanged);
             }
             let mut out: Vec<String> = lines[..entry.start].iter().map(|l| l.to_string()).collect();
             out.extend(
-                rewrite(&lines[entry.clone()], new, &indent)
+                rewrite(&lines[entry.clone()], &changes, &indent)?
                     .lines()
                     .map(str::to_string),
             );
@@ -462,9 +577,15 @@ fn entry_indent(lines: &[&str], containers: &Block) -> String {
 /// The line range of one container entry: its key line and everything indented
 /// under it, plus any comment lines directly above that describe it.
 fn find_entry(lines: &[&str], containers: &Block, indent: &str, key: &str) -> Option<Entry> {
-    let head = format!("{indent}{key}:");
-    let at =
-        (containers.start..containers.end).find(|i| lines[*i].trim_end() == head.trim_end())?;
+    let at = (containers.start..containers.end).find(|i| {
+        lines[*i]
+            .strip_prefix(indent)
+            .filter(|body| !body.starts_with(char::is_whitespace))
+            .and_then(|body| body.split_once(':'))
+            .filter(|(_, value)| value.trim().is_empty() || value.trim_start().starts_with('#'))
+            .and_then(|(name, _)| serde_yaml::from_str::<String>(name).ok())
+            .is_some_and(|name| name == key)
+    })?;
 
     let mut end = at + 1;
     for line in &lines[at + 1..containers.end] {
@@ -488,72 +609,16 @@ fn find_entry(lines: &[&str], containers: &Block, indent: &str, key: &str) -> Op
 
 type Entry = std::ops::Range<usize>;
 
-/// The `start_after:` an entry declares, sorted so two lists compare by content
-/// rather than by the order someone wrote them in.
-fn declared_needs(entry: &[&str]) -> Vec<String> {
-    let mut inside = false;
-    let mut needs = Vec::new();
-    for line in entry {
-        let trimmed = line.trim();
-        // `start_after: [queue, state]` declares the same thing as a block list,
-        // and reading it as empty would rewrite an entry that already says what
-        // was asked for — and a rewrite is where fields get lost.
-        if let Some(inline) = trimmed.strip_prefix("start_after:")
-            && let Some(list) = inline
-                .trim()
-                .strip_prefix('[')
-                .and_then(|rest| rest.strip_suffix(']'))
-        {
-            needs.extend(
-                list.split(',')
-                    .map(|name| name.trim().trim_matches(['"', '\'']).to_string())
-                    .filter(|name| !name.is_empty()),
-            );
-            continue;
-        }
-        if trimmed == "start_after:" {
-            inside = true;
-            continue;
-        }
-        if inside {
-            match trimmed.strip_prefix("- ") {
-                Some(name) => needs.push(name.trim().trim_matches(['"', '\'']).to_string()),
-                // The list ended; anything after it belongs to another key.
-                None if !trimmed.is_empty() => break,
-                None => {}
-            }
-        }
-    }
-    needs.sort();
-    needs
-}
-
-/// The `version:` an entry declares, if it declares one.
-/// Whether the entry names a registry package or a directory, read from its
-/// `worker:` line. `None` when the entry has none, which a hand-written file
-/// may do when the manifest supplies it.
-fn declared_kind(entry: &[&str]) -> Option<&'static str> {
-    entry.iter().find_map(|line| {
-        let value = line.trim().strip_prefix("worker:")?.trim();
-        let value = value.trim_matches(['"', '\'']);
-        if value.starts_with("path://") || value.starts_with('.') || value.starts_with('/') {
-            Some("path")
-        } else if value.starts_with("package://") {
-            Some("package")
-        } else {
-            None
-        }
-    })
-}
-
-fn declared_version(entry: &[&str]) -> Option<String> {
-    entry.iter().find_map(|line| {
-        let trimmed = line.trim();
-        trimmed
-            .strip_prefix("version:")
-            .map(|value| value.trim().trim_matches(['"', '\'']).to_string())
-            .filter(|value| !value.is_empty())
-    })
+/// Read values for comparison only. Unchanged text is never serialized.
+fn entry_fields(text: &str, key: &str) -> Result<Mapping> {
+    // Aliases can refer to anchors in other containers.
+    let value: Value = serde_yaml::from_str(text).map_err(|err| invalid(key, &err.to_string()))?;
+    value
+        .get("containers")
+        .and_then(|containers| containers.get(key))
+        .and_then(Value::as_mapping)
+        .cloned()
+        .ok_or_else(|| invalid(key, "expected a container mapping"))
 }
 
 fn wanted_version(new: &NewContainer) -> Option<String> {
@@ -563,104 +628,301 @@ fn wanted_version(new: &NewContainer) -> Option<String> {
     }
 }
 
-/// Rewrites an existing entry, keeping every line it does not own.
-///
-/// A replacement changes the version and the dependencies. Everything else in
-/// the entry belongs to whoever wrote it — `env_file` naming the credentials a
-/// worker needs, `config_name`, `working_dir`, a `scripts.run` — and rendering
-/// the block afresh would drop all of it, leaving a project that starts and
-/// cannot work.
-fn rewrite(entry: &[&str], new: &NewContainer, indent: &str) -> String {
-    let inner = format!("{indent}{indent}");
-    let mut kept: Vec<&str> = Vec::new();
-    let mut skipping_list = false;
-
-    for line in entry
-        .iter()
-        .skip_while(|line| !line.trim_end().ends_with(':'))
-        .skip(1)
-    {
-        let trimmed = line.trim();
-        // The list items under a `start_after:` we are replacing.
-        if skipping_list {
-            if trimmed.starts_with("- ") {
-                continue;
-            }
-            skipping_list = false;
-        }
-        if trimmed.starts_with("worker:") || trimmed.starts_with("version:") {
-            continue;
-        }
-        if trimmed.starts_with("start_after:") {
-            skipping_list = !trimmed.contains('[');
-            continue;
-        }
-        kept.push(line);
+/// Build only the fields owned by this request, including resolved dependencies.
+fn declaration_fields(new: &NewContainer, existing: Option<&Mapping>) -> Result<Mapping> {
+    let mut fields = Mapping::new();
+    let source = match &new.source {
+        Source::Package { reference, .. } => format!("package://{reference}"),
+        Source::Path { path } => format!("path://{path}"),
+    };
+    fields.insert(Value::from("worker"), Value::from(source));
+    if let Some(version) = wanted_version(new) {
+        fields.insert(Value::from("version"), Value::from(version));
     }
+    let mut needs = new.start_after.clone();
+    if !new.fields.contains_key("start_after")
+        && let Some(Value::Sequence(dependencies)) =
+            existing.and_then(|fields| fields.get("start_after"))
+    {
+        needs.extend(
+            dependencies
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string),
+        );
+    }
+    needs.sort();
+    needs.dedup();
+    if !needs.is_empty() || new.fields.contains_key("start_after") {
+        let value =
+            serde_yaml::to_value(needs).map_err(|err| invalid(&new.key, &err.to_string()))?;
+        // Preserve order and comments when the dependency set is unchanged.
+        let previous = existing.and_then(|fields| fields.get("start_after"));
+        let same = previous.and_then(Value::as_sequence).is_some_and(|old| {
+            let mut old = old.clone();
+            old.sort_by(|a, b| a.as_str().cmp(&b.as_str()));
+            old.dedup();
+            value.as_sequence() == Some(&old)
+        });
+        fields.insert(
+            Value::from("start_after"),
+            if same {
+                previous.cloned().unwrap_or(value)
+            } else {
+                value
+            },
+        );
+    }
+    for (key, value) in &new.fields {
+        if key.as_str() != Some("start_after") {
+            fields.insert(key.clone(), value.clone());
+        }
+    }
+    Ok(fields)
+}
 
+/// Replace complete fields at the container's indentation. Nested keys with the
+/// same names (for example config_override.worker) belong to their parent field.
+fn rewrite(entry: &[&str], changes: &Mapping, indent: &str) -> Result<String> {
+    let inner = entry
+        .iter()
+        .find_map(|line| {
+            let trimmed = line.trim_start();
+            let width = line.len() - trimmed.len();
+            (width > indent.len() && !trimmed.is_empty() && !trimmed.starts_with('#'))
+                .then(|| line[..width].to_string())
+        })
+        .unwrap_or_else(|| format!("{indent}{indent}"));
+    let mut remaining = changes.clone();
     let mut out = String::new();
-    // The comments above the key, and the key itself, exactly as they were.
-    for line in entry
-        .iter()
-        .take_while(|line| !line.trim_end().ends_with(':'))
-    {
-        out.push_str(line);
-        out.push('\n');
-    }
-    out.push_str(&format!("{indent}{}:\n", new.key));
-    match &new.source {
-        Source::Package { reference, version } => {
-            out.push_str(&format!("{inner}worker: package://{reference}\n"));
-            if let Some(version) = version {
-                out.push_str(&format!("{inner}version: \"{version}\"\n"));
+    let mut index = 0;
+    while index < entry.len() {
+        let line = entry[index];
+        let key = line
+            .strip_prefix(&inner)
+            .filter(|body| !body.starts_with(char::is_whitespace))
+            .and_then(|body| body.split_once(':'))
+            .and_then(|(key, _)| serde_yaml::from_str::<String>(key).ok());
+        if let Some(key) = key
+            && let Some(value) = remaining.remove(Value::from(key.clone()))
+        {
+            out.push_str(&render_field(&key, &value, &inner)?);
+            index += 1;
+            let start = index;
+            while index < entry.len() {
+                let next = entry[index];
+                let body = next.trim_start();
+                let width = next.len() - body.len();
+                // YAML also permits sequence items at the field's indentation.
+                if body.is_empty()
+                    || width > inner.len()
+                    || (width == inner.len() && (body.starts_with("- ") || body.starts_with('#')))
+                {
+                    index += 1;
+                } else {
+                    break;
+                }
             }
-        }
-        Source::Path { path } => {
-            out.push_str(&format!("{inner}worker: path://{path}\n"));
+            // Keep trailing blank lines and comments for the next field.
+            while index > start {
+                let previous = entry[index - 1];
+                let body = previous.trim_start();
+                if body.is_empty()
+                    || (previous.len() - body.len() == inner.len() && body.starts_with('#'))
+                {
+                    index -= 1;
+                } else {
+                    break;
+                }
+            }
+        } else {
+            out.push_str(line);
+            out.push('\n');
+            index += 1;
         }
     }
-    if !new.start_after.is_empty() {
-        out.push_str(&format!("{inner}start_after:\n"));
-        for dependency in &new.start_after {
-            out.push_str(&format!("{inner}{indent}- {dependency}\n"));
+    for (key, value) in remaining {
+        if let Some(key) = key.as_str() {
+            out.push_str(&render_field(key, &value, &inner)?);
         }
     }
-    for line in kept {
-        out.push_str(line);
-        out.push('\n');
-    }
-    out
+    Ok(out)
+}
+
+fn render_field(key: &str, value: &Value, indent: &str) -> Result<String> {
+    let yaml = if key == "version" && value.is_string() {
+        format!(
+            "version: {}\n",
+            serde_json::to_string(value.as_str().unwrap_or_default())
+                .map_err(|err| invalid(key, &err.to_string()))?
+        )
+    } else {
+        let mut field = Mapping::new();
+        field.insert(Value::from(key), value.clone());
+        serde_yaml::to_string(&field).map_err(|err| invalid(key, &err.to_string()))?
+    };
+    Ok(yaml
+        .lines()
+        .map(|line| format!("{indent}{line}\n"))
+        .collect())
 }
 
 /// The YAML for one entry, indented to match the file.
-fn render(new: &NewContainer, indent: &str) -> String {
+fn render(new: &NewContainer, indent: &str) -> Result<String> {
     let inner = format!("{indent}{indent}");
-    let mut out = String::new();
-    out.push_str(&format!("{indent}{MARKER}\n"));
-    out.push_str(&format!("{indent}{}:\n", new.key));
-    match &new.source {
-        Source::Package { reference, version } => {
-            out.push_str(&format!("{inner}worker: package://{reference}\n"));
-            if let Some(version) = version {
-                out.push_str(&format!("{inner}version: \"{version}\"\n"));
-            }
-        }
-        Source::Path { path } => {
-            out.push_str(&format!("{inner}worker: path://{path}\n"));
+    let key = serde_yaml::to_string(&new.key).map_err(|err| invalid(&new.key, &err.to_string()))?;
+    let mut out = format!("{indent}{MARKER}\n{indent}{}:\n", key.trim_end());
+    for (key, value) in declaration_fields(new, None)? {
+        if let Some(key) = key.as_str() {
+            out.push_str(&render_field(key, &value, &inner)?);
         }
     }
-    if !new.start_after.is_empty() {
-        out.push_str(&format!("{inner}start_after:\n"));
-        for dependency in &new.start_after {
-            out.push_str(&format!("{inner}{indent}- {dependency}\n"));
-        }
-    }
-    out
+    Ok(out)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn configured(value: serde_json::Value) -> NewContainer {
+        serde_json::from_value::<WorkerInput>(value)
+            .unwrap()
+            .parse()
+            .unwrap()
+    }
+
+    fn changed(text: &str, new: &NewContainer) -> String {
+        match upsert_container(text, new).unwrap() {
+            Outcome::Added(text) | Outcome::Replaced { text, .. } => text,
+            Outcome::Unchanged => panic!("expected an edit"),
+        }
+    }
+
+    #[test]
+    fn configured_worker_round_trips_every_container_field() {
+        let request = serde_json::json!({
+            "worker": "path://workers/api",
+            "version": "local",
+            "start_after": ["database"],
+            "config_name": "api-config",
+            "config_override": {"url": "${API_URL}", "port": 3000, "enabled": true},
+            "scripts": {
+                "pre_run": "echo 'prepare: #1'\necho ready",
+                "pre_run_timeout": "10s",
+                "run": "./api --name 'a: b'",
+                "post_run": "echo stopped"
+            },
+            "working_dir": ".",
+            "environment": {"MODE": "on", "COUNT": "123"},
+            "env_file": ["./api.env"],
+            "startup_timeout": "5s"
+        });
+        let worker = configured(request.clone());
+        let out = changed(
+            "containers:\n  database:\n    worker: path://./database\n",
+            &worker,
+        );
+        let document: serde_json::Value = serde_yaml::from_str(&out).unwrap();
+        assert_eq!(document["containers"]["api"], request);
+        crate::ComposeFile::parse(&out, "/tmp/worker-compose.yaml").unwrap();
+        assert_eq!(upsert_container(&out, &worker).unwrap(), Outcome::Unchanged);
+    }
+
+    #[test]
+    fn a_version_change_preserves_settings_that_reference_an_external_anchor() {
+        let text = "containers:\n  defaults:\n    worker: path://./defaults\n    config_override: &defaults { version: nested }\n  api:\n    worker: package://api.workers.iii.dev/api\n    version: '1.0.0'\n    config_override: *defaults\n";
+        let out = changed(text, &parse_worker("api@1.1.0").unwrap());
+        assert_eq!(out, text.replace("version: '1.0.0'", "version: \"1.1.0\""));
+        crate::ComposeFile::parse(&out, "/tmp/worker-compose.yaml").unwrap();
+    }
+
+    #[test]
+    fn configuration_changes_replace_only_explicit_fields() {
+        let text = "containers:\n  api:\n    worker: path://./api\n    scripts:\n      run: |\n        echo old\n\n        echo obsolete\n    # keep the environment\n    environment: { MODE: 'on' }\n    config_override:\n      worker: custom\n      version: 'nested'\n      start_after: [nested]\n    env_file: [./api.env]\n";
+        let worker = configured(serde_json::json!({
+            "worker": "./api", "scripts": {"run": "echo 'new: #value'"}
+        }));
+        let out = changed(text, &worker);
+        assert!(out.ends_with("    # keep the environment\n    environment: { MODE: 'on' }\n    config_override:\n      worker: custom\n      version: 'nested'\n      start_after: [nested]\n    env_file: [./api.env]\n"), "{out}");
+        let parsed = crate::ComposeFile::parse(&out, "/tmp/worker-compose.yaml").unwrap();
+        assert_eq!(
+            parsed.containers["api"].scripts.run.as_deref(),
+            Some("echo 'new: #value'")
+        );
+        assert_eq!(upsert_container(&out, &worker).unwrap(), Outcome::Unchanged);
+    }
+
+    #[test]
+    fn explicit_empty_fields_clear_values_and_omitted_fields_preserve_them() {
+        let text = "containers:\n  api:\n    worker: path://./api\n    start_after: [database] # keep order\n    environment: { MODE: dev }\n    env_file: [./api.env]\n    config_override: {port: 3000}\n  database:\n    worker: path://./database\n";
+        assert_eq!(
+            upsert_container(text, &parse_worker("./api").unwrap()).unwrap(),
+            Outcome::Unchanged
+        );
+        let worker = configured(serde_json::json!({
+            "worker": "./api", "start_after": [], "environment": {}, "env_file": [], "config_override": null
+        }));
+        let out = changed(text, &worker);
+        let parsed = crate::ComposeFile::parse(&out, "/tmp/worker-compose.yaml").unwrap();
+        let api = &parsed.containers["api"];
+        assert!(api.start_after.is_empty());
+        assert!(api.environment.is_empty());
+        assert!(api.env_file.is_empty());
+        assert!(api.config_override.is_none());
+        assert_eq!(upsert_container(&out, &worker).unwrap(), Outcome::Unchanged);
+    }
+
+    #[test]
+    fn configured_package_keeps_resolved_and_explicit_dependencies() {
+        let mut worker = configured(serde_json::json!({
+            "worker": "api", "version": "1.2.3", "start_after": ["custom"],
+            "config_override": {"mode": "production"}
+        }));
+        worker.start_after.push("database".to_string());
+        let out = changed("containers: {}\n", &worker);
+        let document: Value = serde_yaml::from_str(&out).unwrap();
+        assert_eq!(
+            document["containers"]["api"]["start_after"],
+            serde_yaml::to_value(["custom", "database"]).unwrap()
+        );
+        assert_eq!(
+            document["containers"]["api"]["version"].as_str(),
+            Some("1.2.3")
+        );
+    }
+
+    #[test]
+    fn changing_the_source_or_nested_config_at_the_same_version_is_an_edit() {
+        let text = "containers:\n  api:\n    worker: package://old.example/api\n    version: '1.2.3'\n    config_override:\n      worker: nested\n      version: nested\n";
+        let worker = configured(serde_json::json!({
+            "worker": "new.example/api", "version": "1.2.3", "config_override": {"port": 3001}
+        }));
+        let out = changed(text, &worker);
+        let parsed = crate::ComposeFile::parse(&out, "/tmp/worker-compose.yaml").unwrap();
+        assert_eq!(
+            parsed.containers["api"].config_override.as_ref().unwrap()["port"].as_u64(),
+            Some(3001)
+        );
+        assert!(out.contains("worker: package://new.example/api"));
+        assert_eq!(upsert_container(&out, &worker).unwrap(), Outcome::Unchanged);
+    }
+
+    #[test]
+    fn configured_workers_reject_unknown_fields_wrong_types_and_conflicting_versions() {
+        for value in [
+            serde_json::json!({"worker": "./api", "script": {"run": "./api"}}),
+            serde_json::json!({"worker": "./api", "scripts": {"start": "./api"}}),
+            serde_json::json!({"worker": "./api", "start_after": "database"}),
+            serde_json::json!({"worker": "./api", "environment": {"PORT": 3000}}),
+        ] {
+            assert!(serde_json::from_value::<WorkerInput>(value).is_err());
+        }
+        let input: WorkerInput = serde_json::from_value(serde_json::json!({
+            "worker": "api@1.0.0", "version": "2.0.0"
+        }))
+        .unwrap();
+        assert_eq!(input.parse().unwrap_err().code(), "INVALID_WORKER_SPEC");
+    }
 
     const FILE: &str = "\
 namespace: default
@@ -815,6 +1077,7 @@ containers:
                 version: Some("0.21.4".to_string()),
             },
             start_after: vec!["queue".to_string()],
+            fields: serde_yaml::Mapping::new(),
         };
 
         let once = added(FILE);
@@ -1119,6 +1382,7 @@ containers:
                 version: Some("1.2.3".to_string()),
             },
             start_after: vec![],
+            fields: serde_yaml::Mapping::new(),
         };
 
         let err = upsert_container(text, &new).unwrap_err();
@@ -1134,6 +1398,7 @@ containers:
                 path: "./workers/state".to_string(),
             },
             start_after: vec![],
+            fields: serde_yaml::Mapping::new(),
         };
 
         assert_eq!(
@@ -1152,6 +1417,7 @@ containers:
                 version: Some("1.2.3".to_string()),
             },
             start_after: vec![],
+            fields: serde_yaml::Mapping::new(),
         };
 
         assert!(matches!(

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -30,6 +30,7 @@ use serde_json::{Value, json};
 
 use crate::{
     daemon::{Daemon, MutationOutcome},
+    edit::WorkerInput,
     error::ComposeError,
     logs::{LogCursor, LogStream, LogsOutcome},
     project::ContainerStatus,
@@ -66,7 +67,8 @@ pub struct ComposeRequest {
     ///
     /// This is the canonical JSON field for all three operations. The singular
     /// `worker` field remains accepted for clients that used the old contract.
-    pub workers: Option<Vec<String>>,
+    /// Add also accepts objects with the fields of a compose container.
+    pub workers: Option<Vec<WorkerInput>>,
     /// Caller-selected operation id used to bind mutation progress before submission.
     pub operation_id: Option<String>,
     /// Last cursor returned for each selected worker.
@@ -119,17 +121,18 @@ struct ProjectOptions {
 /// Request fields used by batch worker mutations.
 #[allow(dead_code)]
 #[derive(JsonSchema)]
-struct BatchWorkerOptions {
+struct BatchWorkerOptions<T> {
     /// Optional daemon guard. Use the trigger `--namespace` flag to route.
     namespace: Option<String>,
     /// Compose file on the daemon host. Defaults to `worker-compose.yaml` in
     /// the daemon working directory.
     file: Option<String>,
     /// Canonical list of workers to mutate together. Add accepts worker names,
-    /// `name@version` references, registry references, or local paths. Update
+    /// `name@version` references, registry references, local paths, or container
+    /// objects with scripts, dependencies, and configuration fields. Update
     /// accepts package names or `name@version` references. Remove accepts
     /// declared worker keys.
-    workers: Option<Vec<String>>,
+    workers: Option<Vec<T>>,
     /// Backward-compatible form for mutating one worker.
     worker: Option<String>,
     /// Caller-selected operation id for race-free progress subscription.
@@ -410,7 +413,7 @@ async fn dispatch(
                     .emit(None, "resolving", "resolving dependency trees")
                     .await;
                 daemon_task
-                    .add(file.as_deref(), &workers, task_operation_id)
+                    .add_configured(file.as_deref(), &workers, task_operation_id)
                     .await
             };
             spawn_mutation(
@@ -422,7 +425,7 @@ async fn dispatch(
             Ok(to_value(&accepted))
         }
         Operation::Remove => {
-            let workers = requested_workers(request.workers, request.worker);
+            let workers = requested_specs(request.workers, request.worker)?;
             if workers.is_empty() {
                 return daemon
                     .remove(file.as_deref(), &[], operation_id())
@@ -471,7 +474,7 @@ async fn dispatch(
             Err(err) => Err(compose_error(&err)),
         },
         Operation::Update => {
-            let workers = requested_workers(request.workers, request.worker);
+            let workers = requested_specs(request.workers, request.worker)?;
             if workers.is_empty() {
                 return daemon
                     .update(file.as_deref(), &[], operation_id())
@@ -691,10 +694,29 @@ fn schema_for_value<T: JsonSchema>() -> Option<Value> {
     serde_json::to_value(schema_for!(T)).ok()
 }
 
-fn requested_workers(workers: Option<Vec<String>>, worker: Option<String>) -> Vec<String> {
+fn requested_workers(
+    workers: Option<Vec<WorkerInput>>,
+    worker: Option<String>,
+) -> Vec<WorkerInput> {
     workers
-        .or_else(|| worker.map(|worker| vec![worker]))
+        .or_else(|| worker.map(|worker| vec![WorkerInput::Spec(worker)]))
         .unwrap_or_default()
+}
+
+fn requested_specs(
+    workers: Option<Vec<WorkerInput>>,
+    worker: Option<String>,
+) -> Result<Vec<String>, Error> {
+    requested_workers(workers, worker)
+        .into_iter()
+        .map(|input| match input {
+            WorkerInput::Spec(spec) => Ok(spec),
+            WorkerInput::Definition(_) => Err(compose_error(&ComposeError::InvalidWorkerSpec {
+                spec: "container object".to_string(),
+                reason: "container objects are supported only by compose::add".to_string(),
+            })),
+        })
+        .collect()
 }
 
 /// Batch worker mutations accept their canonical list or the old singular field.
@@ -704,7 +726,7 @@ fn requested_workers(workers: Option<Vec<String>>, worker: Option<String>) -> Ve
 /// least one input form must be present. Supplying both is valid; dispatch
 /// gives the canonical `workers` list precedence.
 fn batch_worker_options_schema() -> Option<Value> {
-    let mut schema = schema_for_value::<BatchWorkerOptions>()?;
+    let mut schema = schema_for_value::<BatchWorkerOptions<String>>()?;
     for field in ["workers", "worker"] {
         let types = schema
             .pointer_mut(&format!("/properties/{field}/type"))?
@@ -728,6 +750,16 @@ fn batch_worker_options_schema() -> Option<Value> {
             { "required": ["worker"] },
         ]),
     );
+    Some(schema)
+}
+
+fn add_worker_options_schema() -> Option<Value> {
+    let mut schema = batch_worker_options_schema()?;
+    let detailed = schema_for_value::<BatchWorkerOptions<WorkerInput>>()?;
+    schema["properties"]["workers"]["items"] = detailed["properties"]["workers"]["items"].clone();
+    schema["definitions"] = detailed["definitions"].clone();
+    schema["definitions"]["WorkerInput"]["anyOf"][0]["pattern"] = json!(r"\S");
+    schema["definitions"]["RawContainer"]["properties"]["worker"]["pattern"] = json!(r"\S");
     Some(schema)
 }
 
@@ -858,7 +890,7 @@ fn schema_table() -> &'static [SchemaTriple] {
             ),
             (
                 "compose::add",
-                batch_worker_options_schema(),
+                add_worker_options_schema(),
                 schema_for_value::<OperationAcceptedOutcome>(),
             ),
             (
@@ -993,7 +1025,10 @@ mod tests {
         .expect("workers should deserialize");
         assert_eq!(
             listed.workers,
-            Some(vec!["database".to_string(), "web".to_string()])
+            Some(vec![
+                WorkerInput::Spec("database".to_string()),
+                WorkerInput::Spec("web".to_string())
+            ])
         );
         assert_eq!(listed.worker, None);
 
@@ -1005,13 +1040,50 @@ mod tests {
         assert_eq!(singular.workers, None);
 
         assert_eq!(
-            requested_workers(None, singular.worker),
+            requested_specs(None, singular.worker).unwrap(),
             vec!["database".to_string()]
         );
         assert_eq!(
-            requested_workers(listed.workers, Some("ignored".to_string())),
+            requested_specs(listed.workers, Some("ignored".to_string())).unwrap(),
             vec!["database".to_string(), "web".to_string()]
         );
+    }
+
+    #[test]
+    fn only_add_accepts_full_container_objects_in_mixed_batches() {
+        let payload = json!({"workers": ["database", {
+            "worker": "./api",
+            "scripts": {"run": "./api", "pre_run": "echo ready", "pre_run_timeout": "10s", "post_run": "echo stopped"},
+            "start_after": ["database"],
+            "config_name": "api",
+            "config_override": {"port": 3000},
+            "working_dir": ".",
+            "environment": {"MODE": "dev"},
+            "env_file": ["./api.env"],
+            "startup_timeout": "5s"
+        }]});
+        let request: ComposeRequest = serde_json::from_value(payload.clone()).unwrap();
+        assert!(requested_specs(request.workers, request.worker).is_err());
+        for function_id in ["compose::add", "compose::update", "compose::remove"] {
+            let schema = schema_entry(function_id).1.as_ref().unwrap();
+            let validator = jsonschema::Validator::new(schema).unwrap();
+            assert_eq!(
+                validator.is_valid(&payload),
+                function_id == "compose::add",
+                "{function_id}: {:?}",
+                validator.iter_errors(&payload).collect::<Vec<_>>()
+            );
+        }
+        let schema = schema_entry("compose::add").1.as_ref().unwrap();
+        let validator = jsonschema::Validator::new(schema).unwrap();
+        for invalid in [
+            json!({"workers": [{"worker": " "}]}),
+            json!({"workers": [{"worker": "api", "script": {"run": "./api"}}]}),
+            json!({"workers": [{"worker": "api", "scripts": {"unknown": "./api"}}]}),
+            json!({"workers": [{"scripts": {"run": "./api"}}]}),
+        ] {
+            assert!(!validator.is_valid(&invalid), "accepted {invalid}");
+        }
     }
 
     #[test]

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -703,6 +703,7 @@ fn requested_workers(
         .unwrap_or_default()
 }
 
+/// Resolve legacy worker inputs and reject container objects for update and remove.
 fn requested_specs(
     workers: Option<Vec<WorkerInput>>,
     worker: Option<String>,
@@ -753,6 +754,7 @@ fn batch_worker_options_schema() -> Option<Value> {
     Some(schema)
 }
 
+/// Extend the batch contract with the container object form accepted by add.
 fn add_worker_options_schema() -> Option<Value> {
     let mut schema = batch_worker_options_schema()?;
     let detailed = schema_for_value::<BatchWorkerOptions<WorkerInput>>()?;

--- a/crates/iii-compose/tests/project_cache.rs
+++ b/crates/iii-compose/tests/project_cache.rs
@@ -339,6 +339,37 @@ async fn add_rejects_an_engine_change_before_editing_the_file() {
 }
 
 #[tokio::test]
+async fn configured_add_rejects_invalid_batches_without_writing() {
+    let tmp = project_dir();
+    let file = tmp.path().join("worker-compose.yaml");
+    std::fs::write(&file, COMPOSE).unwrap();
+    let daemon = daemon();
+    for workers in [
+        serde_json::json!([
+            {"worker": "./workers/api", "environment": {"MODE": "dev"}},
+            {"worker": "./workers/extra", "start_after": ["missing"]}
+        ]),
+        serde_json::json!([
+            {"worker": "./workers/api", "start_after": ["extra"]},
+            {"worker": "./workers/extra", "start_after": ["api"]}
+        ]),
+        serde_json::json!([{"worker": "./workers/api", "startup_timeout": "invalid"}]),
+        serde_json::json!([{"worker": "./workers/api", "scripts": {"pre_run_timeout": "1s"}}]),
+        serde_json::json!([
+            {"worker": "./workers/api", "environment": {"MODE": "dev"}},
+            {"worker": "./workers/api", "environment": {"MODE": "production"}}
+        ]),
+    ] {
+        let workers: Vec<iii_compose::edit::WorkerInput> = serde_json::from_value(workers).unwrap();
+        daemon
+            .add_configured(Some(&file), &workers, "invalid-add".to_string())
+            .await
+            .expect_err("invalid batch must fail");
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), COMPOSE);
+    }
+}
+
+#[tokio::test]
 async fn update_rejects_an_engine_change_before_editing_the_file() {
     let containers =
         "  state:\n    worker: package://api.workers.iii.dev/state\n    version: '1.0.0'\n";

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -178,18 +178,68 @@ and reconciles the project once. On the CLI, repeat `worker=` for each worker. E
 registry package name (`state`), a package name with a version (`state@0.21.4`), or a directory
 (`./workers/api`).
 
-A JSON payload for this function can use a single list: `{ "workers": ["database", "web"] }`.
+A JSON payload can mix worker names and container objects in the same list. Each object accepts
+the container fields from `worker-compose.yaml`. The container key comes from the last part of
+the worker name or directory path.
+
+```bash
+iii trigger compose::add --namespace dev file=./worker-compose.yaml --json '{
+  "workers": [
+    "database",
+    {
+      "worker": "./workers/api",
+      "start_after": ["database"],
+      "scripts": {
+        "pre_run": "pnpm build",
+        "pre_run_timeout": "60s",
+        "run": "pnpm start",
+        "post_run": "echo stopped"
+      },
+      "config_name": "api",
+      "config_override": { "port": 3000 },
+      "working_dir": "./workers/api",
+      "environment": { "NODE_ENV": "development" },
+      "env_file": ["./api.env"],
+      "startup_timeout": "30s"
+    }
+  ]
+}'
+```
 
 | Field     | Description                                    |
 | --------- | ---------------------------------------------- |
 | `file`    | The project to edit.                           |
-| `workers` | The canonical JSON list of workers to declare. |
+| `workers` | A JSON list of worker names or container objects. |
 | `worker`  | One worker. Repeatable on the CLI.             |
 
-An package without a version specified will pin to the latest available version (ex. `0.23.1`).
+A container object accepts these fields:
 
-Workers whose declarations did not change remain running. Existing workers whose resolved versions
-changed restart in place, and newly declared workers start through the normal dependency plan.
+| Field | Description |
+| ----- | ----------- |
+| `worker` | Required. A package name, `name@version`, registry reference, or local path. Also accepts `package://` and `path://` sources. |
+| `version` | Package version. Must agree with a version included in `worker`. |
+| `start_after` | Container keys to start first. Compose adds the package's resolved dependencies to this list. |
+| `scripts` | `pre_run`, `pre_run_timeout`, `run`, and `post_run`. `run` is valid only for local workers. |
+| `config_name` | Name of the worker's base configuration. |
+| `config_override` | Configuration value applied over the base configuration. |
+| `working_dir` | Working directory, relative to the compose file. |
+| `environment` | Environment variables with string values. |
+| `env_file` | List of environment file paths, relative to the compose file. |
+| `startup_timeout` | Maximum wait for worker registration, such as `30s`. |
+
+A package without a version pins to the latest available version, for example `0.23.1`.
+Unknown fields and invalid field types are rejected. Compose validates the complete edited file
+before it writes any changes.
+
+For an existing container, omitted fields other than `version` keep their values. A supplied field replaces that entire
+field, including maps such as `scripts`, `environment`, and `config_override`. Use `{}` or `[]` to
+clear maps or lists. An omitted `start_after` keeps existing dependencies; a supplied list replaces
+them and includes any required package dependencies.
+
+Workers whose declarations did not change remain running. Existing workers whose source, version,
+dependencies, or settings changed restart in place. Newly declared workers start through the normal
+dependency plan. If the resolved declaration already matches the file, the call makes no file
+changes and causes no restart.
 
 ### Removing a worker
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -172,18 +172,68 @@ and reconciles the project once. On the CLI, repeat `worker=` for each worker. E
 registry package name (`state`), a package name with a version (`state@0.21.4`), or a directory
 (`./workers/api`).
 
-A JSON payload for this function can use a single list: `{ "workers": ["database", "web"] }`.
+A JSON payload can mix worker names and container objects in the same list. Each object accepts
+the container fields from `worker-compose.yaml`. The container key comes from the last part of
+the worker name or directory path.
+
+```bash
+iii trigger compose::add --namespace dev file=./worker-compose.yaml --json '{
+  "workers": [
+    "database",
+    {
+      "worker": "./workers/api",
+      "start_after": ["database"],
+      "scripts": {
+        "pre_run": "pnpm build",
+        "pre_run_timeout": "60s",
+        "run": "pnpm start",
+        "post_run": "echo stopped"
+      },
+      "config_name": "api",
+      "config_override": { "port": 3000 },
+      "working_dir": "./workers/api",
+      "environment": { "NODE_ENV": "development" },
+      "env_file": ["./api.env"],
+      "startup_timeout": "30s"
+    }
+  ]
+}'
+```
 
 | Field     | Description                                    |
 | --------- | ---------------------------------------------- |
 | `file`    | The project to edit.                           |
-| `workers` | The canonical JSON list of workers to declare. |
+| `workers` | A JSON list of worker names or container objects. |
 | `worker`  | One worker. Repeatable on the CLI.             |
 
-An package without a version specified will pin to the latest available version (ex. `0.23.1`).
+A container object accepts these fields:
 
-Workers whose declarations did not change remain running. Existing workers whose resolved versions
-changed restart in place, and newly declared workers start through the normal dependency plan.
+| Field | Description |
+| ----- | ----------- |
+| `worker` | Required. A package name, `name@version`, registry reference, or local path. Also accepts `package://` and `path://` sources. |
+| `version` | Package version. Must agree with a version included in `worker`. |
+| `start_after` | Container keys to start first. Compose adds the package's resolved dependencies to this list. |
+| `scripts` | `pre_run`, `pre_run_timeout`, `run`, and `post_run`. `run` is valid only for local workers. |
+| `config_name` | Name of the worker's base configuration. |
+| `config_override` | Configuration value applied over the base configuration. |
+| `working_dir` | Working directory, relative to the compose file. |
+| `environment` | Environment variables with string values. |
+| `env_file` | List of environment file paths, relative to the compose file. |
+| `startup_timeout` | Maximum wait for worker registration, such as `30s`. |
+
+A package without a version pins to the latest available version, for example `0.23.1`.
+Unknown fields and invalid field types are rejected. Compose validates the complete edited file
+before it writes any changes.
+
+For an existing container, omitted fields other than `version` keep their values. A supplied field replaces that entire
+field, including maps such as `scripts`, `environment`, and `config_override`. Use `{}` or `[]` to
+clear maps or lists. An omitted `start_after` keeps existing dependencies; a supplied list replaces
+them and includes any required package dependencies.
+
+Workers whose declarations did not change remain running. Existing workers whose source, version,
+dependencies, or settings changed restart in place. Newly declared workers start through the normal
+dependency plan. If the resolved declaration already matches the file, the call makes no file
+changes and causes no restart.
 
 ### Removing a worker
 

--- a/docs/using-iii/compose.mdx
+++ b/docs/using-iii/compose.mdx
@@ -178,18 +178,68 @@ and reconciles the project once. On the CLI, repeat `worker=` for each worker. E
 registry package name (`state`), a package name with a version (`state@0.21.4`), or a directory
 (`./workers/api`).
 
-A JSON payload for this function can use a single list: `{ "workers": ["database", "web"] }`.
+A JSON payload can mix worker names and container objects in the same list. Each object accepts
+the container fields from `worker-compose.yaml`. The container key comes from the last part of
+the worker name or directory path.
+
+```bash
+iii trigger compose::add --namespace dev file=./worker-compose.yaml --json '{
+  "workers": [
+    "database",
+    {
+      "worker": "./workers/api",
+      "start_after": ["database"],
+      "scripts": {
+        "pre_run": "pnpm build",
+        "pre_run_timeout": "60s",
+        "run": "pnpm start",
+        "post_run": "echo stopped"
+      },
+      "config_name": "api",
+      "config_override": { "port": 3000 },
+      "working_dir": "./workers/api",
+      "environment": { "NODE_ENV": "development" },
+      "env_file": ["./api.env"],
+      "startup_timeout": "30s"
+    }
+  ]
+}'
+```
 
 | Field     | Description                                    |
 | --------- | ---------------------------------------------- |
 | `file`    | The project to edit.                           |
-| `workers` | The canonical JSON list of workers to declare. |
+| `workers` | A JSON list of worker names or container objects. |
 | `worker`  | One worker. Repeatable on the CLI.             |
 
-An package without a version specified will pin to the latest available version (ex. `0.23.1`).
+A container object accepts these fields:
 
-Workers whose declarations did not change remain running. Existing workers whose resolved versions
-changed restart in place, and newly declared workers start through the normal dependency plan.
+| Field | Description |
+| ----- | ----------- |
+| `worker` | Required. A package name, `name@version`, registry reference, or local path. Also accepts `package://` and `path://` sources. |
+| `version` | Package version. Must agree with a version included in `worker`. |
+| `start_after` | Container keys to start first. Compose adds the package's resolved dependencies to this list. |
+| `scripts` | `pre_run`, `pre_run_timeout`, `run`, and `post_run`. `run` is valid only for local workers. |
+| `config_name` | Name of the worker's base configuration. |
+| `config_override` | Configuration value applied over the base configuration. |
+| `working_dir` | Working directory, relative to the compose file. |
+| `environment` | Environment variables with string values. |
+| `env_file` | List of environment file paths, relative to the compose file. |
+| `startup_timeout` | Maximum wait for worker registration, such as `30s`. |
+
+A package without a version pins to the latest available version, for example `0.23.1`.
+Unknown fields and invalid field types are rejected. Compose validates the complete edited file
+before it writes any changes.
+
+For an existing container, omitted fields other than `version` keep their values. A supplied field replaces that entire
+field, including maps such as `scripts`, `environment`, and `config_override`. Use `{}` or `[]` to
+clear maps or lists. An omitted `start_after` keeps existing dependencies; a supplied list replaces
+them and includes any required package dependencies.
+
+Workers whose declarations did not change remain running. Existing workers whose source, version,
+dependencies, or settings changed restart in place. Newly declared workers start through the normal
+dependency plan. If the resolved declaration already matches the file, the call makes no file
+changes and causes no restart.
 
 ### Removing a worker
 

--- a/docs/using-iii/compose.mdx.skill.md
+++ b/docs/using-iii/compose.mdx.skill.md
@@ -172,18 +172,68 @@ and reconciles the project once. On the CLI, repeat `worker=` for each worker. E
 registry package name (`state`), a package name with a version (`state@0.21.4`), or a directory
 (`./workers/api`).
 
-A JSON payload for this function can use a single list: `{ "workers": ["database", "web"] }`.
+A JSON payload can mix worker names and container objects in the same list. Each object accepts
+the container fields from `worker-compose.yaml`. The container key comes from the last part of
+the worker name or directory path.
+
+```bash
+iii trigger compose::add --namespace dev file=./worker-compose.yaml --json '{
+  "workers": [
+    "database",
+    {
+      "worker": "./workers/api",
+      "start_after": ["database"],
+      "scripts": {
+        "pre_run": "pnpm build",
+        "pre_run_timeout": "60s",
+        "run": "pnpm start",
+        "post_run": "echo stopped"
+      },
+      "config_name": "api",
+      "config_override": { "port": 3000 },
+      "working_dir": "./workers/api",
+      "environment": { "NODE_ENV": "development" },
+      "env_file": ["./api.env"],
+      "startup_timeout": "30s"
+    }
+  ]
+}'
+```
 
 | Field     | Description                                    |
 | --------- | ---------------------------------------------- |
 | `file`    | The project to edit.                           |
-| `workers` | The canonical JSON list of workers to declare. |
+| `workers` | A JSON list of worker names or container objects. |
 | `worker`  | One worker. Repeatable on the CLI.             |
 
-An package without a version specified will pin to the latest available version (ex. `0.23.1`).
+A container object accepts these fields:
 
-Workers whose declarations did not change remain running. Existing workers whose resolved versions
-changed restart in place, and newly declared workers start through the normal dependency plan.
+| Field | Description |
+| ----- | ----------- |
+| `worker` | Required. A package name, `name@version`, registry reference, or local path. Also accepts `package://` and `path://` sources. |
+| `version` | Package version. Must agree with a version included in `worker`. |
+| `start_after` | Container keys to start first. Compose adds the package's resolved dependencies to this list. |
+| `scripts` | `pre_run`, `pre_run_timeout`, `run`, and `post_run`. `run` is valid only for local workers. |
+| `config_name` | Name of the worker's base configuration. |
+| `config_override` | Configuration value applied over the base configuration. |
+| `working_dir` | Working directory, relative to the compose file. |
+| `environment` | Environment variables with string values. |
+| `env_file` | List of environment file paths, relative to the compose file. |
+| `startup_timeout` | Maximum wait for worker registration, such as `30s`. |
+
+A package without a version pins to the latest available version, for example `0.23.1`.
+Unknown fields and invalid field types are rejected. Compose validates the complete edited file
+before it writes any changes.
+
+For an existing container, omitted fields other than `version` keep their values. A supplied field replaces that entire
+field, including maps such as `scripts`, `environment`, and `config_override`. Use `{}` or `[]` to
+clear maps or lists. An omitted `start_after` keeps existing dependencies; a supplied list replaces
+them and includes any required package dependencies.
+
+Workers whose declarations did not change remain running. Existing workers whose source, version,
+dependencies, or settings changed restart in place. Newly declared workers start through the normal
+dependency plan. If the resolved declaration already matches the file, the call makes no file
+changes and causes no restart.
 
 ### Removing a worker
 

--- a/engine/tests/compose_daemon_e2e.rs
+++ b/engine/tests/compose_daemon_e2e.rs
@@ -494,6 +494,73 @@ async fn validating_a_file_does_not_take_the_project_on() {
     daemon.shutdown().await;
 }
 
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn configured_add_writes_settings_runs_hooks_and_is_idempotent() {
+    isolate_state();
+    let port = spawn_engine().await;
+    let daemon = start_daemon(port).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let file = project(
+        tmp.path(),
+        "containers:\n  api:\n    worker: path://./workers/api\n",
+        &["api"],
+    );
+    let workers: Vec<iii_compose::edit::WorkerInput> = serde_json::from_value(serde_json::json!([{
+        "worker": "./workers/api",
+        "working_dir": ".",
+        "scripts": {"pre_run": "printf '%s\\n' \"$MODE\" >> hook-output", "run": "exit 1"},
+        "environment": {"MODE": "dev"},
+        "config_override": {"port": 3000},
+        "startup_timeout": "1s"
+    }]))
+    .unwrap();
+    // The child exits by design. A failed start retains the requested file edit.
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        daemon.add_configured(Some(&file), &workers, "configured-add".to_string()),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(serde_json::to_value(outcome).unwrap()["changed"], true);
+    let initial_hooks = std::fs::read_to_string(tmp.path().join("hook-output")).unwrap();
+    assert!(!initial_hooks.is_empty());
+    assert!(initial_hooks.lines().all(|mode| mode == "dev"));
+    let once = std::fs::read_to_string(&file).unwrap();
+    let outcome = daemon
+        .add_configured(Some(&file), &workers, "same-add".to_string())
+        .await
+        .unwrap();
+    assert_eq!(serde_json::to_value(outcome).unwrap()["changed"], false);
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), once);
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("hook-output")).unwrap(),
+        initial_hooks
+    );
+
+    let mut changed = workers;
+    if let iii_compose::edit::WorkerInput::Definition(fields) = &mut changed[0] {
+        fields.insert(
+            "environment".to_string(),
+            serde_json::json!({"MODE": "prod"}),
+        );
+    }
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        daemon.add_configured(Some(&file), &changed, "changed-add".to_string()),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(serde_json::to_value(outcome).unwrap()["changed"], true);
+    let final_hooks = std::fs::read_to_string(tmp.path().join("hook-output")).unwrap();
+    let changed_hooks = final_hooks.strip_prefix(&initial_hooks).unwrap();
+    assert!(!changed_hooks.is_empty());
+    assert!(changed_hooks.lines().all(|mode| mode == "prod"));
+    daemon.shutdown().await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn add_edits_several_workers_and_reconciles_the_project_once() {
     isolate_state();
@@ -534,22 +601,25 @@ containers:
         "compose::add",
         json!({
             "file": file.to_str().unwrap(),
-            "workers": ["./workers/database", "./workers/web"],
+            "workers": [{
+                "worker": "./workers/database",
+                "start_after": ["existing"],
+                "scripts": {"pre_run": "printf '%s' \"$MODE\" > mode && cat \"$III_CONFIG\" > config"},
+                "environment": {"MODE": "dev"},
+                "config_override": {"port": 3000}
+            }, "./workers/web"],
         }),
     );
     let ready = async {
-        wait_for_start_markers(&[
-            existing_started.as_path(),
-            database_started.as_path(),
-            web_started.as_path(),
-        ])
-        .await;
+        wait_for_start_markers(&[existing_started.as_path(), web_started.as_path()]).await;
         let existing = register_test_worker(port, "addition", "existing");
-        let database = register_test_worker(port, "addition", "database");
         let web = register_test_worker(port, "addition", "web");
-        for worker in ["existing", "database", "web"] {
+        for worker in ["existing", "web"] {
             wait_for_worker_state(&daemon, "addition", worker, true).await;
         }
+        wait_for_start_markers(&[database_started.as_path()]).await;
+        let database = register_test_worker(port, "addition", "database");
+        wait_for_worker_state(&daemon, "addition", "database", true).await;
         (existing, database, web)
     };
     let (result, (existing, database, web)) = tokio::join!(add, ready);
@@ -582,6 +652,15 @@ containers:
     );
 
     let edited = std::fs::read_to_string(&file).expect("read edited compose file");
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("workers/database/mode")).unwrap(),
+        "dev"
+    );
+    let delivered: Value = serde_yaml::from_str(
+        &std::fs::read_to_string(tmp.path().join("workers/database/config")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(delivered, json!({"port": 3000}));
     for worker in ["database", "web"] {
         assert_eq!(
             edited.matches(&format!("  {worker}:\n")).count(),


### PR DESCRIPTION
## What

Allow `compose::add` to accept container objects alongside worker names in the `workers` list. Objects support every existing container field, including `scripts`, `start_after`, `config_override`, environment settings, and timeouts.

Reuse the compose-file field definitions for request validation and JSON Schema. Preserve omitted settings and unrelated YAML text, combine explicit startup dependencies with resolved package dependencies, and restart workers when their settings change.

## Why

A worker that needs a run script or custom configuration previously required a separate manual YAML edit. The add operation can now declare that worker with its complete settings and apply the change in one call.

## Notes

- Existing worker-name lists and the singular `worker` form remain supported.
- Supplied maps replace the complete field; omitted settings remain in place. Package versions continue to follow the existing resolution rules.
- Invalid batches leave the file unchanged. Repeating a matching resolved declaration makes no file change and causes no restart.
- Updated both Compose documentation pages and their generated skill artifacts.

Validation:

- `cargo fmt --all -- --check`
- `cargo test -p iii-compose --locked -- --test-threads=1` (328 tests)
- `cargo test -p iii --test compose_daemon_e2e --locked -- --test-threads=1` (18 tests)
- `cargo clippy -p iii-compose --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p iii --test compose_daemon_e2e --locked --no-deps`
- `cargo build -p iii --locked`
- Regenerated the next-version documentation artifact with `iii-skill-render` and checked that both documentation copies match.

The additional strict engine Clippy run reports nine existing lints in unchanged configuration, observability, and queue code under `engine/src/workers`. The Compose Clippy check passes with warnings denied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `compose::add` accepts mixed worker names and full container definitions in one request.
  - Container definitions support environment, configuration, lifecycle hooks, dependencies, and timeouts.
  - Updates preserve omitted settings and support explicitly clearing maps and lists.
  - Workers restart when source, version, dependencies, or settings change; unchanged definitions are no-ops.

- **Bug Fixes**
  - Invalid batches are rejected before compose files are modified.
  - Worker edits better preserve existing configuration and formatting.

- **Documentation**
  - Expanded `compose::add` documentation with fields, validation, merge behavior, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->