### PR TITLE
feat(compose): include namespace in Linux process names

### DIFF
--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -37,6 +37,7 @@ pub mod namespace;
 pub mod operation;
 mod parallelism;
 pub mod process;
+pub mod process_title;
 pub mod project;
 pub mod registry;
 pub mod remote;
@@ -441,6 +442,25 @@ async fn serve(
     }
 
     result
+}
+
+/// Resolves the daemon's process label before the CLI starts its async runtime.
+/// Build and logs commands do not serve a namespace and need no process label.
+pub fn process_namespace(cli: &ComposeCli) -> Result<Option<String>> {
+    let ComposeCommand::Serve {
+        explicit_daemon_namespace,
+        file,
+        start,
+        ..
+    } = cli.plan()?
+    else {
+        return Ok(None);
+    };
+    let initial_file = load_invocation_file(&file, start)?;
+    Ok(Some(resolve_daemon_namespace(
+        explicit_daemon_namespace,
+        initial_file.as_ref(),
+    )))
 }
 
 fn resolve_daemon_namespace(

--- a/crates/iii-compose/src/managed_engine.rs
+++ b/crates/iii-compose/src/managed_engine.rs
@@ -63,8 +63,13 @@ impl ManagedEngine {
                 })??;
         let config_path = materialize_engine_config(spec, &namespace_dir)?;
         let log_path = engine_log_path(&state_root, daemon_namespace);
-        let mut engine =
-            Self::spawn_with_materialized_config(&executable, &config_path, &log_path).await?;
+        let mut engine = Self::spawn_with_materialized_config(
+            &executable,
+            &config_path,
+            &log_path,
+            daemon_namespace,
+        )
+        .await?;
         engine._namespace_lock = Some(namespace_lock);
         Ok(engine)
     }
@@ -73,8 +78,9 @@ impl ManagedEngine {
         executable: &Path,
         config_path: &Path,
         log_path: &Path,
+        namespace: &str,
     ) -> Result<Self> {
-        match Self::spawn_with_paths(executable, config_path, log_path).await {
+        match Self::spawn_with_paths(executable, config_path, log_path, namespace).await {
             Ok(mut engine) => {
                 engine.remove_config_on_stop = true;
                 Ok(engine)
@@ -90,6 +96,7 @@ impl ManagedEngine {
         executable: &Path,
         config_path: &Path,
         log_path: &Path,
+        namespace: &str,
     ) -> Result<Self> {
         let parent = log_path.parent().unwrap_or_else(|| Path::new("."));
         std::fs::create_dir_all(parent).map_err(|source| ComposeError::Io {
@@ -119,6 +126,19 @@ impl ManagedEngine {
             .arg("--config")
             .arg(config_path)
             .stdin(Stdio::null());
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::unix::process::CommandExt;
+
+            command
+                .as_std_mut()
+                .arg0(crate::process_title::command_name(
+                    crate::process_title::Role::Engine,
+                    namespace,
+                ));
+        }
+        #[cfg(not(target_os = "linux"))]
+        let _ = namespace;
 
         let (process, output) =
             spawn_supervised_piped(command).map_err(|err| ComposeError::EngineSpawnFailed {
@@ -1225,7 +1245,7 @@ port: 60123
             "#!/bin/sh\nprintf 'args:%s\\n' \"$*\"\nprintf '\\033[31mengine stdout\\033[0m\\n'\nprintf '\\033]2;forged title\\007engine stderr\\n' >&2\nexit 7\n",
         );
 
-        let engine = ManagedEngine::spawn_with_paths(&script, &config, &log)
+        let engine = ManagedEngine::spawn_with_paths(&script, &config, &log, "test")
             .await
             .unwrap();
         let status = tokio::time::timeout(Duration::from_secs(5), engine.wait())
@@ -1264,7 +1284,9 @@ port: 60123
         std::fs::create_dir(&log).unwrap();
 
         let error =
-            match ManagedEngine::spawn_with_materialized_config(&script, &config, &log).await {
+            match ManagedEngine::spawn_with_materialized_config(&script, &config, &log, "test")
+                .await
+            {
                 Ok(_) => panic!("a directory cannot be opened as the engine log"),
                 Err(error) => error,
             };
@@ -1290,7 +1312,7 @@ port: 60123
             "#!/bin/sh\ndd if=/dev/zero bs=1048576 count=11 2>/dev/null | tr '\\000' x\n",
         );
 
-        let engine = ManagedEngine::spawn_with_paths(&script, &config, &log)
+        let engine = ManagedEngine::spawn_with_paths(&script, &config, &log, "test")
             .await
             .unwrap();
         let status = tokio::time::timeout(Duration::from_secs(10), engine.wait())
@@ -1325,7 +1347,7 @@ port: 60123
             "#!/bin/sh\ntrap 'exit 0' TERM INT\nwhile :; do sleep 1; done\n",
         );
 
-        let engine = ManagedEngine::spawn_with_paths(&script, &config, &log)
+        let engine = ManagedEngine::spawn_with_paths(&script, &config, &log, "test")
             .await
             .unwrap();
         let pid = engine.pid();

--- a/crates/iii-compose/src/process_title.rs
+++ b/crates/iii-compose/src/process_title.rs
@@ -1,0 +1,122 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
+//! Linux process labels for the compose CLI and its managed engine.
+
+/// The role of a process in a compose invocation.
+#[derive(Clone, Copy)]
+pub enum Role {
+    Compose,
+    Engine,
+}
+
+/// Full label used as argv[0], including namespaces longer than Linux comm.
+pub fn command_name(role: Role, namespace: &str) -> String {
+    let role = match role {
+        Role::Compose => 'c',
+        Role::Engine => 'e',
+    };
+    format!("iii:{role}:{namespace}")
+}
+
+/// Reads the label passed directly to a managed engine's argv[0]. Unlike an
+/// environment variable, this label is not inherited by workers it starts.
+pub fn engine_namespace(arg0: &str) -> Option<&str> {
+    let namespace = arg0.strip_prefix("iii:e:")?;
+    (!namespace.is_empty() && crate::namespace::check(namespace).is_ok()).then_some(namespace)
+}
+
+/// Labels the CLI process before it starts threads, telemetry, or children.
+///
+/// On Linux, re-execs the current binary with a full argv[0] if needed, keeping
+/// the PID, arguments, environment, working directory, and standard streams.
+/// This avoids overwriting Rust's argument storage or relocating environ.
+/// The next invocation sets the main thread's comm before building the runtime.
+/// Other platforms retain their existing process names.
+pub fn set_current(role: Role, namespace: &str) -> std::io::Result<()> {
+    if namespace.is_empty() || crate::namespace::check(namespace).is_err() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "invalid process namespace",
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        use std::{ffi::CString, os::unix::process::CommandExt, process::Command};
+
+        let title = command_name(role, namespace);
+        if std::env::args_os().next().as_deref() != Some(std::ffi::OsStr::new(&title)) {
+            return Err(Command::new(std::env::current_exe()?)
+                .arg0(&title)
+                .args(std::env::args_os().skip(1))
+                .exec());
+        }
+
+        let name = CString::new(short_name(role, namespace))?;
+        nix::sys::prctl::set_name(&name).map_err(std::io::Error::from)?;
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = role;
+
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn short_name(role: Role, namespace: &str) -> String {
+    use sha2::{Digest, Sha256};
+
+    let title = command_name(role, namespace);
+    if title.len() <= 15 {
+        return title;
+    }
+
+    // Validated namespaces are ASCII. Keep a readable prefix and a stable
+    // suffix so names sharing their first characters do not simply truncate
+    // to the same label. The full namespace remains available in argv[0].
+    let digest = hex::encode(Sha256::digest(namespace.as_bytes()));
+    format!(
+        "{}{}~{}",
+        command_name(role, ""),
+        &namespace[..2],
+        &digest[..6]
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_names_show_the_role_and_complete_namespace() {
+        assert_eq!(short_name(Role::Compose, "orders"), "iii:c:orders");
+        assert_eq!(short_name(Role::Engine, "orders"), "iii:e:orders");
+        assert_eq!(short_name(Role::Compose, "default"), "iii:c:default");
+        assert_eq!(short_name(Role::Compose, "123456789"), "iii:c:123456789");
+    }
+
+    #[test]
+    fn long_names_fit_comm_and_keep_shared_prefixes_distinct() {
+        let orders = short_name(Role::Compose, "production-orders");
+        let billing = short_name(Role::Compose, "production-billing");
+        assert_eq!(orders.len(), 15);
+        assert_eq!(billing.len(), 15);
+        assert!(orders.starts_with("iii:c:pr~"));
+        assert_ne!(orders, billing);
+        assert_eq!(
+            command_name(Role::Compose, "production-orders"),
+            "iii:c:production-orders"
+        );
+    }
+
+    #[test]
+    fn only_valid_managed_engine_labels_supply_a_namespace() {
+        assert_eq!(engine_namespace("iii:e:orders"), Some("orders"));
+        for arg0 in ["iii", "/usr/bin/iii", "iii:c:orders", "iii:e:", "iii:e:BAD"] {
+            assert_eq!(engine_namespace(arg0), None);
+        }
+    }
+}

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -46,6 +46,28 @@ this operation.
 
 `compose::*` functions as documented below are the intended way to manage a running compose daemon.
 
+### Process names on Linux
+
+Compose includes its resolved namespace in the process label. The daemon uses `iii:c:<namespace>`,
+and an engine started by that daemon uses `iii:e:<namespace>`. The namespace comes from
+`--namespace`, then `namespace:` in the compose file, then `default`.
+
+For example, `iii compose --namespace orders --up` produces these labels when it starts an engine:
+
+```text
+iii:c:orders
+  +-- iii:e:orders
+```
+
+Use `ps -p <PID> -o pid,ppid,comm,args` to inspect both fields. The `args` field retains the full
+namespace and the original command arguments. Linux limits `comm` to 15 bytes, so namespaces longer
+than nine characters use their first two characters, `~`, and six hexadecimal hash characters in
+that field. Use `args` to read the full namespace when a short label is abbreviated.
+
+The daemon sets its command label through an early re-exec with the same PID, before starting
+the runtime or any children. Existing external engines keep their names. On other operating
+systems, process names retain their previous behavior.
+
 ### Compose logs
 
 Compose logs stdout and stderr output from started workers to `$HOME/.iii/compose/namespace/`.

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -40,6 +40,28 @@ this operation.
 
 `compose::*` functions as documented below are the intended way to manage a running compose daemon.
 
+### Process names on Linux
+
+Compose includes its resolved namespace in the process label. The daemon uses `iii:c:<namespace>`,
+and an engine started by that daemon uses `iii:e:<namespace>`. The namespace comes from
+`--namespace`, then `namespace:` in the compose file, then `default`.
+
+For example, `iii compose --namespace orders --up` produces these labels when it starts an engine:
+
+```text
+iii:c:orders
+  +-- iii:e:orders
+```
+
+Use `ps -p <PID> -o pid,ppid,comm,args` to inspect both fields. The `args` field retains the full
+namespace and the original command arguments. Linux limits `comm` to 15 bytes, so namespaces longer
+than nine characters use their first two characters, `~`, and six hexadecimal hash characters in
+that field. Use `args` to read the full namespace when a short label is abbreviated.
+
+The daemon sets its command label through an early re-exec with the same PID, before starting
+the runtime or any children. Existing external engines keep their names. On other operating
+systems, process names retain their previous behavior.
+
 ### Compose logs
 
 Compose logs stdout and stderr output from started workers to `$HOME/.iii/compose/namespace/`.

--- a/docs/using-iii/compose.mdx
+++ b/docs/using-iii/compose.mdx
@@ -46,6 +46,28 @@ this operation.
 
 `compose::*` functions as documented below are the intended way to manage a running compose daemon.
 
+### Process names on Linux
+
+Compose includes its resolved namespace in the process label. The daemon uses `iii:c:<namespace>`,
+and an engine started by that daemon uses `iii:e:<namespace>`. The namespace comes from
+`--namespace`, then `namespace:` in the compose file, then `default`.
+
+For example, `iii compose --namespace orders --up` produces these labels when it starts an engine:
+
+```text
+iii:c:orders
+  +-- iii:e:orders
+```
+
+Use `ps -p <PID> -o pid,ppid,comm,args` to inspect both fields. The `args` field retains the full
+namespace and the original command arguments. Linux limits `comm` to 15 bytes, so namespaces longer
+than nine characters use their first two characters, `~`, and six hexadecimal hash characters in
+that field. Use `args` to read the full namespace when a short label is abbreviated.
+
+The daemon sets its command label through an early re-exec with the same PID, before starting
+the runtime or any children. Existing external engines keep their names. On other operating
+systems, process names retain their previous behavior.
+
 ### Compose logs
 
 Compose logs stdout and stderr output from started workers to `$HOME/.iii/compose/namespace/`.

--- a/docs/using-iii/compose.mdx.skill.md
+++ b/docs/using-iii/compose.mdx.skill.md
@@ -40,6 +40,28 @@ this operation.
 
 `compose::*` functions as documented below are the intended way to manage a running compose daemon.
 
+### Process names on Linux
+
+Compose includes its resolved namespace in the process label. The daemon uses `iii:c:<namespace>`,
+and an engine started by that daemon uses `iii:e:<namespace>`. The namespace comes from
+`--namespace`, then `namespace:` in the compose file, then `default`.
+
+For example, `iii compose --namespace orders --up` produces these labels when it starts an engine:
+
+```text
+iii:c:orders
+  +-- iii:e:orders
+```
+
+Use `ps -p <PID> -o pid,ppid,comm,args` to inspect both fields. The `args` field retains the full
+namespace and the original command arguments. Linux limits `comm` to 15 bytes, so namespaces longer
+than nine characters use their first two characters, `~`, and six hexadecimal hash characters in
+that field. Use `args` to read the full namespace when a short label is abbreviated.
+
+The daemon sets its command label through an early re-exec with the same PID, before starting
+the runtime or any children. Existing external engines keep their names. On other operating
+systems, process names retain their previous behavior.
+
 ### Compose logs
 
 Compose logs stdout and stderr output from started workers to `$HOME/.iii/compose/namespace/`.

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -299,8 +299,7 @@ async fn run_serve(cli: &Cli) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     let argv: Vec<String> = std::env::args().collect();
     let cli_args = match Cli::try_parse_from(&argv) {
         Ok(c) => c,
@@ -317,6 +316,35 @@ async fn main() -> anyhow::Result<()> {
         },
     };
 
+    // Re-exec for argv[0] before creating runtime threads or recording usage.
+    // Errors in compose configuration still go through its normal reporter.
+    #[cfg(target_os = "linux")]
+    if !cli_args.version && !cli_args.install_only_generate_ids {
+        use iii_compose::process_title::{self, Role};
+
+        let label = match &cli_args.command {
+            Some(Commands::Compose(args)) if cli_args.config.is_none() => {
+                iii_compose::process_namespace(args)
+                    .ok()
+                    .flatten()
+                    .map(|namespace| (Role::Compose, namespace))
+            }
+            None => argv
+                .first()
+                .and_then(|arg0| process_title::engine_namespace(arg0))
+                .map(|namespace| (Role::Engine, namespace.to_string())),
+            _ => None,
+        };
+        if let Some((role, namespace)) = label {
+            process_title::set_current(role, &namespace)?;
+        }
+    }
+
+    run(cli_args)
+}
+
+#[tokio::main]
+async fn run(cli_args: Cli) -> anyhow::Result<()> {
     // Docs generation is offline build tooling: handle it before telemetry
     // and any engine setup so the output stays deterministic.
     if let Some(Commands::GenDocs { out }) = &cli_args.command {

--- a/engine/tests/compose_process_title_e2e.rs
+++ b/engine/tests/compose_process_title_e2e.rs
@@ -1,0 +1,232 @@
+//! Process labels as observed by Linux, through the real iii CLI.
+
+#![cfg(target_os = "linux")]
+
+use std::{
+    fs,
+    net::{TcpListener, TcpStream},
+    path::Path,
+    process::{Child, Command, Stdio},
+    time::{Duration, Instant},
+};
+
+use nix::{sys::signal::Signal, unistd::Pid};
+
+struct Process {
+    child: Child,
+    log: std::path::PathBuf,
+}
+
+impl Process {
+    fn start(dir: &Path, args: &[&str]) -> Self {
+        let log = dir.join("process.log");
+        let output = fs::File::create(&log).unwrap();
+        let child = Command::new(env!("CARGO_BIN_EXE_iii"))
+            .current_dir(dir)
+            .args(args)
+            .env("III_TELEMETRY_ENABLED", "false")
+            .env("III_COMPOSE_STATE_DIR", dir.join("state"))
+            .env("TOKIO_WORKER_THREADS", "2")
+            .env("NO_COLOR", "1")
+            .env_remove("III_URL")
+            .stdin(Stdio::null())
+            .stdout(output.try_clone().unwrap())
+            .stderr(output)
+            .spawn()
+            .unwrap();
+        Self { child, log }
+    }
+
+    fn wait_until(&mut self, ready: impl Fn() -> bool) {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            if ready() {
+                return;
+            }
+            assert!(
+                self.child.try_wait().unwrap().is_none() && Instant::now() < deadline,
+                "process did not become ready:\n{}",
+                fs::read_to_string(&self.log).unwrap_or_default()
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    fn wait_for_compose(&mut self) {
+        let log = self.log.clone();
+        self.wait_until(|| {
+            fs::read_to_string(&log)
+                .unwrap_or_default()
+                .contains("compose serving")
+        });
+    }
+
+    fn stop(&mut self, signal: Signal) {
+        nix::sys::signal::kill(Pid::from_raw(self.child.id() as i32), signal).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(20);
+        loop {
+            if let Some(status) = self.child.try_wait().unwrap() {
+                assert!(
+                    status.success(),
+                    "process failed during shutdown:\n{}",
+                    fs::read_to_string(&self.log).unwrap_or_default()
+                );
+                return;
+            }
+            assert!(Instant::now() < deadline, "process did not stop");
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+impl Drop for Process {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = nix::sys::signal::kill(Pid::from_raw(self.child.id() as i32), Signal::SIGTERM);
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while Instant::now() < deadline {
+                if self.child.try_wait().ok().flatten().is_some() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+fn unused_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn comm(pid: u32) -> String {
+    fs::read_to_string(format!("/proc/{pid}/comm"))
+        .unwrap()
+        .trim_end()
+        .to_string()
+}
+
+fn cmdline(pid: u32) -> Vec<String> {
+    fs::read(format!("/proc/{pid}/cmdline"))
+        .unwrap()
+        .split(|byte| *byte == 0)
+        .filter(|arg| !arg.is_empty())
+        .map(|arg| String::from_utf8(arg.to_vec()).unwrap())
+        .collect()
+}
+
+#[test]
+fn compose_instances_show_resolved_namespaces_in_both_process_fields() {
+    let engine_dir = tempfile::tempdir().unwrap();
+    let port = unused_port();
+    let address = format!("ws://127.0.0.1:{port}");
+    fs::write(
+        engine_dir.path().join("config.yaml"),
+        format!(
+            "workers:\n  - name: iii-worker-manager\n    config:\n      host: 127.0.0.1\n      port: {port}\n"
+        ),
+    )
+    .unwrap();
+    let mut engine = Process::start(engine_dir.path(), &["--no-update-check"]);
+    engine.wait_until(|| TcpStream::connect(("127.0.0.1", port)).is_ok());
+    let engine_name = comm(engine.child.id());
+    let engine_args = cmdline(engine.child.id());
+
+    let mut daemons = Vec::new();
+    for (namespace, explicit) in [
+        ("orders", false),
+        ("billing", true),
+        ("production-orders", false),
+        ("production-billing", true),
+        ("default", false),
+    ] {
+        let dir = tempfile::Builder::new()
+            .prefix("compose names ")
+            .tempdir()
+            .unwrap();
+        if namespace != "default" {
+            let declared = if explicit { "ignored" } else { namespace };
+            fs::write(
+                dir.path().join("worker-compose.yaml"),
+                format!("namespace: {declared}\ncontainers:\n  api:\n    worker: path://./api\n"),
+            )
+            .unwrap();
+        }
+        let mut args = vec!["compose", "--engine", &address];
+        if explicit {
+            args.extend(["--namespace", namespace]);
+        }
+        let mut daemon = Process::start(dir.path(), &args);
+        let pid = daemon.child.id();
+        daemon.wait_for_compose();
+        let command = cmdline(pid);
+        assert_eq!(command[0], format!("iii:c:{namespace}"));
+        assert_eq!(command[1..], args);
+        let name = comm(pid);
+        if namespace.starts_with("production-") {
+            assert_eq!(name.len(), 15);
+            assert!(name.starts_with("iii:c:pr~"));
+        } else {
+            assert_eq!(name, format!("iii:c:{namespace}"));
+        }
+        daemons.push((dir, daemon));
+    }
+
+    // All five daemons are alive together on one engine, with distinct labels.
+    let names: std::collections::HashSet<_> = daemons
+        .iter()
+        .map(|(_, daemon)| comm(daemon.child.id()))
+        .collect();
+    assert_eq!(names.len(), daemons.len());
+    for (_, daemon) in &mut daemons {
+        daemon.stop(Signal::SIGTERM);
+    }
+    assert!(engine.child.try_wait().unwrap().is_none());
+    assert_eq!(comm(engine.child.id()), engine_name);
+    assert_eq!(cmdline(engine.child.id()), engine_args);
+}
+
+#[test]
+fn managed_engine_has_its_own_role_and_stops_with_the_named_compose() {
+    let dir = tempfile::Builder::new()
+        .prefix("managed names ")
+        .tempdir()
+        .unwrap();
+    let port = unused_port();
+    fs::write(
+        dir.path().join("worker-compose.yaml"),
+        format!(
+            "namespace: ignored\nengine:\n  url: ws://127.0.0.1:{port}\n  workers:\n    iii-worker-manager:\n      host: 127.0.0.1\n      port: {port}\ncontainers: {{}}\n"
+        ),
+    )
+    .unwrap();
+    let mut daemon = Process::start(dir.path(), &["compose", "--namespace", "orders", "--up"]);
+    let pid = daemon.child.id();
+    daemon.wait_for_compose();
+    assert_eq!(comm(pid), "iii:c:orders");
+    assert_eq!(cmdline(pid)[0], "iii:c:orders");
+
+    let children = fs::read_to_string(format!("/proc/{pid}/task/{pid}/children")).unwrap();
+    let engine_pid: u32 = children.split_whitespace().next().unwrap().parse().unwrap();
+    assert_eq!(comm(engine_pid), "iii:e:orders");
+    assert_eq!(
+        cmdline(engine_pid),
+        [
+            "iii:e:orders".to_string(),
+            "--config".to_string(),
+            dir.path()
+                .join("state/orders/engine-config.yaml")
+                .display()
+                .to_string(),
+        ]
+    );
+
+    daemon.stop(Signal::SIGINT);
+    assert!(!Path::new(&format!("/proc/{engine_pid}")).exists());
+    TcpListener::bind(("127.0.0.1", port)).expect("managed engine released its port");
+}


### PR DESCRIPTION
## What

Include the resolved namespace in Linux Compose process names: `iii:c:orders` for the daemon and `iii:e:orders` for its managed engine. Keep the full namespace in the command line and use a stable hash suffix when the short name exceeds Linux's 15-byte limit.

Resolve the daemon label before runtime startup and apply it through an early re-exec that keeps the PID and original arguments. Pass the managed engine label directly through its first argument. Add process-level tests and document the naming behavior.

## Why

Several Compose instances currently appear as `iii` in process tools. Including the namespace and role makes each daemon and its engine identifiable in `ps` and `htop`, including when the namespace comes from YAML.

## Notes

- Linux only. Existing external engines and process names on other operating systems retain their current behavior.
- Validation: 322 Compose tests, 147 CLI tests, and 9 process/lifecycle integration tests passed. The integration tests include five simultaneous daemons, namespace precedence, long names, and signal shutdown.
- `cargo fmt --all`, the relevant Clippy targets, `cargo build -p iii --all-features --locked`, and the generated documentation check passed. Clippy reports existing warnings outside this change.
- Engine checks use `SKIP_UI_BUILD=1` with the committed UI assets.
- The process-label module also passes metadata compilation for macOS and Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Linux Compose daemons and managed engines now display namespace-based process labels, making them easier to identify in system tools.
  - Process labels reflect resolved namespaces, including abbreviated labels for long namespaces.
  - Compose-managed engines identify themselves separately from Compose daemons.

- **Documentation**
  - Added guidance on viewing process labels, namespace resolution, and platform-specific behavior.

- **Tests**
  - Added end-to-end coverage for daemon and managed-engine process labels, namespace handling, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->