### PR TITLE
fix(engine): register function-path triggers in the caller's namespace

### DIFF
--- a/docs/next/reference/engine-protocol.mdx
+++ b/docs/next/reference/engine-protocol.mdx
@@ -388,10 +388,10 @@ and worker lifecycle. Defined in
 | `engine::workers::info`       | Inspect one connected worker's full surface (functions, trigger types, registered triggers). Takes `name` plus an optional `namespace`. |
 | `engine::triggers::list`      | List every registered trigger type (filterable by `include_internal`).        |
 | `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count. Accepts an optional `namespace`; absent resolves the caller's namespace first, then `default`. |
-| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`: `active`, or `pending` while its trigger type has no provider yet. |
+| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`; pass `include_pending: true` to also list registrations parked as `pending` while their trigger type has no provider. |
 | `engine::registered-triggers::info` | Inspect one registered trigger instance, with denormalized trigger and function detail. |
 | `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `namespace`, optional `description`). |
-| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding lives in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |
+| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding is registered in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |
 | `engine::unregister_trigger`  | Unregister a trigger by id. Idempotent; reports whether it existed. |
 
 Every row returned by `engine::functions::list`, `engine::functions::info`, `engine::workers::list`,

--- a/docs/next/reference/engine-protocol.mdx
+++ b/docs/next/reference/engine-protocol.mdx
@@ -388,7 +388,7 @@ and worker lifecycle. Defined in
 | `engine::workers::info`       | Inspect one connected worker's full surface (functions, trigger types, registered triggers). Takes `name` plus an optional `namespace`. |
 | `engine::triggers::list`      | List every registered trigger type (filterable by `include_internal`).        |
 | `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count. Accepts an optional `namespace`; absent resolves the caller's namespace first, then `default`. |
-| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`; pass `include_pending: true` to also list registrations parked as `pending` while their trigger type has no provider. |
+| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`; pass `include_pending: true` to also list registrations with `status: pending`, whose trigger type has no provider yet. |
 | `engine::registered-triggers::info` | Inspect one registered trigger instance, with denormalized trigger and function detail. |
 | `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `namespace`, optional `description`). |
 | `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding is registered in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |

--- a/docs/next/reference/engine-protocol.mdx
+++ b/docs/next/reference/engine-protocol.mdx
@@ -387,11 +387,11 @@ and worker lifecycle. Defined in
 | `engine::workers::list`       | List every connected worker with metrics.                                     |
 | `engine::workers::info`       | Inspect one connected worker's full surface (functions, trigger types, registered triggers). Takes `name` plus an optional `namespace`. |
 | `engine::triggers::list`      | List every registered trigger type (filterable by `include_internal`).        |
-| `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count.            |
-| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). |
+| `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count. Accepts an optional `namespace`; absent resolves the caller's namespace first, then `default`. |
+| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`: `active`, or `pending` while its trigger type has no provider yet. |
 | `engine::registered-triggers::info` | Inspect one registered trigger instance, with denormalized trigger and function detail. |
 | `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `namespace`, optional `description`). |
-| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. Returns the trigger id. |
+| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding lives in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |
 | `engine::unregister_trigger`  | Unregister a trigger by id. Idempotent; reports whether it existed. |
 
 Every row returned by `engine::functions::list`, `engine::functions::info`, `engine::workers::list`,

--- a/docs/next/reference/engine-protocol.mdx.skill.md
+++ b/docs/next/reference/engine-protocol.mdx.skill.md
@@ -386,10 +386,10 @@ and worker lifecycle. Defined in
 | `engine::workers::info`       | Inspect one connected worker's full surface (functions, trigger types, registered triggers). Takes `name` plus an optional `namespace`. |
 | `engine::triggers::list`      | List every registered trigger type (filterable by `include_internal`).        |
 | `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count. Accepts an optional `namespace`; absent resolves the caller's namespace first, then `default`. |
-| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`: `active`, or `pending` while its trigger type has no provider yet. |
+| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`; pass `include_pending: true` to also list registrations parked as `pending` while their trigger type has no provider. |
 | `engine::registered-triggers::info` | Inspect one registered trigger instance, with denormalized trigger and function detail. |
 | `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `namespace`, optional `description`). |
-| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding lives in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |
+| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding is registered in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |
 | `engine::unregister_trigger`  | Unregister a trigger by id. Idempotent; reports whether it existed. |
 
 Every row returned by `engine::functions::list`, `engine::functions::info`, `engine::workers::list`,

--- a/docs/next/reference/engine-protocol.mdx.skill.md
+++ b/docs/next/reference/engine-protocol.mdx.skill.md
@@ -386,7 +386,7 @@ and worker lifecycle. Defined in
 | `engine::workers::info`       | Inspect one connected worker's full surface (functions, trigger types, registered triggers). Takes `name` plus an optional `namespace`. |
 | `engine::triggers::list`      | List every registered trigger type (filterable by `include_internal`).        |
 | `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count. Accepts an optional `namespace`; absent resolves the caller's namespace first, then `default`. |
-| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`; pass `include_pending: true` to also list registrations parked as `pending` while their trigger type has no provider. |
+| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`; pass `include_pending: true` to also list registrations with `status: pending`, whose trigger type has no provider yet. |
 | `engine::registered-triggers::info` | Inspect one registered trigger instance, with denormalized trigger and function detail. |
 | `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `namespace`, optional `description`). |
 | `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding is registered in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |

--- a/docs/next/reference/engine-protocol.mdx.skill.md
+++ b/docs/next/reference/engine-protocol.mdx.skill.md
@@ -385,11 +385,11 @@ and worker lifecycle. Defined in
 | `engine::workers::list`       | List every connected worker with metrics.                                     |
 | `engine::workers::info`       | Inspect one connected worker's full surface (functions, trigger types, registered triggers). Takes `name` plus an optional `namespace`. |
 | `engine::triggers::list`      | List every registered trigger type (filterable by `include_internal`).        |
-| `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count.            |
-| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). |
+| `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count. Accepts an optional `namespace`; absent resolves the caller's namespace first, then `default`. |
+| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`: `active`, or `pending` while its trigger type has no provider yet. |
 | `engine::registered-triggers::info` | Inspect one registered trigger instance, with denormalized trigger and function detail. |
 | `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `namespace`, optional `description`). |
-| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. Returns the trigger id. |
+| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding lives in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |
 | `engine::unregister_trigger`  | Unregister a trigger by id. Idempotent; reports whether it existed. |
 
 Every row returned by `engine::functions::list`, `engine::functions::info`, `engine::workers::list`,

--- a/docs/reference/engine-protocol.mdx
+++ b/docs/reference/engine-protocol.mdx
@@ -388,10 +388,10 @@ and worker lifecycle. Defined in
 | `engine::workers::info`       | Inspect one connected worker's full surface (functions, trigger types, registered triggers). Takes `name` plus an optional `namespace`. |
 | `engine::triggers::list`      | List every registered trigger type (filterable by `include_internal`).        |
 | `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count. Accepts an optional `namespace`; absent resolves the caller's namespace first, then `default`. |
-| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`: `active`, or `pending` while its trigger type has no provider yet. |
+| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`; pass `include_pending: true` to also list registrations parked as `pending` while their trigger type has no provider. |
 | `engine::registered-triggers::info` | Inspect one registered trigger instance, with denormalized trigger and function detail. |
 | `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `namespace`, optional `description`). |
-| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding lives in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |
+| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding is registered in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |
 | `engine::unregister_trigger`  | Unregister a trigger by id. Idempotent; reports whether it existed. |
 
 Every row returned by `engine::functions::list`, `engine::functions::info`, `engine::workers::list`,

--- a/docs/reference/engine-protocol.mdx
+++ b/docs/reference/engine-protocol.mdx
@@ -388,7 +388,7 @@ and worker lifecycle. Defined in
 | `engine::workers::info`       | Inspect one connected worker's full surface (functions, trigger types, registered triggers). Takes `name` plus an optional `namespace`. |
 | `engine::triggers::list`      | List every registered trigger type (filterable by `include_internal`).        |
 | `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count. Accepts an optional `namespace`; absent resolves the caller's namespace first, then `default`. |
-| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`; pass `include_pending: true` to also list registrations parked as `pending` while their trigger type has no provider. |
+| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`; pass `include_pending: true` to also list registrations with `status: pending`, whose trigger type has no provider yet. |
 | `engine::registered-triggers::info` | Inspect one registered trigger instance, with denormalized trigger and function detail. |
 | `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `namespace`, optional `description`). |
 | `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding is registered in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |

--- a/docs/reference/engine-protocol.mdx
+++ b/docs/reference/engine-protocol.mdx
@@ -387,11 +387,11 @@ and worker lifecycle. Defined in
 | `engine::workers::list`       | List every connected worker with metrics.                                     |
 | `engine::workers::info`       | Inspect one connected worker's full surface (functions, trigger types, registered triggers). Takes `name` plus an optional `namespace`. |
 | `engine::triggers::list`      | List every registered trigger type (filterable by `include_internal`).        |
-| `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count.            |
-| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). |
+| `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count. Accepts an optional `namespace`; absent resolves the caller's namespace first, then `default`. |
+| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`: `active`, or `pending` while its trigger type has no provider yet. |
 | `engine::registered-triggers::info` | Inspect one registered trigger instance, with denormalized trigger and function detail. |
 | `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `namespace`, optional `description`). |
-| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. Returns the trigger id. |
+| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding lives in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |
 | `engine::unregister_trigger`  | Unregister a trigger by id. Idempotent; reports whether it existed. |
 
 Every row returned by `engine::functions::list`, `engine::functions::info`, `engine::workers::list`,

--- a/docs/reference/engine-protocol.mdx.skill.md
+++ b/docs/reference/engine-protocol.mdx.skill.md
@@ -386,10 +386,10 @@ and worker lifecycle. Defined in
 | `engine::workers::info`       | Inspect one connected worker's full surface (functions, trigger types, registered triggers). Takes `name` plus an optional `namespace`. |
 | `engine::triggers::list`      | List every registered trigger type (filterable by `include_internal`).        |
 | `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count. Accepts an optional `namespace`; absent resolves the caller's namespace first, then `default`. |
-| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`: `active`, or `pending` while its trigger type has no provider yet. |
+| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`; pass `include_pending: true` to also list registrations parked as `pending` while their trigger type has no provider. |
 | `engine::registered-triggers::info` | Inspect one registered trigger instance, with denormalized trigger and function detail. |
 | `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `namespace`, optional `description`). |
-| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding lives in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |
+| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding is registered in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |
 | `engine::unregister_trigger`  | Unregister a trigger by id. Idempotent; reports whether it existed. |
 
 Every row returned by `engine::functions::list`, `engine::functions::info`, `engine::workers::list`,

--- a/docs/reference/engine-protocol.mdx.skill.md
+++ b/docs/reference/engine-protocol.mdx.skill.md
@@ -386,7 +386,7 @@ and worker lifecycle. Defined in
 | `engine::workers::info`       | Inspect one connected worker's full surface (functions, trigger types, registered triggers). Takes `name` plus an optional `namespace`. |
 | `engine::triggers::list`      | List every registered trigger type (filterable by `include_internal`).        |
 | `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count. Accepts an optional `namespace`; absent resolves the caller's namespace first, then `default`. |
-| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`; pass `include_pending: true` to also list registrations parked as `pending` while their trigger type has no provider. |
+| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`; pass `include_pending: true` to also list registrations with `status: pending`, whose trigger type has no provider yet. |
 | `engine::registered-triggers::info` | Inspect one registered trigger instance, with denormalized trigger and function detail. |
 | `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `namespace`, optional `description`). |
 | `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding is registered in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |

--- a/docs/reference/engine-protocol.mdx.skill.md
+++ b/docs/reference/engine-protocol.mdx.skill.md
@@ -385,11 +385,11 @@ and worker lifecycle. Defined in
 | `engine::workers::list`       | List every connected worker with metrics.                                     |
 | `engine::workers::info`       | Inspect one connected worker's full surface (functions, trigger types, registered triggers). Takes `name` plus an optional `namespace`. |
 | `engine::triggers::list`      | List every registered trigger type (filterable by `include_internal`).        |
-| `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count.            |
-| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). |
+| `engine::triggers::info`      | Inspect one trigger type: schemas, owner, and live instance count. Accepts an optional `namespace`; absent resolves the caller's namespace first, then `default`. |
+| `engine::registered-triggers::list` | List every registered trigger instance (filterable by `include_internal`). Each row carries a `status`: `active`, or `pending` while its trigger type has no provider yet. |
 | `engine::registered-triggers::info` | Inspect one registered trigger instance, with denormalized trigger and function detail. |
 | `engine::workers::register`   | Publish the calling worker's metadata (runtime, version, OS, PID, isolation, optional `namespace`, optional `description`). |
-| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. Returns the trigger id. |
+| `engine::register_trigger`    | Register a trigger that fires `function_id` directly, with optional `metadata` delivered to the handler as a distinct argument. The binding lives in the calling worker's namespace: the target resolves there and the provider is looked up there first, then in `default`. Returns the trigger id. |
 | `engine::unregister_trigger`  | Unregister a trigger by id. Idempotent; reports whether it existed. |
 
 Every row returned by `engine::functions::list`, `engine::functions::info`, `engine::workers::list`,

--- a/engine/src/trigger.rs
+++ b/engine/src/trigger.rs
@@ -245,8 +245,10 @@ pub struct Trigger {
     /// Taken from the `RegisterTrigger` message's `namespace` (not the registering
     /// connection): the trigger names its target namespace explicitly, and an
     /// absent value means [`crate::protocol::DEFAULT_NAMESPACE`] — see
-    /// `Engine::fire_triggers`. Also defaults to `default` for engine-internal /
-    /// durable registrations and for wire payloads that predate the field.
+    /// `Engine::fire_triggers`. Also defaults to `default` for engine-internal
+    /// registrations and for wire payloads that predate the field. A durable
+    /// `engine::register_trigger` binding takes the calling connection's
+    /// namespace instead: its target is the caller's own function.
     #[serde(default = "crate::protocol::default_namespace")]
     pub namespace: String,
     /// Namespace the caller named for the provider, if any.
@@ -276,8 +278,7 @@ pub struct Trigger {
 
 impl Trigger {
     /// The three namespace fields for an engine-internal binding: one declared
-    /// in engine configuration, or registered through
-    /// `engine::register_trigger` rather than by a worker connection.
+    /// in engine configuration rather than by a worker connection.
     ///
     /// These are engine orchestration, so they are at home in
     /// [`DEFAULT_NAMESPACE`] and resolve their provider there — which is also

--- a/engine/src/workers/engine_fn/README.md
+++ b/engine/src/workers/engine_fn/README.md
@@ -37,7 +37,7 @@ Every call is `caller → engine → handler`. The function id is the only contr
 
 ## Functions — `engine::*`
 
-Implemented in-process by mandatory worker **`iii-engine-functions`**. Filter lists with `prefix`, `search`, or `worker`. By default, `engine::functions::list`, `engine::triggers::list`, and `engine::registered-triggers::list` hide internal `engine::*` rows unless `include_internal: true`.
+Implemented in-process by mandatory worker **`iii-engine-functions`**. Filter lists with `prefix`, `search`, or `worker`. By default, `engine::functions::list`, `engine::triggers::list`, and `engine::registered-triggers::list` hide internal `engine::*` rows unless `include_internal: true`. `engine::registered-triggers::list` also hides registrations parked as `pending` (no provider for their trigger type yet) unless `include_pending: true`; every row carries a `status`.
 
 For exact request/response JSON Schemas, call `engine::functions::info { function_id: "engine::…" }`.
 

--- a/engine/src/workers/engine_fn/README.md
+++ b/engine/src/workers/engine_fn/README.md
@@ -37,7 +37,7 @@ Every call is `caller → engine → handler`. The function id is the only contr
 
 ## Functions — `engine::*`
 
-Implemented in-process by mandatory worker **`iii-engine-functions`**. Filter lists with `prefix`, `search`, or `worker`. By default, `engine::functions::list`, `engine::triggers::list`, and `engine::registered-triggers::list` hide internal `engine::*` rows unless `include_internal: true`. `engine::registered-triggers::list` also hides registrations parked as `pending` (no provider for their trigger type yet) unless `include_pending: true`; every row carries a `status`.
+Implemented in-process by mandatory worker **`iii-engine-functions`**. Filter lists with `prefix`, `search`, or `worker`. By default, `engine::functions::list`, `engine::triggers::list`, and `engine::registered-triggers::list` hide internal `engine::*` rows unless `include_internal: true`. `engine::registered-triggers::list` also hides registrations with `status: pending` (no provider for their trigger type yet) unless `include_pending: true`; every row carries a `status`.
 
 For exact request/response JSON Schemas, call `engine::functions::info { function_id: "engine::…" }`.
 

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -151,10 +151,16 @@ pub struct TriggersListInput {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct TriggerInfoInput {
     pub id: String,
-    /// Which provider of this id. Absent means the one in the default
-    /// namespace, where every in-process engine provider lives.
+    /// Which provider of this id. `Some` is strict: that namespace or nothing.
+    /// Absent resolves the way a trigger registered by the caller would: the
+    /// caller's connection namespace first, then `default`, where every
+    /// in-process engine provider lives.
     #[serde(default)]
     pub namespace: Option<String>,
+    /// Injected by the engine from the calling worker. Absent for in-process
+    /// callers, whose home is `default`.
+    #[serde(rename = "_caller_worker_id", default)]
+    pub caller_worker_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, JsonSchema)]
@@ -317,12 +323,22 @@ pub struct TriggerTypeDetail {
     pub instance_count: usize,
 }
 
+/// Whether a registered trigger is bound to a live provider or parked in
+/// `pending_triggers` waiting for one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum RegisteredTriggerStatus {
+    Active,
+    Pending,
+}
+
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct RegisteredTriggerSummary {
     pub id: String,
     pub trigger_type: String,
     pub function_id: String,
     pub worker_name: String,
+    pub status: RegisteredTriggerStatus,
     /// Full trigger config (e.g. `{ "api_path": "...", "http_method": "GET" }`
     /// for HTTP triggers, `{ "topic": "..." }` for events, etc.). Console
     /// list views need this structured payload to render method/path/topic.
@@ -338,6 +354,7 @@ pub struct RegisteredTriggerDetail {
     pub trigger_type: String,
     pub function_id: String,
     pub worker_name: String,
+    pub status: RegisteredTriggerStatus,
     pub config: Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
@@ -486,13 +503,15 @@ pub struct RegisterTriggerInput {
     /// recover per-trigger context the engine routing otherwise drops.
     #[serde(default)]
     pub metadata: Option<Value>,
-    /// Injected by the engine from the calling worker; scopes the trigger so it
-    /// is GC'd when that worker disconnects. Absent for in-process callers.
+    /// Injected by the engine from the calling worker. Its connection namespace
+    /// is where the binding is at home: the target `function_id` resolves there
+    /// and the provider lookup starts there. Not an owner — the binding outlives
+    /// the connection. Absent for in-process callers, whose home is `default`.
     #[serde(rename = "_caller_worker_id", default)]
     pub caller_worker_id: Option<String>,
     /// Namespace to find the trigger type's provider in. Absent asks the engine
-    /// to resolve it, which for a durable registration means
-    /// [`crate::protocol::DEFAULT_NAMESPACE`] — its home — and nothing else.
+    /// to resolve it: the caller's connection namespace first, then
+    /// [`crate::protocol::DEFAULT_NAMESPACE`].
     #[serde(default)]
     pub trigger_namespace: Option<String>,
 }
@@ -599,6 +618,16 @@ impl EngineFunctionsWorker {
             out.push('…');
             out
         }
+    }
+
+    /// The connection namespace of the worker behind an injected
+    /// `_caller_worker_id`. In-process callers carry none and are at home in
+    /// [`crate::protocol::DEFAULT_NAMESPACE`].
+    fn caller_namespace(&self, caller_worker_id: Option<&str>) -> String {
+        caller_worker_id
+            .and_then(|id| uuid::Uuid::parse_str(id).ok())
+            .map(|id| self.engine.worker_registry.get_namespace(&id))
+            .unwrap_or_else(crate::protocol::default_namespace)
     }
 
     /// Builds a `(namespace, function_id) -> worker_name` map by scanning both
@@ -914,28 +943,39 @@ impl EngineFunctionsWorker {
             .collect()
     }
 
+    fn registered_trigger_summary(
+        index: &HashMap<(String, String), String>,
+        t: &Trigger,
+        status: RegisteredTriggerStatus,
+    ) -> RegisteredTriggerSummary {
+        RegisteredTriggerSummary {
+            id: t.id.clone(),
+            trigger_type: t.trigger_type.clone(),
+            function_id: t.function_id.clone(),
+            worker_name: Self::worker_name_for_function_id(index, &t.namespace, &t.function_id),
+            status,
+            config: t.config.clone(),
+            config_summary: Self::config_summary(&t.config),
+        }
+    }
+
+    /// Live bindings and parked ones alike: a registration whose provider has
+    /// not shown up is still a registration, and the only way to see why it
+    /// never fires is to list it.
     async fn list_registered_trigger_summaries(&self) -> Vec<RegisteredTriggerSummary> {
         let index = self.function_owner_index().await;
-        self.engine
-            .trigger_registry
-            .triggers
-            .iter()
-            .map(|entry| {
-                let t = entry.value();
-                RegisteredTriggerSummary {
-                    id: t.id.clone(),
-                    trigger_type: t.trigger_type.clone(),
-                    function_id: t.function_id.clone(),
-                    worker_name: Self::worker_name_for_function_id(
-                        &index,
-                        &t.namespace,
-                        &t.function_id,
-                    ),
-                    config: t.config.clone(),
-                    config_summary: Self::config_summary(&t.config),
-                }
-            })
-            .collect()
+        let registry = &self.engine.trigger_registry;
+        let active = registry.triggers.iter().map(|entry| {
+            Self::registered_trigger_summary(&index, entry.value(), RegisteredTriggerStatus::Active)
+        });
+        let pending = registry.pending_triggers.iter().map(|entry| {
+            Self::registered_trigger_summary(
+                &index,
+                entry.value(),
+                RegisteredTriggerStatus::Pending,
+            )
+        });
+        active.chain(pending).collect()
     }
 
     async fn list_worker_summaries(&self, filter_worker_id: Option<&str>) -> Vec<WorkerSummary> {
@@ -1097,12 +1137,14 @@ impl EngineFunctionsWorker {
     }
 
     async fn build_registered_trigger_detail(&self, id: &str) -> Option<RegisteredTriggerDetail> {
-        let trigger = self
-            .engine
-            .trigger_registry
-            .triggers
-            .get(id)
-            .map(|entry| entry.value().clone())?;
+        let registry = &self.engine.trigger_registry;
+        let (trigger, status) = match registry.triggers.get(id) {
+            Some(entry) => (entry.value().clone(), RegisteredTriggerStatus::Active),
+            None => (
+                registry.pending_triggers.get(id)?.value().clone(),
+                RegisteredTriggerStatus::Pending,
+            ),
+        };
 
         let index = self.function_owner_index().await;
         let worker_name =
@@ -1118,6 +1160,7 @@ impl EngineFunctionsWorker {
             trigger_type: trigger.trigger_type.clone(),
             function_id: trigger.function_id.clone(),
             worker_name,
+            status,
             config: trigger.config.clone(),
             metadata: trigger.metadata.clone(),
             trigger: trigger_detail,
@@ -1341,18 +1384,7 @@ impl EngineFunctionsWorker {
             })
             .map(|entry| {
                 let t = entry.value();
-                RegisteredTriggerSummary {
-                    id: t.id.clone(),
-                    trigger_type: t.trigger_type.clone(),
-                    function_id: t.function_id.clone(),
-                    worker_name: Self::worker_name_for_function_id(
-                        &index,
-                        &t.namespace,
-                        &t.function_id,
-                    ),
-                    config: t.config.clone(),
-                    config_summary: Self::config_summary(&t.config),
-                }
+                Self::registered_trigger_summary(&index, t, RegisteredTriggerStatus::Active)
             })
             .collect();
         registered_triggers.sort_by(|a, b| a.id.cmp(&b.id));
@@ -1811,17 +1843,29 @@ impl EngineFunctionsWorker {
         &self,
         input: TriggerInfoInput,
     ) -> FunctionResult<TriggerTypeDetail, ErrorBody> {
-        let namespace = input
-            .namespace
-            .clone()
-            .unwrap_or_else(crate::protocol::default_namespace);
-        match self.build_trigger_type_detail(&crate::trigger::type_key(&namespace, &input.id)) {
+        // Same order as `TriggerRegistry::resolve_provider_key`: an explicit
+        // namespace is strict; absent tries the caller's home, then `default`.
+        // Answering from `default` alone would report a namespaced worker's own
+        // provider as NOT_FOUND.
+        let mut candidates = match input.namespace.as_deref() {
+            Some(explicit) => vec![explicit.to_string()],
+            None => vec![
+                self.caller_namespace(input.caller_worker_id.as_deref()),
+                crate::protocol::default_namespace(),
+            ],
+        };
+        candidates.dedup();
+        let found = candidates.iter().find_map(|ns| {
+            self.build_trigger_type_detail(&crate::trigger::type_key(ns, &input.id))
+        });
+        match found {
             Some(detail) => FunctionResult::Success(detail),
             None => FunctionResult::Failure(ErrorBody {
                 code: "NOT_FOUND".into(),
                 message: format!(
-                    "Trigger type '{}' is not registered in namespace '{}'.",
-                    input.id, namespace
+                    "Trigger type '{}' is not registered in namespace(s): {}.",
+                    input.id,
+                    candidates.join(", ")
                 ),
                 stacktrace: None,
             }),
@@ -2102,6 +2146,15 @@ impl EngineFunctionsWorker {
         // must not reap them. A worker's own lifecycle bindings go through the
         // `Message::RegisterTrigger` path, which keeps connection ownership and
         // the disconnect GC.
+        //
+        // The binding is at home in the caller's connection namespace: that is
+        // where its target function lives and where the provider lookup starts
+        // (falling back to `default`, where the engine's own providers are).
+        // Hardcoding `default` here parked every registration from a namespaced
+        // worker in `pending_triggers` for good — its provider was never looked
+        // for at home, and a fire would have resolved the target in `default`
+        // anyway. In-process callers carry no worker id and stay in `default`.
+        let namespace = self.caller_namespace(input.caller_worker_id.as_deref());
         let trigger = Trigger {
             id: id.clone(),
             trigger_type: input.trigger_type,
@@ -2109,13 +2162,10 @@ impl EngineFunctionsWorker {
             config: input.config,
             worker_id: None,
             metadata: input.metadata,
-            // Function-path (durable) registrations are engine orchestration and
-            // resolve their target in the default namespace, matching the
-            // `fire_triggers` behavior they predate. Their provider resolves
-            // there too — see `Trigger::internal_namespaces`.
-            namespace: crate::protocol::default_namespace(),
+            namespace: namespace.clone(),
             trigger_namespace: input.trigger_namespace,
-            home_namespace: crate::protocol::default_namespace(),
+            home_namespace: namespace,
+            // Written by the registry once it resolves; only the starting value.
             provider_namespace: crate::protocol::default_namespace(),
         };
 
@@ -3060,6 +3110,7 @@ mod tests {
             trigger_type: "cron".to_string(),
             function_id: "fn::handler".to_string(),
             worker_name: "fn".to_string(),
+            status: RegisteredTriggerStatus::Active,
             config: serde_json::json!({ "x": 1 }),
             config_summary: "{\"x\":1}".to_string(),
         };
@@ -3702,6 +3753,7 @@ mod tests {
             .triggers_info(TriggerInfoInput {
                 id: "cron".to_string(),
                 namespace: None,
+                caller_worker_id: None,
             })
             .await;
         match result {
@@ -3735,6 +3787,7 @@ mod tests {
             .triggers_info(TriggerInfoInput {
                 id: "http".to_string(),
                 namespace: None,
+                caller_worker_id: None,
             })
             .await;
         match result {
@@ -3802,6 +3855,7 @@ mod tests {
             .triggers_info(TriggerInfoInput {
                 id: "nope".to_string(),
                 namespace: None,
+                caller_worker_id: None,
             })
             .await;
         assert!(matches!(result, FunctionResult::Failure(_)));
@@ -4691,5 +4745,190 @@ mod tests {
         register_test_trigger_type(&engine, &module).await;
         assert!(engine.trigger_registry.pending_triggers.is_empty());
         assert!(engine.trigger_registry.triggers.contains_key(&id));
+    }
+
+    /// Registers a WS worker connection whose `engine::workers::register`
+    /// declared `namespace`, returning its id as a `_caller_worker_id`.
+    async fn connect_worker_in_namespace(
+        engine: &Engine,
+        module: &EngineFunctionsWorker,
+        namespace: &str,
+    ) -> String {
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let worker = crate::worker_connections::WorkerConnection::new(tx);
+        let worker_id = worker.id.to_string();
+        engine.worker_registry.register_worker(worker);
+        module
+            .register_worker_metadata(register_worker_input_with_namespace(
+                &worker_id,
+                Some(namespace.to_string()),
+            ))
+            .await;
+        worker_id
+    }
+
+    fn register_trigger_input_from(caller_worker_id: &str) -> RegisterTriggerInput {
+        RegisterTriggerInput {
+            trigger_type: "test-type".to_string(),
+            function_id: "test::target".to_string(),
+            config: serde_json::json!({}),
+            metadata: None,
+            caller_worker_id: Some(caller_worker_id.to_string()),
+            trigger_namespace: None,
+        }
+    }
+
+    /// The reported bug: a worker in `orders` binds a `state`-style trigger
+    /// whose provider is the engine's own, in `default`. The binding must go
+    /// live on that provider with `orders` as target and home — not park in
+    /// `pending_triggers` because `default` was assumed to be its home.
+    #[tokio::test]
+    async fn register_trigger_fn_from_namespaced_caller_falls_back_to_default_provider() {
+        let (engine, module) = setup_engine_and_module();
+        register_test_trigger_type(&engine, &module).await;
+        let caller = connect_worker_in_namespace(&engine, &module, "orders").await;
+
+        let id = match module
+            .register_trigger_fn(register_trigger_input_from(&caller), None)
+            .await
+        {
+            FunctionResult::Success(r) => r.id,
+            _ => panic!("expected register success"),
+        };
+
+        assert!(engine.trigger_registry.pending_triggers.is_empty());
+        let trig = engine
+            .trigger_registry
+            .triggers
+            .get(&id)
+            .expect("trigger live");
+        assert_eq!(
+            trig.namespace, "orders",
+            "target resolves in the caller's namespace"
+        );
+        assert_eq!(trig.home_namespace, "orders");
+        assert_eq!(trig.provider_namespace, crate::protocol::DEFAULT_NAMESPACE);
+    }
+
+    /// A provider registered in the caller's own namespace wins over the
+    /// engine's fallback, exactly as it does on the `Message::RegisterTrigger`
+    /// path.
+    #[tokio::test]
+    async fn register_trigger_fn_prefers_provider_in_callers_namespace() {
+        let (engine, module) = setup_engine_and_module();
+        register_test_trigger_type(&engine, &module).await;
+        engine
+            .trigger_registry
+            .register_trigger_type(crate::trigger::TriggerType::new_ns(
+                "orders",
+                "test-type",
+                "Orders' own provider",
+                Box::new(module.clone()),
+                None,
+            ))
+            .await
+            .unwrap();
+        let caller = connect_worker_in_namespace(&engine, &module, "orders").await;
+
+        let id = match module
+            .register_trigger_fn(register_trigger_input_from(&caller), None)
+            .await
+        {
+            FunctionResult::Success(r) => r.id,
+            _ => panic!("expected register success"),
+        };
+
+        let trig = engine.trigger_registry.triggers.get(&id).expect("live");
+        assert_eq!(trig.provider_namespace, "orders");
+    }
+
+    /// A parked registration is still a registration: `list` and `info` show
+    /// it as `pending`, and flip it to `active` once its provider registers.
+    #[tokio::test]
+    async fn registered_triggers_list_and_info_include_pending_rows_with_status() {
+        let (engine, module) = setup_engine_and_module();
+        let caller = connect_worker_in_namespace(&engine, &module, "orders").await;
+
+        let id = match module
+            .register_trigger_fn(register_trigger_input_from(&caller), None)
+            .await
+        {
+            FunctionResult::Success(r) => r.id,
+            _ => panic!("expected deferred register success"),
+        };
+        assert!(engine.trigger_registry.pending_triggers.contains_key(&id));
+
+        let listed = match module
+            .registered_triggers_list(RegisteredTriggersListInput::default())
+            .await
+        {
+            FunctionResult::Success(r) => r.registered_triggers,
+            _ => panic!("expected list success"),
+        };
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, id);
+        assert_eq!(listed[0].status, RegisteredTriggerStatus::Pending);
+
+        let detail = match module
+            .registered_triggers_info(RegisteredTriggerInfoInput { id: id.clone() })
+            .await
+        {
+            FunctionResult::Success(d) => d,
+            _ => panic!("pending row must be inspectable"),
+        };
+        assert_eq!(detail.status, RegisteredTriggerStatus::Pending);
+        assert_eq!(detail.function_id, "test::target");
+
+        register_test_trigger_type(&engine, &module).await;
+        let detail = match module
+            .registered_triggers_info(RegisteredTriggerInfoInput { id })
+            .await
+        {
+            FunctionResult::Success(d) => d,
+            _ => panic!("expected info success"),
+        };
+        assert_eq!(detail.status, RegisteredTriggerStatus::Active);
+    }
+
+    /// `engine::triggers::info` without a namespace answers for the caller's
+    /// own provider first, then `default` — not `default` alone, which reported
+    /// a namespaced worker's provider as NOT_FOUND.
+    #[tokio::test]
+    async fn triggers_info_resolves_callers_namespace_before_default() {
+        let (engine, module) = setup_engine_and_module();
+        engine
+            .trigger_registry
+            .register_trigger_type(crate::trigger::TriggerType::new_ns(
+                "orders",
+                "test-type",
+                "Orders' own provider",
+                Box::new(module.clone()),
+                None,
+            ))
+            .await
+            .unwrap();
+        let caller = connect_worker_in_namespace(&engine, &module, "orders").await;
+
+        let from_orders = module
+            .triggers_info(TriggerInfoInput {
+                id: "test-type".to_string(),
+                namespace: None,
+                caller_worker_id: Some(caller),
+            })
+            .await;
+        match from_orders {
+            FunctionResult::Success(detail) => assert_eq!(detail.namespace, "orders"),
+            _ => panic!("caller's own provider must resolve"),
+        }
+
+        // An in-process caller is at home in `default`, where nothing provides it.
+        let from_default = module
+            .triggers_info(TriggerInfoInput {
+                id: "test-type".to_string(),
+                namespace: None,
+                caller_worker_id: None,
+            })
+            .await;
+        assert!(matches!(from_default, FunctionResult::Failure(_)));
     }
 }

--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -182,6 +182,12 @@ pub struct RegisteredTriggersListInput {
     /// Defaults to false.
     #[serde(default)]
     pub include_internal: Option<bool>,
+    /// Include registrations parked in `pending_triggers` because their trigger
+    /// type has no provider yet (rows with `status: "pending"`). Defaults to
+    /// false: a bare list is the set of live bindings, which is what every
+    /// caller before `status` existed was counting on.
+    #[serde(default)]
+    pub include_pending: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -959,23 +965,36 @@ impl EngineFunctionsWorker {
         }
     }
 
-    /// Live bindings and parked ones alike: a registration whose provider has
-    /// not shown up is still a registration, and the only way to see why it
-    /// never fires is to list it.
-    async fn list_registered_trigger_summaries(&self) -> Vec<RegisteredTriggerSummary> {
+    /// Live bindings, plus the parked ones when asked: a registration whose
+    /// provider has not shown up is still a registration, and the only way to
+    /// see why it never fires is to list it.
+    async fn list_registered_trigger_summaries(
+        &self,
+        include_pending: bool,
+    ) -> Vec<RegisteredTriggerSummary> {
         let index = self.function_owner_index().await;
         let registry = &self.engine.trigger_registry;
-        let active = registry.triggers.iter().map(|entry| {
-            Self::registered_trigger_summary(&index, entry.value(), RegisteredTriggerStatus::Active)
-        });
-        let pending = registry.pending_triggers.iter().map(|entry| {
-            Self::registered_trigger_summary(
-                &index,
-                entry.value(),
-                RegisteredTriggerStatus::Pending,
-            )
-        });
-        active.chain(pending).collect()
+        let mut rows: Vec<RegisteredTriggerSummary> = registry
+            .triggers
+            .iter()
+            .map(|entry| {
+                Self::registered_trigger_summary(
+                    &index,
+                    entry.value(),
+                    RegisteredTriggerStatus::Active,
+                )
+            })
+            .collect();
+        if include_pending {
+            rows.extend(registry.pending_triggers.iter().map(|entry| {
+                Self::registered_trigger_summary(
+                    &index,
+                    entry.value(),
+                    RegisteredTriggerStatus::Pending,
+                )
+            }));
+        }
+        rows
     }
 
     async fn list_worker_summaries(&self, filter_worker_id: Option<&str>) -> Vec<WorkerSummary> {
@@ -1880,7 +1899,9 @@ impl EngineFunctionsWorker {
         &self,
         input: RegisteredTriggersListInput,
     ) -> FunctionResult<RegisteredTriggersListResult, ErrorBody> {
-        let mut registered_triggers = self.list_registered_trigger_summaries().await;
+        let mut registered_triggers = self
+            .list_registered_trigger_summaries(input.include_pending.unwrap_or(false))
+            .await;
 
         if !input.include_internal.unwrap_or(false) {
             registered_triggers.retain(|t| !t.function_id.starts_with("engine::"));
@@ -2436,7 +2457,7 @@ mod tests {
     #[tokio::test]
     async fn list_registered_trigger_summaries_empty() {
         let (_engine, module) = setup_engine_and_module();
-        let triggers = module.list_registered_trigger_summaries().await;
+        let triggers = module.list_registered_trigger_summaries(false).await;
         assert!(triggers.is_empty());
     }
 
@@ -2451,7 +2472,7 @@ mod tests {
             serde_json::json!({"interval": 5}),
         );
 
-        let summaries = module.list_registered_trigger_summaries().await;
+        let summaries = module.list_registered_trigger_summaries(false).await;
         assert_eq!(summaries.len(), 1);
         assert_eq!(summaries[0].id, "trig-1");
         assert_eq!(summaries[0].trigger_type, "cron");
@@ -2472,7 +2493,7 @@ mod tests {
             serde_json::json!({"data": huge}),
         );
 
-        let summaries = module.list_registered_trigger_summaries().await;
+        let summaries = module.list_registered_trigger_summaries(false).await;
         assert_eq!(summaries.len(), 1);
         let summary = &summaries[0].config_summary;
         let char_count = summary.chars().count();
@@ -4842,8 +4863,10 @@ mod tests {
         assert_eq!(trig.provider_namespace, "orders");
     }
 
-    /// A parked registration is still a registration: `list` and `info` show
-    /// it as `pending`, and flip it to `active` once its provider registers.
+    /// A parked registration is still a registration: `list` shows it as
+    /// `pending` when asked (a bare list stays the set of live bindings), `info`
+    /// always resolves it, and both flip it to `active` once its provider
+    /// registers.
     #[tokio::test]
     async fn registered_triggers_list_and_info_include_pending_rows_with_status() {
         let (engine, module) = setup_engine_and_module();
@@ -4858,8 +4881,20 @@ mod tests {
         };
         assert!(engine.trigger_registry.pending_triggers.contains_key(&id));
 
-        let listed = match module
+        let bare = match module
             .registered_triggers_list(RegisteredTriggersListInput::default())
+            .await
+        {
+            FunctionResult::Success(r) => r.registered_triggers,
+            _ => panic!("expected list success"),
+        };
+        assert!(bare.is_empty(), "a bare list is live bindings only");
+
+        let listed = match module
+            .registered_triggers_list(RegisteredTriggersListInput {
+                include_pending: Some(true),
+                ..Default::default()
+            })
             .await
         {
             FunctionResult::Success(r) => r.registered_triggers,

--- a/engine/tests/namespace_trigger_e2e.rs
+++ b/engine/tests/namespace_trigger_e2e.rs
@@ -361,3 +361,95 @@ async fn trigger_registered_before_workers_register_resolves_in_the_real_namespa
     let _ = orders.close(None).await;
     let _ = default.close(None).await;
 }
+
+/// The function path. A namespaced worker that calls `engine::register_trigger`
+/// over the wire (the engine injects `_caller_worker_id`) must get a LIVE
+/// binding at home in its own namespace, and a fire must reach its function
+/// there. Before the fix every namespace field was hardcoded to `default`: the
+/// provider was never looked for at home, so the registration parked in
+/// `pending_triggers` for good while the call still returned success — and a
+/// fire, had one happened, would have resolved the target in `default`.
+#[tokio::test]
+async fn function_path_register_trigger_binds_in_the_callers_namespace() {
+    let (port, engine) = spawn_engine().await;
+
+    let mut orders = connect(port).await;
+    send_register_worker(&mut orders, "orders-worker", Some("orders")).await;
+    send_register_function(&mut orders, "orders::wake", "from-orders").await;
+    orders
+        .send(WsMessage::Text(
+            json!({
+                "type": "invokefunction",
+                "invocation_id": uuid::Uuid::new_v4(),
+                "function_id": "engine::register_trigger",
+                "data": {
+                    "trigger_type": TRIGGER_FUNCTIONS_AVAILABLE,
+                    "function_id": "orders::wake",
+                    "config": {},
+                },
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send engine::register_trigger");
+
+    // A same-named function in `default` must NOT be the one fired.
+    let mut default = connect(port).await;
+    send_register_worker(&mut default, "default-worker", None).await;
+    send_register_function(&mut default, "orders::wake", "from-default").await;
+
+    let live_binding = || {
+        engine
+            .trigger_registry
+            .triggers
+            .iter()
+            .find(|t| t.function_id == "orders::wake")
+            .map(|t| t.value().clone())
+    };
+    assert!(
+        eventually(|| live_binding().is_some()
+            && engine.functions.get("default", "orders::wake").is_some())
+        .await,
+        "the function-path registration must go live, not park in pending_triggers"
+    );
+    assert!(engine.trigger_registry.pending_triggers.is_empty());
+    let trigger = live_binding().expect("live binding");
+    assert_eq!(
+        trigger.namespace, "orders",
+        "target resolves in the caller's namespace"
+    );
+    assert_eq!(
+        trigger.home_namespace, "orders",
+        "provider lookup starts at home"
+    );
+
+    let info = call_engine_fn(
+        &engine,
+        "engine::registered-triggers::info",
+        json!({ "id": trigger.id }),
+    )
+    .await;
+    assert_eq!(info["status"], json!("active"), "got: {info}");
+    assert_eq!(
+        info["function"]["namespace"],
+        json!("orders"),
+        "got: {info}"
+    );
+
+    engine
+        .fire_triggers(TRIGGER_FUNCTIONS_AVAILABLE, json!({ "event": "test" }))
+        .await;
+
+    assert!(
+        received_invoke(&mut orders, "orders::wake").await,
+        "the registering worker's own function must receive the fire"
+    );
+    assert!(
+        !received_invoke(&mut default, "orders::wake").await,
+        "the default worker's same-named function must NOT be fired"
+    );
+
+    let _ = orders.close(None).await;
+    let _ = default.close(None).await;
+}


### PR DESCRIPTION
## What

`engine::register_trigger` now binds the trigger in the calling connection's namespace. The target `function_id` resolves there and the provider is looked up there first, then in `default`, the same order the `Message::RegisterTrigger` path already uses. In-process callers carry no `_caller_worker_id` and keep `default`.

`engine::triggers::info` without a `namespace` resolves the caller's namespace first, then `default`, and its NOT_FOUND message names every namespace it tried.

`engine::registered-triggers::list` and `::info` can now surface registrations parked in `pending_triggers`. Every row carries a `status` field (`active` or `pending`); `info` resolves a parked id directly, and `list` includes parked rows when called with `include_pending: true`.

## Why

The function path hardcoded `namespace`, `home_namespace` and `provider_namespace` to `default`. For a worker in a non-default namespace, the provider lookup never looked at home, so the registration parked in `pending_triggers` for good while the call still returned an id. Parked rows were invisible to `registered-triggers::*`, and a fire would have resolved the target in `default`, where the registrant's function is not registered. Observed as state, cron and custom-type wakes from a namespaced deployment that never fired.

Closes [MOT-4586](https://linear.app/motia/issue/MOT-4586/fix-namespace-handling-for-function-trigger-registration).

## Notes

- Additive wire change: `status` is a new field on `registered-triggers::list/info` rows, and `include_pending` a new optional input on `list`; `_caller_worker_id` is now accepted by `engine::triggers::info` (already injected by the engine on every worker-initiated call).
- Pending rows are opt-in on `list` rather than on by default: the Rust and Go SDK tests (and the console bridge) read a bare `registered-triggers::list` as the set of live bindings, and a provider-rejected registration (for example a conflicting HTTP route) is parked in `pending_triggers`, so listing parked rows by default double-counted it in `conflicting_route_structure_is_rejected`.
- Not in scope: the Compose items listed in the ticket (`-n test --up` conflict, CLI namespace override precedence, `--engine` URL resolution) are separate code paths. No explicit target `namespace` input was added to `engine::register_trigger`; the caller's namespace is the default, matching what the SDK does on the message path.
- Validation: `cargo test -p iii --lib` (1760 passed), `namespace_trigger_e2e` (4, including the new wire-level test, confirmed red without the fix), `builtin_functions_e2e`, `namespace_introspection_e2e`. `cargo fmt --all` clean; Clippy reports only pre-existing warnings in the touched files.
- Engine checks use `SKIP_UI_BUILD=1` with the committed UI assets.
- Docs: protocol reference rows updated in `docs/next` and `docs/` (`.mdx` and `.skill.md`) by hand, since `iii-skill-render` is not available locally.

https://claude.ai/code/session_01CdWnnCmUDQpAccoqbNzY5G


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Trigger discovery now reports whether registrations are **active** or **pending**.
  - Pending registrations can be included by requesting `include_pending: true`.
  - Trigger lookup and registration now respect the caller’s namespace, with fallback to the default namespace.

- **Documentation**
  - Updated engine protocol and reference documentation to describe namespace resolution, registration behavior, and pending trigger visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->