### PR TITLE
feat(compose): update all package workers when no worker is specified

### DIFF
--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -126,7 +126,7 @@ impl EnginePolicy {
 ///
 /// Registry graphs and direct request lists can contain the same container
 /// more than once. Identical declarations collapse into one edit. Conflicting
-/// declarations reject the batch before the file is read or edited, so
+/// declarations reject the batch before the file is edited, so
 /// argument order cannot select the winning declaration.
 fn coalesce_containers(
     containers: Vec<crate::edit::NewContainer>,
@@ -154,6 +154,36 @@ fn coalesce_containers(
     }
 
     Ok(unique)
+}
+
+/// Select declared packages when no worker specs were supplied.
+fn workers_to_update(
+    compose: &crate::ComposeFile,
+    workers: &[String],
+) -> Result<Vec<crate::edit::NewContainer>> {
+    if !workers.is_empty() {
+        return workers
+            .iter()
+            .map(|worker| crate::edit::parse_worker(worker))
+            .collect();
+    }
+
+    Ok(compose
+        .containers
+        .iter()
+        .filter_map(|(key, container)| match &container.worker {
+            crate::config::WorkerSource::Package { reference } => Some(crate::edit::NewContainer {
+                key: key.clone(),
+                source: crate::edit::Source::Package {
+                    reference: reference.clone(),
+                    version: None,
+                },
+                start_after: container.start_after.clone(),
+                fields: serde_yaml::Mapping::new(),
+            }),
+            crate::config::WorkerSource::Path { .. } => None,
+        })
+        .collect())
 }
 
 pub struct Daemon {
@@ -646,6 +676,8 @@ impl Daemon {
     ///
     /// `worker=state` takes whatever the registry calls latest;
     /// `worker=state@1.2.3` takes that one, which is how a downgrade is spelled.
+    /// An empty worker list selects every declared package at its latest
+    /// version, using its existing registry reference. Path workers are skipped.
     /// Every container has to be declared already. This edits existing lines;
     /// `compose::add` is the call that adds them.
     ///
@@ -657,25 +689,6 @@ impl Daemon {
         workers: &[String],
         operation_id: String,
     ) -> Result<MutationOutcome> {
-        if workers.is_empty() {
-            return Err(ComposeError::InvalidWorkerSpec {
-                spec: String::new(),
-                reason: "no worker was named. Pass worker=<name>, worker=<name@version>, or a workers list"
-                    .to_string(),
-            });
-        }
-
-        let asked = workers
-            .iter()
-            .map(|worker| crate::edit::parse_worker(worker))
-            .collect::<Result<Vec<_>>>()?;
-        let requested = asked
-            .iter()
-            .map(|worker| worker.key.clone())
-            .collect::<Vec<_>>();
-        let primary = requested[0].clone();
-        let asked = coalesce_containers(asked)?;
-
         let path = self.resolve_file(file)?;
         let _mutation = self.lock_mutation(path).await;
         let text = std::fs::read_to_string(path).map_err(|source| ComposeError::Io {
@@ -684,6 +697,13 @@ impl Daemon {
         })?;
         let compose = crate::ComposeFile::parse(&text, path)?;
         self.engine_policy.validate_project(&compose)?;
+        let asked = workers_to_update(&compose, workers)?;
+        let requested = asked
+            .iter()
+            .map(|worker| worker.key.clone())
+            .collect::<Vec<_>>();
+        let primary = requested.first().map(String::as_str);
+        let asked = coalesce_containers(asked)?;
         let mut wanted = Vec::with_capacity(asked.len());
         for worker in &asked {
             let crate::edit::Source::Package { reference, version } = &worker.source else {
@@ -728,7 +748,7 @@ impl Daemon {
 
         let version = wanted
             .iter()
-            .find(|worker| worker.key == primary)
+            .find(|worker| Some(worker.key.as_str()) == primary)
             .and_then(|worker| match &worker.source {
                 crate::edit::Source::Package { version, .. } => version.clone(),
                 crate::edit::Source::Path { .. } => None,
@@ -749,7 +769,7 @@ impl Daemon {
             return Ok(MutationOutcome::from_operations(
                 OpStatus::Ok,
                 false,
-                Some(&primary),
+                primary,
                 Some(&requested),
                 version,
                 std::iter::empty::<&OpResult>(),
@@ -770,7 +790,7 @@ impl Daemon {
         Ok(MutationOutcome::from_operations(
             up.status,
             true,
-            Some(&primary),
+            primary,
             Some(&requested),
             version,
             [&down, &up].into_iter(),
@@ -1464,6 +1484,71 @@ fn expand_graph(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn update_without_workers_selects_packages_with_their_declared_references() {
+        let tmp = tempfile::tempdir().unwrap();
+        let compose = crate::ComposeFile::parse(
+            r#"
+containers:
+  database:
+    worker: package://private.example/team/state
+    version: '1.0.0'
+  api:
+    worker: path://.
+    scripts:
+      run: ./api
+  cache:
+    worker: package://api.workers.iii.dev/cache
+    version: '2.0.0'
+    start_after: [database]
+"#,
+            tmp.path().join("worker-compose.yaml"),
+        )
+        .unwrap();
+
+        let selected = workers_to_update(&compose, &[]).unwrap();
+
+        assert_eq!(
+            selected,
+            vec![
+                crate::edit::NewContainer {
+                    key: "database".to_string(),
+                    source: crate::edit::Source::Package {
+                        reference: "private.example/team/state".to_string(),
+                        version: None,
+                    },
+                    start_after: Vec::new(),
+                    fields: serde_yaml::Mapping::new(),
+                },
+                crate::edit::NewContainer {
+                    key: "cache".to_string(),
+                    source: crate::edit::Source::Package {
+                        reference: "api.workers.iii.dev/cache".to_string(),
+                        version: None,
+                    },
+                    start_after: vec!["database".to_string()],
+                    fields: serde_yaml::Mapping::new(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn update_with_a_worker_keeps_the_explicit_selection_and_version() {
+        let compose = crate::ComposeFile::parse(
+            "containers:\n  state:\n    worker: package://state\n    version: '1.0.0'\n  cache:\n    worker: package://cache\n    version: '2.0.0'\n",
+            Path::new("worker-compose.yaml"),
+        )
+        .unwrap();
+
+        let selected = workers_to_update(&compose, &["state@1.2.3".to_string()]).unwrap();
+
+        assert_eq!(
+            selected,
+            vec![crate::edit::parse_worker("state@1.2.3").unwrap()]
+        );
+    }
 
     fn package(name: &str) -> crate::edit::NewContainer {
         crate::edit::NewContainer {

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -56,7 +56,8 @@ pub struct ComposeRequest {
     pub container: Option<String>,
     /// The worker a call is about.
     ///
-    /// `compose::update` reads a spec: `name`, `name@version`, or a path.
+    /// `compose::update` reads a spec: `name` or `name@version`. Omit both
+    /// worker fields to update every declared package worker to latest.
     /// `compose::remove` and `compose::restart` read a container key, where it
     /// is the spelling for `container` — an operator naming a worker should not
     /// have to know which of the two words this call wanted. `compose::add`,
@@ -474,20 +475,26 @@ async fn dispatch(
             Err(err) => Err(compose_error(&err)),
         },
         Operation::Update => {
-            let workers = requested_specs(request.workers, request.worker)?;
-            if workers.is_empty() {
-                return daemon
-                    .update(file.as_deref(), &[], operation_id())
-                    .await
-                    .map(|outcome| to_value(&outcome))
-                    .map_err(|err| compose_error(&err));
+            if request.workers.as_ref().is_some_and(Vec::is_empty) {
+                return Err(compose_error(&ComposeError::InvalidWorkerSpec {
+                    spec: String::new(),
+                    reason:
+                        "workers cannot be empty. Omit worker and workers to update all packages"
+                            .to_string(),
+                }));
             }
+            let workers = requested_specs(request.workers, request.worker)?;
             let requested = workers.len();
+            let selection = if workers.is_empty() {
+                "all declared package workers".to_string()
+            } else {
+                format!("{requested} requested workers")
+            };
             let (operation, accepted) = admit_mutation(
                 &daemon,
                 request.operation_id,
                 requested,
-                format!("updating {requested} requested workers"),
+                format!("updating {selection}"),
             )
             .await?;
 
@@ -499,7 +506,7 @@ async fn dispatch(
                     .emit(
                         None,
                         "resolving",
-                        format!("resolving updates for {requested} workers"),
+                        format!("resolving updates for {selection}"),
                     )
                     .await;
                 daemon_task
@@ -754,6 +761,16 @@ fn batch_worker_options_schema() -> Option<Value> {
     Some(schema)
 }
 
+/// Update defaults to all packages, but explicit inputs must still be valid.
+fn update_worker_options_schema() -> Option<Value> {
+    let mut schema = batch_worker_options_schema()?;
+    schema.as_object_mut()?.remove("anyOf");
+    schema["description"] = json!(
+        "Omit worker and workers to update all declared package workers to latest. Path workers are skipped."
+    );
+    Some(schema)
+}
+
 /// Extend the batch contract with the container object form accepted by add.
 fn add_worker_options_schema() -> Option<Value> {
     let mut schema = batch_worker_options_schema()?;
@@ -809,7 +826,8 @@ fn op_description(function_id: &str) -> &'static str {
         }
         "compose::update" => {
             "Accept an observable operation that moves one or more declared package workers to \
-             requested or latest versions, then restarts the project once."
+             requested or latest versions, then restarts the project once if versions change. \
+             Omit worker and workers to update all declared package workers; path workers are skipped."
         }
         "compose::schema" => {
             "Return request and response JSON Schemas for compose::* functions. \
@@ -907,7 +925,7 @@ fn schema_table() -> &'static [SchemaTriple] {
             ),
             (
                 "compose::update",
-                batch_worker_options_schema(),
+                update_worker_options_schema(),
                 schema_for_value::<OperationAcceptedOutcome>(),
             ),
             (
@@ -1001,6 +1019,76 @@ fn operation_id() -> String {
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn update_without_worker_fields_returns_an_observable_operation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("worker-compose.yaml");
+        std::fs::write(
+            &file,
+            "containers:\n  api:\n    worker: path://.\n    scripts:\n      run: ./api\n",
+        )
+        .unwrap();
+        let daemon = Daemon::start(
+            "ws://127.0.0.1:1/ws".to_string(),
+            "update-test".to_string(),
+            None,
+            crate::daemon::EnginePolicy::External,
+        );
+        let accepted = dispatch(
+            Arc::clone(&daemon),
+            Operation::Update,
+            "update".to_string(),
+            ComposeRequest {
+                file: Some(file.to_string_lossy().into_owned()),
+                operation_id: Some("update-all".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(accepted["status"], "accepted");
+        assert_eq!(accepted["operation_id"], "update-all");
+        let operation = daemon.operations.get("update-all").await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let snapshot = operation.snapshot().await;
+                if snapshot.status == crate::operation::OperationStatus::Succeeded {
+                    break;
+                }
+                assert_ne!(snapshot.status, crate::operation::OperationStatus::Failed);
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("update all should complete without starting a path worker");
+    }
+
+    #[tokio::test]
+    async fn update_rejects_an_explicit_empty_list_even_with_a_singular_worker() {
+        let daemon = Daemon::start(
+            "ws://127.0.0.1:1/ws".to_string(),
+            "update-test".to_string(),
+            None,
+            crate::daemon::EnginePolicy::External,
+        );
+        for worker in [None, Some("state".to_string())] {
+            let error = dispatch(
+                Arc::clone(&daemon),
+                Operation::Update,
+                "update".to_string(),
+                ComposeRequest {
+                    workers: Some(Vec::new()),
+                    worker,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+            assert!(matches!(error, Error::Remote { code, .. } if code == "INVALID_WORKER_SPEC"));
+        }
+    }
+
     fn schema_entry(id: &str) -> &'static SchemaTriple {
         schema_table()
             .iter()
@@ -1089,7 +1177,7 @@ mod tests {
     }
 
     #[test]
-    fn batch_worker_schemas_require_one_non_null_non_empty_worker_form() {
+    fn batch_worker_schemas_validate_explicit_worker_forms() {
         for function_id in ["compose::add", "compose::update", "compose::remove"] {
             let schema = schema_entry(function_id).1.as_ref().unwrap();
             let validator = jsonschema::Validator::new(schema)
@@ -1110,7 +1198,6 @@ mod tests {
             }
 
             for invalid in [
-                json!({}),
                 json!({ "workers": [] }),
                 json!({ "workers": null }),
                 json!({ "worker": null }),
@@ -1123,6 +1210,21 @@ mod tests {
                 assert!(
                     !validator.is_valid(&invalid),
                     "{function_id} should reject {invalid}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn only_update_allows_omitting_both_worker_fields() {
+        for function_id in ["compose::add", "compose::update", "compose::remove"] {
+            let schema = schema_entry(function_id).1.as_ref().unwrap();
+            let validator = jsonschema::Validator::new(schema).unwrap();
+            for payload in [json!({}), json!({"file": "worker-compose.yaml"})] {
+                assert_eq!(
+                    validator.is_valid(&payload),
+                    function_id == "compose::update",
+                    "{function_id}: {payload}"
                 );
             }
         }
@@ -1148,6 +1250,10 @@ mod tests {
             }
             assert!(!properties.contains_key("container"));
             assert_eq!(properties["workers"]["minItems"], 1);
+            if function_id == "compose::update" {
+                assert!(request.as_ref().unwrap().get("anyOf").is_none());
+                continue;
+            }
             let alternatives = request.as_ref().unwrap()["anyOf"]
                 .as_array()
                 .unwrap_or_else(|| panic!("{function_id} should require either request form"));

--- a/crates/iii-compose/tests/project_cache.rs
+++ b/crates/iii-compose/tests/project_cache.rs
@@ -390,6 +390,49 @@ async fn update_rejects_an_engine_change_before_editing_the_file() {
 }
 
 #[tokio::test]
+async fn update_without_workers_is_unchanged_when_only_path_workers_are_declared() {
+    let tmp = project_dir();
+    let file = tmp.path().join("worker-compose.yaml");
+    std::fs::write(&file, COMPOSE).unwrap();
+    let daemon = daemon();
+
+    let outcome = daemon
+        .update(Some(&file), &[], "update-all-path-workers".to_string())
+        .await
+        .expect("a project with no package workers has nothing to update");
+
+    assert_eq!(
+        serde_json::to_value(outcome).unwrap(),
+        serde_json::json!({"status": "ok", "changed": false})
+    );
+    assert_eq!(std::fs::read_to_string(file).unwrap(), COMPOSE);
+    assert!(
+        daemon.list().await.is_empty(),
+        "no project should be started"
+    );
+}
+
+#[tokio::test]
+async fn update_without_workers_rejects_an_engine_change_before_editing() {
+    let containers =
+        "  state:\n    worker: package://api.workers.iii.dev/state\n    version: '1.0.0'\n";
+    let (_tmp, file, daemon) = managed_mutation_fixture(containers);
+    let changed = change_managed_engine(&file, containers);
+
+    let err = daemon
+        .update(
+            Some(&file),
+            &[],
+            "update-all-after-engine-change".to_string(),
+        )
+        .await
+        .expect_err("update all must reject the changed managed engine");
+
+    assert_eq!(err.code(), "ENGINE_RESTART_REQUIRED");
+    assert_eq!(std::fs::read_to_string(file).unwrap(), changed);
+}
+
+#[tokio::test]
 async fn update_accepts_multiple_unchanged_package_workers() {
     let containers = concat!(
         "  state:\n    worker: package://api.workers.iii.dev/state\n    version: '1.0.0'\n",

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -290,17 +290,27 @@ approximately the equivalent of `compose::down` followed by `compose::up`.
 | `file`   | The project to restart. |
 | `worker` | The worker to restart.  |
 
-### Updating a worker
+### Updating workers
+
+`compose::update` without `worker` or `workers` updates every declared `package://` worker to its
+registry's latest version. It keeps each worker's registry reference and skips `path://` workers.
+
+```bash
+iii trigger compose::update
+iii trigger compose::update file=worker-compose.yaml
+```
 
 `compose::update worker=state` updates a worker to either the current `latest` version when no
 version is specified or to the target version when it is.
 
-If the requested version is already installed this operation is treated as a NOOP.
+If all selected workers already use the requested versions, the operation leaves the file and
+running processes unchanged. A project with only `path://` workers also stays unchanged.
 
-| Field    | Description                                |
-| -------- | ------------------------------------------ |
-| `file`   | The project to edit.                       |
-| `worker` | The worker spec: `name` or `name@version`. |
+| Field     | Description                                                   |
+| --------- | ------------------------------------------------------------- |
+| `file`    | The project to edit.                                          |
+| `worker`  | Optional worker spec: `name` or `name@version`.                 |
+| `workers` | Optional non-empty list of specs. Takes precedence over `worker`. |
 
 ```text
 worker=state            the version the registry calls latest
@@ -313,7 +323,7 @@ The worker has to be declared already in order to be updated, and it has to be a
 Workers specified with `path://` are not versioned, any updates to these workers will be reflected
 the next time the worker is restarted.
 
-<Note>Unlike `compose::restart worker=state`, an update restarts the whole project.</Note>
+<Note>When versions change, an update restarts the whole project once.</Note>
 
 ### Checking status
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -284,17 +284,27 @@ approximately the equivalent of `compose::down` followed by `compose::up`.
 | `file`   | The project to restart. |
 | `worker` | The worker to restart.  |
 
-### Updating a worker
+### Updating workers
+
+`compose::update` without `worker` or `workers` updates every declared `package://` worker to its
+registry's latest version. It keeps each worker's registry reference and skips `path://` workers.
+
+```bash
+iii trigger compose::update
+iii trigger compose::update file=worker-compose.yaml
+```
 
 `compose::update worker=state` updates a worker to either the current `latest` version when no
 version is specified or to the target version when it is.
 
-If the requested version is already installed this operation is treated as a NOOP.
+If all selected workers already use the requested versions, the operation leaves the file and
+running processes unchanged. A project with only `path://` workers also stays unchanged.
 
-| Field    | Description                                |
-| -------- | ------------------------------------------ |
-| `file`   | The project to edit.                       |
-| `worker` | The worker spec: `name` or `name@version`. |
+| Field     | Description                                                   |
+| --------- | ------------------------------------------------------------- |
+| `file`    | The project to edit.                                          |
+| `worker`  | Optional worker spec: `name` or `name@version`.                 |
+| `workers` | Optional non-empty list of specs. Takes precedence over `worker`. |
 
 ```text
 worker=state            the version the registry calls latest
@@ -307,7 +317,7 @@ The worker has to be declared already in order to be updated, and it has to be a
 Workers specified with `path://` are not versioned, any updates to these workers will be reflected
 the next time the worker is restarted.
 
-<Note>Unlike `compose::restart worker=state`, an update restarts the whole project.</Note>
+<Note>When versions change, an update restarts the whole project once.</Note>
 
 ### Checking status
 

--- a/docs/using-iii/compose.mdx
+++ b/docs/using-iii/compose.mdx
@@ -290,17 +290,27 @@ approximately the equivalent of `compose::down` followed by `compose::up`.
 | `file`   | The project to restart. |
 | `worker` | The worker to restart.  |
 
-### Updating a worker
+### Updating workers
+
+`compose::update` without `worker` or `workers` updates every declared `package://` worker to its
+registry's latest version. It keeps each worker's registry reference and skips `path://` workers.
+
+```bash
+iii trigger compose::update
+iii trigger compose::update file=worker-compose.yaml
+```
 
 `compose::update worker=state` updates a worker to either the current `latest` version when no
 version is specified or to the target version when it is.
 
-If the requested version is already installed this operation is treated as a NOOP.
+If all selected workers already use the requested versions, the operation leaves the file and
+running processes unchanged. A project with only `path://` workers also stays unchanged.
 
-| Field    | Description                                |
-| -------- | ------------------------------------------ |
-| `file`   | The project to edit.                       |
-| `worker` | The worker spec: `name` or `name@version`. |
+| Field     | Description                                                   |
+| --------- | ------------------------------------------------------------- |
+| `file`    | The project to edit.                                          |
+| `worker`  | Optional worker spec: `name` or `name@version`.                 |
+| `workers` | Optional non-empty list of specs. Takes precedence over `worker`. |
 
 ```text
 worker=state            the version the registry calls latest
@@ -313,7 +323,7 @@ The worker has to be declared already in order to be updated, and it has to be a
 Workers specified with `path://` are not versioned, any updates to these workers will be reflected
 the next time the worker is restarted.
 
-<Note>Unlike `compose::restart worker=state`, an update restarts the whole project.</Note>
+<Note>When versions change, an update restarts the whole project once.</Note>
 
 ### Checking status
 

--- a/docs/using-iii/compose.mdx.skill.md
+++ b/docs/using-iii/compose.mdx.skill.md
@@ -284,17 +284,27 @@ approximately the equivalent of `compose::down` followed by `compose::up`.
 | `file`   | The project to restart. |
 | `worker` | The worker to restart.  |
 
-### Updating a worker
+### Updating workers
+
+`compose::update` without `worker` or `workers` updates every declared `package://` worker to its
+registry's latest version. It keeps each worker's registry reference and skips `path://` workers.
+
+```bash
+iii trigger compose::update
+iii trigger compose::update file=worker-compose.yaml
+```
 
 `compose::update worker=state` updates a worker to either the current `latest` version when no
 version is specified or to the target version when it is.
 
-If the requested version is already installed this operation is treated as a NOOP.
+If all selected workers already use the requested versions, the operation leaves the file and
+running processes unchanged. A project with only `path://` workers also stays unchanged.
 
-| Field    | Description                                |
-| -------- | ------------------------------------------ |
-| `file`   | The project to edit.                       |
-| `worker` | The worker spec: `name` or `name@version`. |
+| Field     | Description                                                   |
+| --------- | ------------------------------------------------------------- |
+| `file`    | The project to edit.                                          |
+| `worker`  | Optional worker spec: `name` or `name@version`.                 |
+| `workers` | Optional non-empty list of specs. Takes precedence over `worker`. |
 
 ```text
 worker=state            the version the registry calls latest
@@ -307,7 +317,7 @@ The worker has to be declared already in order to be updated, and it has to be a
 Workers specified with `path://` are not versioned, any updates to these workers will be reflected
 the next time the worker is restarted.
 
-<Note>Unlike `compose::restart worker=state`, an update restarts the whole project.</Note>
+<Note>When versions change, an update restarts the whole project once.</Note>
 
 ### Checking status
 


### PR DESCRIPTION
`compose::update` now updates every declared package worker when neither `worker` nor `workers` is supplied. It uses each package's existing registry reference, skips local path workers, and restarts the project once if versions change. Existing targeted updates remain supported, and explicit empty lists remain invalid.

The request schema and Compose documentation describe the new default. Regression tests cover automatic selection, custom registries and container aliases, targeted versions, projects with only local workers, managed engine validation, and operation tracking.

Validation:
- `cargo fmt --all -- --check`
- `cargo test -p iii-compose --locked` (338 tests passed)
- `cargo clippy -p iii-compose --all-targets --all-features --locked -- -D warnings`
- `cargo build -p iii-compose --locked`
- Documentation structure, Vale, and generated artifact checks passed in a container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `compose::update` now updates all declared package workers to their latest registry versions when no worker is specified.
  - Added support for selecting multiple workers; this takes precedence over a single-worker selection.
  - Path-based workers are skipped during update-all operations.

- **Bug Fixes**
  - Projects with no applicable updates now remain unchanged without restarting processes.
  - Improved validation and safeguards for engine changes during updates.

- **Documentation**
  - Updated compose guidance to describe worker selection, unchanged projects, and restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->