### PR TITLE
feat(compose): show engine and container startup progress

### DIFF
--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -395,6 +395,10 @@ async fn serve(
     // each child itself.
     let shutdown = shutdown::ShutdownSignal::install()?;
 
+    let mut start_project = start.then(|| InitialProject {
+        file,
+        progress: report::StartupProgress::start(matches!(engine_mode, EngineMode::Managed { .. })),
+    });
     let managed_engine = match engine_mode {
         EngineMode::Managed { .. } => {
             let Some(owner) = initial_file.as_ref() else {
@@ -404,31 +408,43 @@ async fn serve(
                 unreachable!("managed mode is selected only from an engine section");
             };
             let engine = managed_engine::ManagedEngine::start(spec, &daemon_namespace).await?;
-            println!("engine {}", "started".green());
-            println!("  {} {}", "pid:".dimmed(), engine.pid());
-            println!("  {} {}", "owner:".dimmed(), owner.path.display());
-            println!(
+            if let Some(project) = &start_project {
+                project.progress.engine_waiting();
+            }
+            report::line(&format!("  {} {}", "pid:".dimmed(), engine.pid()));
+            report::line(&format!("  {} {}", "owner:".dimmed(), owner.path.display()));
+            report::line(&format!(
                 "  {} {}",
                 "config:".dimmed(),
                 engine.config_path().display()
-            );
-            println!("  {} {}", "logs:".dimmed(), engine.log_path().display());
-            println!("  {} {}", "follow logs:".dimmed(), engine.follow_command());
-            println!();
+            ));
+            report::line(&format!(
+                "  {} {}",
+                "logs:".dimmed(),
+                engine.log_path().display()
+            ));
+            report::line(&format!(
+                "  {} {}",
+                "follow logs:".dimmed(),
+                engine.follow_command()
+            ));
+            report::line("");
             Some(engine)
         }
         EngineMode::External { .. } => None,
     };
 
     let result = if shutdown.requested() {
+        if let Some(project) = &mut start_project {
+            project.progress.finish(false, "Cancelled");
+        }
         Ok(())
     } else {
-        let start_file = start.then_some(file);
         serve_daemon(
             engine_url,
             daemon_namespace,
             explicit_daemon_namespace,
-            start_file,
+            start_project,
             managed_engine.as_ref(),
             engine_policy,
             shutdown,
@@ -437,7 +453,7 @@ async fn serve(
     };
 
     if let Some(engine) = &managed_engine {
-        println!("{}", "stopping engine...".dimmed());
+        report::line(&"stopping engine...".dimmed().to_string());
         engine.stop_with_default_grace().await;
     }
 
@@ -485,11 +501,16 @@ fn load_invocation_file(file: &std::path::Path, required: bool) -> Result<Option
     }
 }
 
+struct InitialProject {
+    file: std::path::PathBuf,
+    progress: report::StartupProgress,
+}
+
 async fn serve_daemon(
     engine_url: String,
     daemon_namespace: String,
     project_namespace_override: Option<String>,
-    start: Option<std::path::PathBuf>,
+    mut start: Option<InitialProject>,
     managed_engine: Option<&managed_engine::ManagedEngine>,
     engine_policy: daemon::EnginePolicy,
     shutdown: shutdown::ShutdownSignal,
@@ -535,6 +556,9 @@ async fn serve_daemon(
         let mut interrupted = shutdown.clone();
         tokio::select! {
             _ = interrupted.wait() => {
+                if let Some(project) = &mut start {
+                    project.progress.finish(false, "Cancelled");
+                }
                 daemon.shutdown().await;
                 return Ok(());
             }
@@ -545,6 +569,9 @@ async fn serve_daemon(
     if let Some(engine) = managed_engine
         && !daemon.engine().is_connected()
     {
+        if let Some(project) = &mut start {
+            project.progress.finish(false, "Connection timed out");
+        }
         daemon.shutdown().await;
         return Err(ComposeError::EngineReadinessTimeout {
             engine_url: daemon.engine_url.clone(),
@@ -553,9 +580,18 @@ async fn serve_daemon(
         });
     }
 
-    println!("compose {}", "serving".green());
-    println!("  {} {}", "engine:".dimmed(), daemon.engine_url);
-    println!("  {} {}", "namespace:".dimmed(), daemon.daemon_namespace);
+    if daemon.engine().is_connected()
+        && let Some(project) = &start
+    {
+        project.progress.engine_ready();
+    }
+    report::line(&format!("compose {}", "serving".green()));
+    report::line(&format!("  {} {}", "engine:".dimmed(), daemon.engine_url));
+    report::line(&format!(
+        "  {} {}",
+        "namespace:".dimmed(),
+        daemon.daemon_namespace
+    ));
     // Printed with this daemon's own address already in it. Several daemons
     // can share an engine, and which one a call reaches is a flag an operator
     // should not have to work out.
@@ -563,11 +599,11 @@ async fn serve_daemon(
     // Not printed when a project was named: the operator already started one,
     // and the line would be telling them to do what they just did.
     if start.is_none() {
-        println!(
+        report::line(&format!(
             "  {} iii trigger compose::up --namespace {} file=./worker-compose.yaml",
             "start a project:".dimmed(),
             daemon.daemon_namespace
-        );
+        ));
     }
 
     let startup_operation = if start.is_some() {
@@ -581,17 +617,37 @@ async fn serve_daemon(
 
     // A failed initial project still ends the command. Cancellation rolls its
     // partial startup back but leaves the daemon available for later calls.
-    if let (Some(file), Some(operation)) = (&start, startup_operation) {
-        println!();
+    if let (Some(project), Some(operation)) = (&mut start, startup_operation) {
+        let file = &project.file;
+        report::line("");
+        project.progress.containers_starting();
         let operation_id = operation.id().to_string();
         let startup_shutdown = shutdown.clone().or(shutdown::ShutdownSignal::from_receiver(
             operation.cancellation(),
         ));
-        let result = daemon
-            .up_until_shutdown(Some(file), None, operation_id, startup_shutdown)
-            .await;
+        let up = daemon.up_until_shutdown(Some(file), None, operation_id, startup_shutdown);
+        tokio::pin!(up);
+        let mut connected = daemon.engine().is_connected();
+        if connected {
+            project.progress.engine_ready();
+        }
+        let result = loop {
+            tokio::select! {
+                result = &mut up => break result,
+                _ = tokio::time::sleep(std::time::Duration::from_millis(100)), if !connected => {
+                    connected = daemon.engine().is_connected();
+                    if connected {
+                        project.progress.engine_ready();
+                    }
+                }
+            }
+        };
+        if daemon.engine().is_connected() {
+            project.progress.engine_ready();
+        }
         match result {
             Ok(None) => {
+                project.progress.finish(false, "Cancelled");
                 operation
                     .finish(
                         operation::OperationStatus::Cancelled,
@@ -609,6 +665,7 @@ async fn serve_daemon(
                 println!("{}", "startup cancelled; daemon remains available".dimmed());
             }
             Ok(Some(result)) if result.status == lifecycle::OpStatus::Failed => {
+                project.progress.finish(false, "Failed");
                 let error = ComposeError::ProjectDidNotStart { path: file.clone() };
                 operation
                     .finish(operation::OperationStatus::Failed, error.to_string())
@@ -617,6 +674,7 @@ async fn serve_daemon(
                 return Err(error);
             }
             Ok(Some(_)) => {
+                project.progress.finish(true, "Ready");
                 operation
                     .finish(
                         operation::OperationStatus::Succeeded,
@@ -625,6 +683,7 @@ async fn serve_daemon(
                     .await;
             }
             Err(err) => {
+                project.progress.finish(false, "Failed");
                 operation
                     .finish(operation::OperationStatus::Failed, err.to_string())
                     .await;

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -704,6 +704,7 @@ async fn start_one_until_shutdown(
         crate::config::WorkerSource::Path { .. } => (resolve_start(key, container)?, None),
     };
 
+    report::starting(key, "configuring");
     if let Some(operation) = operation_id.and_then(crate::operation::active) {
         operation
             .emit(Some(key), "configuring", "resolving configuration")
@@ -735,6 +736,7 @@ async fn start_one_until_shutdown(
     };
 
     if let Some(script) = &container.scripts.pre_run {
+        report::starting(key, "running pre-run hook");
         let Some(result) = hooks::await_pre_run_until_shutdown(
             &spawn_ctx,
             script,
@@ -759,6 +761,7 @@ async fn start_one_until_shutdown(
         // back is an ordinary child, so readiness, stop, crash cascade and log
         // capture below are unchanged.
         None => {
+            report::starting(key, "preparing VM runtime");
             if let Some(operation) = operation_id.and_then(crate::operation::active) {
                 operation
                     .emit(Some(key), "preparing", "preparing VM runtime")
@@ -782,6 +785,7 @@ async fn start_one_until_shutdown(
             container: key.to_string(),
             message: err.to_string(),
         })?;
+    report::starting(key, "waiting for engine registration");
     if let Some(operation) = operation_id.and_then(crate::operation::active) {
         operation
             .emit(Some(key), "registering", "waiting for engine registration")

--- a/crates/iii-compose/src/report.rs
+++ b/crates/iii-compose/src/report.rs
@@ -32,7 +32,7 @@
 use std::{
     io::{IsTerminal, Write},
     sync::{Mutex, OnceLock},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use colored::{Color, Colorize};
@@ -60,6 +60,7 @@ const CLEAR_LINE: &str = "\r\x1b[2K";
 /// "where is all of it" — which is a block that is redrawn, not a line that is
 /// replaced.
 struct Console {
+    startup: Option<StartupRows>,
     rows: Vec<Row>,
     /// How many lines the block occupies on screen, so the next draw knows how
     /// far up to go. Zero when nothing is drawn.
@@ -79,20 +80,192 @@ struct Row {
 enum RowState {
     /// Declared, and waiting on something earlier in the graph.
     Waiting,
-    Starting,
+    Starting {
+        what: String,
+        began: Instant,
+    },
     Ready {
         what: String,
         elapsed: Duration,
     },
     Failed,
+    Error {
+        what: String,
+        elapsed: Duration,
+    },
     /// Already running, or otherwise not this operation's to start.
     Skipped(String),
+}
+
+struct StartupRows {
+    engine: Row,
+    containers: Row,
+}
+
+/// Owns the foreground startup panel. Early returns must leave a final status,
+/// never an animated row above an error.
+pub(crate) struct StartupProgress {
+    finished: bool,
+}
+
+impl StartupProgress {
+    pub(crate) fn start(managed: bool) -> Self {
+        let mut state = console().lock().unwrap_or_else(|p| p.into_inner());
+        state.startup = Some(StartupRows::new(managed));
+        if animated() {
+            redraw(&mut state);
+            ensure_ticker();
+        } else if let Some(startup) = &state.startup {
+            eprintln!("{}", render_row(&startup.engine, 0, false));
+            eprintln!("{}", render_row(&startup.containers, 0, false));
+        }
+        Self { finished: false }
+    }
+
+    pub(crate) fn engine_waiting(&self) {
+        self.update_engine("Waiting for connection", false);
+    }
+
+    pub(crate) fn engine_ready(&self) {
+        self.update_engine("Ready", true);
+    }
+
+    fn update_engine(&self, message: &str, ready: bool) {
+        let mut state = console().lock().unwrap_or_else(|p| p.into_inner());
+        let Some(startup) = &mut state.startup else {
+            return;
+        };
+        let RowState::Starting { what, began } = &mut startup.engine.state else {
+            return;
+        };
+        if ready {
+            startup.engine.state = RowState::Ready {
+                what: message.to_string(),
+                elapsed: began.elapsed(),
+            };
+        } else {
+            *what = message.to_string();
+        }
+        if animated() {
+            redraw(&mut state);
+        } else {
+            eprintln!("{}", render_row(&startup.engine, 0, false));
+        }
+    }
+
+    pub(crate) fn containers_starting(&self) {
+        let mut state = console().lock().unwrap_or_else(|p| p.into_inner());
+        let Some(startup) = &mut state.startup else {
+            return;
+        };
+        startup.containers.state = RowState::Starting {
+            what: "Starting".to_string(),
+            began: Instant::now(),
+        };
+        if animated() {
+            redraw(&mut state);
+        } else {
+            eprintln!("{}", render_row(&startup.containers, 0, false));
+        }
+    }
+
+    pub(crate) fn finish(&mut self, success: bool, message: &str) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        let mut state = console().lock().unwrap_or_else(|p| p.into_inner());
+        let Some(startup) = &mut state.startup else {
+            return;
+        };
+        startup.finish(success, message);
+        // Pending/active child rows cannot keep spinning after a failed or
+        // cancelled operation.
+        for row in &mut state.rows {
+            match row.state {
+                RowState::Waiting => row.state = RowState::Skipped("Not started".to_string()),
+                RowState::Starting { .. } => row.state = RowState::Skipped("Cancelled".to_string()),
+                _ => {}
+            }
+        }
+        if animated() {
+            redraw(&mut state);
+        } else if let Some(startup) = &state.startup {
+            if !matches!(startup.engine.state, RowState::Ready { .. }) {
+                eprintln!("{}", render_row(&startup.engine, 0, false));
+            }
+            eprintln!("{}", render_row(&startup.containers, 0, false));
+        }
+        state.startup = None;
+        state.rows.clear();
+        state.drawn = 0;
+    }
+}
+
+impl Drop for StartupProgress {
+    fn drop(&mut self) {
+        self.finish(false, "Failed");
+    }
+}
+
+impl StartupRows {
+    fn new(managed: bool) -> Self {
+        Self {
+            engine: Row {
+                key: "Engine".to_string(),
+                depth: 0,
+                state: RowState::Starting {
+                    what: if managed { "Starting" } else { "Connecting" }.to_string(),
+                    began: Instant::now(),
+                },
+            },
+            containers: Row {
+                key: "Containers".to_string(),
+                depth: 0,
+                state: RowState::Waiting,
+            },
+        }
+    }
+
+    fn finish(&mut self, success: bool, message: &str) {
+        let row = if matches!(self.containers.state, RowState::Waiting)
+            && !matches!(self.engine.state, RowState::Ready { .. })
+        {
+            self.containers.state = RowState::Skipped("Not started".to_string());
+            &mut self.engine
+        } else {
+            // An empty project can finish even while an external engine is
+            // unavailable. Completing that project does not prove connection.
+            if matches!(self.engine.state, RowState::Starting { .. }) {
+                self.engine.state = RowState::Skipped("Not connected".to_string());
+            }
+            &mut self.containers
+        };
+        let elapsed = match &row.state {
+            RowState::Starting { began, .. } => began.elapsed(),
+            _ => Duration::ZERO,
+        };
+        row.state = if success {
+            RowState::Ready {
+                what: message.to_string(),
+                elapsed,
+            }
+        } else if message == "Cancelled" {
+            RowState::Skipped(message.to_string())
+        } else {
+            RowState::Error {
+                what: message.to_string(),
+                elapsed,
+            }
+        };
+    }
 }
 
 fn console() -> &'static Mutex<Console> {
     static CONSOLE: OnceLock<Mutex<Console>> = OnceLock::new();
     CONSOLE.get_or_init(|| {
         Mutex::new(Console {
+            startup: None,
             rows: Vec::new(),
             drawn: 0,
             frame: 0,
@@ -122,7 +295,10 @@ pub fn plan(rows: &[(String, usize)]) {
                 state: RowState::Waiting,
             })
             .collect();
-        state.drawn = 0;
+        // The engine panel already owns the block above these new child rows.
+        if state.startup.is_none() {
+            state.drawn = 0;
+        }
         state.frame = 0;
         redraw(&mut state);
     }
@@ -135,8 +311,10 @@ pub fn plan_done() {
     let mut state = console
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    state.rows.clear();
-    state.drawn = 0;
+    if state.startup.is_none() {
+        state.rows.clear();
+        state.drawn = 0;
+    }
 }
 
 fn set(key: &str, to: RowState) -> bool {
@@ -148,6 +326,20 @@ fn set(key: &str, to: RowState) -> bool {
         return false;
     };
     row.state = to;
+    let ready = state
+        .rows
+        .iter()
+        .filter(|row| {
+            matches!(row.state, RowState::Ready { .. })
+                || matches!(&row.state, RowState::Skipped(why) if why == "already running")
+        })
+        .count();
+    let total = state.rows.len();
+    if let Some(startup) = &mut state.startup
+        && let RowState::Starting { what, .. } = &mut startup.containers.state
+    {
+        *what = format!("Starting ({ready}/{total})");
+    }
     redraw(&mut state);
     true
 }
@@ -158,25 +350,44 @@ fn redraw(state: &mut Console) {
     if state.drawn > 0 {
         out.push_str(&format!("\x1b[{}A", state.drawn));
     }
-    for row in &state.rows {
+    let headers = state
+        .startup
+        .iter()
+        .flat_map(|startup| [&startup.engine, &startup.containers])
+        .map(|row| (row, ""));
+    let indent = if state.startup.is_some() { "  " } else { "" };
+    for (row, prefix) in headers.chain(state.rows.iter().map(|row| (row, indent))) {
         out.push_str(CLEAR_LINE);
-        out.push_str(&render_row(row, state.frame));
+        out.push_str(prefix);
+        out.push_str(&render_row(row, state.frame, true));
         out.push('\n');
     }
-    state.drawn = state.rows.len();
+    state.drawn = state.rows.len() + if state.startup.is_some() { 2 } else { 0 };
     let mut stderr = std::io::stderr().lock();
     let _ = write!(stderr, "{out}");
     let _ = stderr.flush();
 }
 
-fn render_row(row: &Row, frame: usize) -> String {
+fn render_row(row: &Row, frame: usize, animate: bool) -> String {
     let indent = "  ".repeat(row.depth);
     match &row.state {
-        RowState::Waiting => format!("{indent}{} {}", SKIPPED.dimmed(), row.key.dimmed()),
-        RowState::Starting => format!(
-            "{indent}{} {}",
-            FRAMES[frame % FRAMES.len()].cyan(),
-            row.key.bold()
+        RowState::Waiting => format!(
+            "{indent}{} {} {}",
+            SKIPPED.dimmed(),
+            row.key.dimmed(),
+            "Pending".dimmed()
+        ),
+        RowState::Starting { what, began } => format!(
+            "{indent}{} {} {} {}",
+            if animate {
+                FRAMES[frame % FRAMES.len()]
+            } else {
+                RUNNING
+            }
+            .cyan(),
+            row.key.bold(),
+            what.dimmed(),
+            format!("({})", format_elapsed(began.elapsed())).dimmed(),
         ),
         RowState::Ready { what, elapsed } => format!(
             "{indent}{} {} {} {}",
@@ -186,6 +397,13 @@ fn render_row(row: &Row, frame: usize) -> String {
             format!("({})", format_elapsed(*elapsed)).dimmed()
         ),
         RowState::Failed => format!("{indent}{} {}", FAILED.red(), row.key.bold().red()),
+        RowState::Error { what, elapsed } => format!(
+            "{indent}{} {} {} {}",
+            FAILED.red(),
+            row.key.bold(),
+            what.red(),
+            format!("({})", format_elapsed(*elapsed)).dimmed(),
+        ),
         RowState::Skipped(why) => format!(
             "{indent}{} {} {}",
             SKIPPED.dimmed(),
@@ -195,7 +413,7 @@ fn render_row(row: &Row, frame: usize) -> String {
     }
 }
 
-/// Whether progress can animate./// Whether progress can animate. A pipe or a file gets static lines.
+/// Whether progress can animate. A pipe or a file gets static lines.
 fn animated() -> bool {
     static ANIMATED: OnceLock<bool> = OnceLock::new();
     *ANIMATED.get_or_init(|| std::io::stderr().is_terminal())
@@ -257,10 +475,11 @@ fn ensure_ticker() {
                 let mut state = console
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
-                let turning = state
-                    .rows
-                    .iter()
-                    .any(|row| matches!(row.state, RowState::Starting));
+                let turning = state.startup.is_some()
+                    || state
+                        .rows
+                        .iter()
+                        .any(|row| matches!(row.state, RowState::Starting { .. }));
                 if turning {
                     state.frame = state.frame.wrapping_add(1);
                     redraw(&mut state);
@@ -273,7 +492,24 @@ fn ensure_ticker() {
 /// A container is being worked on. On a terminal this spins until the container
 /// settles; anywhere else it is a plain line.
 pub fn starting(key: &str, what: &str) {
-    if set(key, RowState::Starting) {
+    let began = {
+        let state = console().lock().unwrap_or_else(|p| p.into_inner());
+        state
+            .rows
+            .iter()
+            .find_map(|row| match &row.state {
+                RowState::Starting { began, .. } if row.key == key => Some(*began),
+                _ => None,
+            })
+            .unwrap_or_else(Instant::now)
+    };
+    if set(
+        key,
+        RowState::Starting {
+            what: what.to_string(),
+            began,
+        },
+    ) {
         return;
     }
     line(&format!(
@@ -344,6 +580,7 @@ pub fn stopped(key: &str) {
 
 /// Undone by a rollback. Amber, not red: nothing went wrong with this one.
 pub fn rolled_back(key: &str) {
+    set(key, RowState::Skipped("rolled back".to_string()));
     line(&format!(
         "{} {} {}",
         SKIPPED.yellow(),
@@ -461,6 +698,99 @@ fn pick_color(taken: &[Color], last: Option<Color>) -> Color {
 mod tests {
     use super::*;
 
+    #[test]
+    fn engine_failure_leaves_containers_not_started() {
+        let mut startup = StartupRows::new(true);
+        startup.finish(false, "Connection timed out");
+        assert!(matches!(startup.engine.state, RowState::Error { .. }));
+        assert!(
+            matches!(&startup.containers.state, RowState::Skipped(why) if why == "Not started")
+        );
+    }
+
+    #[test]
+    fn container_failure_preserves_confirmed_engine_readiness() {
+        let mut startup = StartupRows::new(true);
+        startup.engine.state = RowState::Ready {
+            what: "Ready".to_string(),
+            elapsed: Duration::from_secs(6),
+        };
+        startup.containers.state = RowState::Starting {
+            what: "Starting (1/3)".to_string(),
+            began: Instant::now(),
+        };
+        startup.finish(false, "Failed");
+        assert!(matches!(startup.engine.state, RowState::Ready { .. }));
+        assert!(matches!(startup.containers.state, RowState::Error { .. }));
+    }
+
+    #[test]
+    fn empty_project_does_not_claim_an_unconnected_engine_is_ready() {
+        let mut startup = StartupRows::new(false);
+        startup.containers.state = RowState::Starting {
+            what: "Starting".to_string(),
+            began: Instant::now(),
+        };
+        startup.finish(true, "Ready");
+        assert!(matches!(&startup.engine.state, RowState::Skipped(why) if why == "Not connected"));
+        assert!(matches!(startup.containers.state, RowState::Ready { .. }));
+    }
+
+    #[test]
+    fn redirected_startup_reports_transitions_without_animation() {
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--ignored",
+                "--exact",
+                "report::tests::startup_panel_fixture",
+                "--nocapture",
+            ])
+            .env("NO_COLOR", "1")
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{output:?}");
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        let starting = stderr.find("Engine Starting").unwrap();
+        let waiting = stderr.find("Engine Waiting for connection").unwrap();
+        let ready = stderr.find("Engine Ready").unwrap();
+        let containers = stderr.find("Containers Starting").unwrap();
+        let done = stderr.find("Containers Ready").unwrap();
+        assert!(
+            starting < waiting && waiting < ready && ready < containers && containers < done,
+            "{stderr}"
+        );
+        assert!(
+            !stderr.contains('\x1b') && !FRAMES.iter().any(|frame| stderr.contains(frame)),
+            "{stderr}"
+        );
+    }
+
+    /// Also usable under a PTY to inspect redraws without starting real workers.
+    #[tokio::test]
+    #[ignore = "subprocess fixture for the progress renderer"]
+    async fn startup_panel_fixture() {
+        let mut progress = StartupProgress::start(true);
+        progress.engine_waiting();
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        progress.engine_ready();
+        line("compose serving");
+        progress.containers_starting();
+        plan(&[("api".to_string(), 0), ("redis".to_string(), 1)]);
+        starting("redis", "waiting for engine registration");
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        ready("redis", Duration::from_millis(250));
+        starting("api", "installing package");
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        starting("api", "waiting for engine registration");
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        ready("api", Duration::from_millis(500));
+        plan_done();
+        progress.finish(true, "Ready");
+        // The finished panel must not be redrawn over subsequent output.
+        line("after startup");
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+
     /// A container keeps its colour once it has one, and red is never handed
     /// out — in this output red means a failure.
     #[test]
@@ -533,9 +863,12 @@ mod tests {
         let row = Row {
             key: "api".to_string(),
             depth: 0,
-            state: RowState::Starting,
+            state: RowState::Starting {
+                what: "starting".to_string(),
+                began: Instant::now(),
+            },
         };
-        assert!(!render_row(&row, usize::MAX).is_empty());
+        assert!(!render_row(&row, usize::MAX, true).is_empty());
     }
 
     /// Depth is what makes the block a graph rather than a list, and it is
@@ -558,8 +891,8 @@ mod tests {
                 elapsed: Duration::from_millis(10),
             },
         };
-        let drawn_parent = render_row(&parent, 0);
-        let drawn_child = render_row(&child, 0);
+        let drawn_parent = render_row(&parent, 0, true);
+        let drawn_child = render_row(&child, 0, true);
         assert!(!drawn_parent.starts_with(' '), "{drawn_parent:?}");
         assert!(drawn_child.starts_with("  "), "{drawn_child:?}");
     }

--- a/crates/iii-compose/src/report.rs
+++ b/crates/iii-compose/src/report.rs
@@ -745,6 +745,7 @@ mod tests {
                 "report::tests::startup_panel_fixture",
                 "--nocapture",
             ])
+            .env_remove("CLICOLOR_FORCE")
             .env("NO_COLOR", "1")
             .output()
             .unwrap();

--- a/engine/tests/compose_managed_engine_e2e.rs
+++ b/engine/tests/compose_managed_engine_e2e.rs
@@ -135,8 +135,22 @@ fn compose_up_starts_logs_and_stops_the_engine_it_owns() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        terminal.contains("engine started"),
+        terminal.contains("Engine Ready"),
         "unexpected output:\n{terminal}"
+    );
+    let progress = String::from_utf8_lossy(&output.stderr);
+    let waiting = progress.find("Engine Waiting for connection").unwrap();
+    let ready = progress.find("Engine Ready").unwrap();
+    let containers = progress.find("Containers Starting").unwrap();
+    let failed = progress.find("Containers Failed").unwrap();
+    assert!(
+        waiting < ready && ready < containers && containers < failed,
+        "{progress}"
+    );
+    assert!(!progress.contains("Containers Ready"), "{progress}");
+    assert!(
+        !progress.contains('\x1b'),
+        "redirected output must not animate: {progress}"
     );
     assert!(
         terminal.contains(compose.to_str().unwrap()),
@@ -238,7 +252,8 @@ fn compose_without_engine_section_uses_and_preserves_an_external_engine() {
 
     assert!(!output.status.success(), "missing project worker must fail");
     assert!(terminal.contains("compose serving"), "{terminal}");
-    assert!(!terminal.contains("engine started"), "{terminal}");
+    assert!(terminal.contains("Engine Connecting"), "{terminal}");
+    assert!(!terminal.contains("Engine Starting"), "{terminal}");
     assert!(engine_survived, "Compose stopped the external engine");
     assert!(
         engine_reachable,
@@ -311,7 +326,8 @@ fn cli_engine_overrides_file_engine_and_preserves_the_external_engine() {
     assert!(!output.status.success(), "missing project worker must fail");
     assert!(terminal.contains("compose serving"), "{terminal}");
     assert!(terminal.contains("namespace: cli-namespace"), "{terminal}");
-    assert!(!terminal.contains("engine started"), "{terminal}");
+    assert!(terminal.contains("Engine Connecting"), "{terminal}");
+    assert!(!terminal.contains("Engine Starting"), "{terminal}");
     assert!(engine_survived, "Compose stopped the external engine");
     assert!(
         engine_reachable,
@@ -348,7 +364,9 @@ fn compose_up_rejects_an_occupied_managed_engine_listener() {
         terminal.contains("MANAGED_ENGINE_LISTENER_UNAVAILABLE"),
         "{terminal}"
     );
-    assert!(!terminal.contains("engine started"), "{terminal}");
+    assert!(terminal.contains("Engine Failed"), "{terminal}");
+    assert!(terminal.contains("Containers Not started"), "{terminal}");
+    assert!(!terminal.contains("Engine Ready"), "{terminal}");
 }
 
 #[cfg(unix)]
@@ -394,6 +412,9 @@ fn signal_during_managed_engine_startup_stops_the_engine() {
     let output = child.wait_with_output().unwrap();
 
     assert!(output.status.success(), "compose exited with {output:?}");
+    let progress = String::from_utf8_lossy(&output.stderr);
+    assert!(progress.contains("Cancelled"), "{progress}");
+    assert!(!progress.contains("Containers Ready"), "{progress}");
     assert!(
         !generated_config.exists(),
         "managed engine config survived shutdown"
@@ -608,6 +629,9 @@ fn ctrl_c_stops_the_worker_before_the_managed_engine() {
     let output = child.wait_with_output().unwrap();
     assert!(output.status.success(), "compose exited with {output:?}");
     assert!(stopped.exists(), "worker shutdown trap did not run");
+    let progress = String::from_utf8_lossy(&output.stderr);
+    assert!(progress.contains("Engine Ready"), "{progress}");
+    assert!(progress.contains("Containers Ready"), "{progress}");
 
     let terminal = format!(
         "{}{}",

--- a/engine/tests/compose_managed_engine_e2e.rs
+++ b/engine/tests/compose_managed_engine_e2e.rs
@@ -6,7 +6,9 @@ use std::{net::TcpListener, process::Command};
 use std::{process::Stdio, time::Duration, time::Instant};
 
 fn iii_bin() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_iii"))
+    let mut command = Command::new(env!("CARGO_BIN_EXE_iii"));
+    command.env_remove("CLICOLOR_FORCE").env("NO_COLOR", "1");
+    command
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## What

Show a live startup panel for `iii compose --up`, with separate Engine and Containers stages, elapsed time, and a ready-container count. Keep each container's current operation visible under the panel, including installation, configuration, hooks, VM preparation, and engine registration.

```text
✓ Engine Ready (6.0s)
⠋ Containers Starting (1/2) (5.0s)
  ⠋ api waiting for engine registration (3.0s)
    ✓ redis ready (2.0s)
```

## Why

The command printed `engine started` before confirming its connection and could then wait silently for up to 30 seconds. The panel now reports Engine Ready only after connection is confirmed. Failure and cancellation leave a final status, and redirected output uses static lines without animation.

## Notes

Validation:
- `cargo test -p iii-compose --locked`
- `SKIP_UI_BUILD=1 cargo test -p iii --test compose_managed_engine_e2e --test compose_process_title_e2e --locked`
- `cargo clippy -p iii-compose --all-targets --all-features --locked -- -D warnings`
- `cargo build -p iii-compose --locked`
- `cargo fmt --all -- --check`
- Terminal verification of animated frames, ready counts, and no redraw after completion.

Engine tests use the unchanged, committed observability UI assets. No config schema or protocol changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a startup progress display for engine and container initialization.
  - Progress now shows engine connection, readiness, container startup, and completion stages.
  - Container startup reports configuration, preparation, and engine registration stages.
  - Startup status covers successful launches, failures, cancellations, and timeouts.
  - Progress output adapts to redirected or non-interactive environments without animation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->