### PR TITLE
fix(compose): keep declared dependency pins on add, no Gone noise on restart, stop refuses a container

### DIFF
--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -487,6 +487,10 @@ impl Daemon {
         }
         let wanted = coalesce_containers(wanted)?;
         let asked_keys: BTreeSet<String> = asked.iter().map(|worker| worker.key.clone()).collect();
+        // Against the snapshot read above, so the registry artifacts acquired
+        // below are only the ones this add can actually declare. The decision
+        // that matters is repeated under the mutation lock against the text
+        // being edited: another add may declare a dependency in between.
         let mut wanted = keep_declared_dependencies(wanted, &asked_keys, &declared);
         for worker in &mut wanted {
             if let Some(declaration) = declarations.iter().find(|item| item.key == worker.key) {
@@ -559,6 +563,11 @@ impl Daemon {
             source,
         })?;
         self.validate_engine_policy_text(path, &text)?;
+        // The declaration this edit lands on, not the pre-lock snapshot: a
+        // dependency another add declared while this one resolved its graph
+        // and acquired artifacts must keep its pin too.
+        let current = ComposeFile::parse(&text, path.to_path_buf())?;
+        let wanted = keep_declared_dependencies(wanted, &asked_keys, &current);
         let mut edited = text.clone();
         let mut added: Vec<String> = Vec::new();
         let mut replaced: Vec<String> = Vec::new();
@@ -1306,7 +1315,10 @@ fn open_private_temp(path: &Path) -> std::io::Result<std::fs::File> {
 /// `compose::update worker=<dep>` is how a version moves. Only nodes that are
 /// NOT yet declared are added, plus whatever the caller explicitly asked for.
 /// A declared dependency whose pin differs from what the registry resolved is
-/// logged, never silently rewritten.
+/// logged, never silently rewritten. `add_configured` runs this twice: once on
+/// its pre-lock snapshot to size the artifact fetch, and again under the
+/// mutation lock against the text it is about to edit, which is the call that
+/// decides what gets written.
 fn keep_declared_dependencies(
     wanted: Vec<crate::edit::NewContainer>,
     asked: &BTreeSet<String>,

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -485,7 +485,9 @@ impl Daemon {
         for (_, graph) in expanded {
             wanted.extend(graph?);
         }
-        let mut wanted = coalesce_containers(wanted)?;
+        let wanted = coalesce_containers(wanted)?;
+        let asked_keys: BTreeSet<String> = asked.iter().map(|worker| worker.key.clone()).collect();
+        let mut wanted = keep_declared_dependencies(wanted, &asked_keys, &declared);
         for worker in &mut wanted {
             if let Some(declaration) = declarations.iter().find(|item| item.key == worker.key) {
                 worker.fields = declaration.fields.clone();
@@ -1293,6 +1295,54 @@ fn open_private_temp(path: &Path) -> std::io::Result<std::fs::File> {
     options.open(path)
 }
 
+/// Drop graph-expanded dependencies the compose file already declares.
+///
+/// `compose::add worker=X` resolves X's whole dependency graph, and every node
+/// used to come back as a fresh declaration — including ones the operator had
+/// already pinned. `upsert_container` then rewrote them: adding
+/// `provider-openai-codex` to the Linkly scaffold moved `state: package://state
+/// version: "0.22.8"` to `package://api.workers.iii.dev/state` `"0.22.9"`
+/// without anyone asking (MOT-4723). A pin the operator wrote stays theirs;
+/// `compose::update worker=<dep>` is how a version moves. Only nodes that are
+/// NOT yet declared are added, plus whatever the caller explicitly asked for.
+/// A declared dependency whose pin differs from what the registry resolved is
+/// logged, never silently rewritten.
+fn keep_declared_dependencies(
+    wanted: Vec<crate::edit::NewContainer>,
+    asked: &BTreeSet<String>,
+    declared: &ComposeFile,
+) -> Vec<crate::edit::NewContainer> {
+    wanted
+        .into_iter()
+        .filter(|worker| {
+            if asked.contains(&worker.key) {
+                return true;
+            }
+            let Some(existing) = declared.containers.get(&worker.key) else {
+                return true;
+            };
+            if let crate::edit::Source::Package {
+                version: Some(resolved),
+                ..
+            } = &worker.source
+                && existing.version.as_deref() != Some(resolved.as_str())
+            {
+                crate::report::daemon_line(
+                    &format!(
+                        "{}: kept the declared version {} (the registry resolved {resolved} for this \
+                         add); run compose::update worker={} to move it",
+                        worker.key,
+                        existing.version.as_deref().unwrap_or("unpinned"),
+                        worker.key
+                    ),
+                    true,
+                );
+            }
+            false
+        })
+        .collect()
+}
+
 /// Turns one registry answer into the declarations Compose can own.
 ///
 /// Engine-kind dependencies are omitted because the engine already provides
@@ -1978,5 +2028,67 @@ mod mutation_outcome_tests {
         for internal in ["operation_id", "containers", "queue", "retry secret output"] {
             assert!(!encoded.contains(internal), "leaked {internal}: {encoded}");
         }
+    }
+}
+
+#[cfg(test)]
+mod declared_dependency_tests {
+    use std::collections::BTreeSet;
+
+    use super::keep_declared_dependencies;
+    use crate::edit::{NewContainer, Source};
+
+    fn resolved(name: &str, version: &str) -> NewContainer {
+        NewContainer {
+            key: name.to_string(),
+            source: Source::Package {
+                reference: format!("api.workers.iii.dev/{name}"),
+                version: Some(version.to_string()),
+            },
+            start_after: Vec::new(),
+            fields: serde_yaml::Mapping::new(),
+        }
+    }
+
+    /// Prevents: `compose::add worker=provider-openai-codex` rewriting the
+    /// operator's `state: package://state version: "0.22.8"` to the registry's
+    /// latest (MOT-4723). Declared dependencies stay as declared; only the
+    /// asked worker and genuinely new dependencies are written.
+    #[test]
+    fn an_add_leaves_already_declared_dependencies_alone() {
+        let declared = crate::ComposeFile::parse(
+            "namespace: default\ncontainers:\n  state:\n    worker: package://state\n    version: \"0.22.8\"\n  http:\n    worker: package://http\n    version: \"0.21.9\"\n",
+            "/tmp/worker-compose.yaml",
+        )
+        .unwrap();
+        let asked: BTreeSet<String> = ["provider-openai-codex".to_string()].into();
+        let wanted = vec![
+            resolved("state", "0.22.9"),
+            resolved("llm-router", "1.4.19"),
+            resolved("provider-openai-codex", "0.4.9"),
+        ];
+
+        let kept = keep_declared_dependencies(wanted, &asked, &declared);
+        let keys: Vec<&str> = kept.iter().map(|worker| worker.key.as_str()).collect();
+
+        assert_eq!(keys, vec!["llm-router", "provider-openai-codex"]);
+    }
+
+    #[test]
+    fn an_explicitly_asked_worker_is_always_written_even_when_declared() {
+        let declared = crate::ComposeFile::parse(
+            "namespace: default\ncontainers:\n  state:\n    worker: package://state\n    version: \"0.22.8\"\n",
+            "/tmp/worker-compose.yaml",
+        )
+        .unwrap();
+        let asked: BTreeSet<String> = ["state".to_string()].into();
+
+        let kept = keep_declared_dependencies(vec![resolved("state", "0.22.9")], &asked, &declared);
+
+        assert_eq!(
+            kept.len(),
+            1,
+            "compose::add worker=state is the operator moving the pin on purpose"
+        );
     }
 }

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -449,13 +449,10 @@ impl Daemon {
         let declarations = coalesce_containers(asked.clone())?;
         let asked_keys: BTreeSet<String> = asked.iter().map(|worker| worker.key.clone()).collect();
         let operation = crate::operation::active(&operation_id);
-        // The plan is made against a snapshot, unlocked. If the file moved
-        // underneath — another add declared a dependency of this graph as
-        // `path://`, whose own dependencies this plan would now write below an
-        // operator-owned boundary — the plan is stale, so it is redone against
-        // the fresh text; the artifact cache makes the second pass cheap. Only
-        // the file the plan was made against is ever edited: past the replan
-        // limit the add fails instead, and the caller retries.
+        // The plan is made against a snapshot, unlocked. Only the file it was
+        // made against is ever edited: a file that moved underneath (another
+        // add declaring one of this graph's dependencies as `path://`, say)
+        // is planned again, and past the limit the add fails for a retry.
         let mut replans = 0;
         let (_mutation, text, wanted) = loop {
             let (snapshot, wanted) = self
@@ -1357,17 +1354,11 @@ fn open_private_temp(path: &Path) -> std::io::Result<std::fs::File> {
 
 /// Drop graph-expanded dependencies the compose file already declares.
 ///
-/// `compose::add worker=X` resolves X's whole dependency graph, and every node
-/// used to come back as a fresh declaration — including ones the operator had
-/// already pinned. `upsert_container` then rewrote them: adding
-/// `provider-openai-codex` to the Linkly scaffold moved `state: package://state
-/// version: "0.22.8"` to `package://api.workers.iii.dev/state` `"0.22.9"`
-/// without anyone asking (MOT-4723). A pin the operator wrote stays theirs;
-/// `compose::update worker=<dep>` is how a version moves. Only nodes that are
-/// NOT yet declared are added, plus whatever the caller explicitly asked for.
-/// A declared dependency whose pin differs from what the registry resolved is
-/// logged, never silently rewritten. `add_configured` applies this to the
-/// snapshot it plans against, and only ever edits that same text.
+/// `compose::add worker=X` resolves X's whole dependency graph. Only nodes not
+/// yet declared are added, plus what the caller explicitly asked for: a pin the
+/// operator wrote stays theirs, and `compose::update worker=<dep>` is how a
+/// version moves. A declared dependency whose pin differs from what the
+/// registry resolved is logged, never rewritten.
 fn keep_declared_dependencies(
     wanted: Vec<crate::edit::NewContainer>,
     asked: &BTreeSet<String>,
@@ -2111,10 +2102,6 @@ mod declared_dependency_tests {
         }
     }
 
-    /// Prevents: `compose::add worker=provider-openai-codex` rewriting the
-    /// operator's `state: package://state version: "0.22.8"` to the registry's
-    /// latest (MOT-4723). Declared dependencies stay as declared; only the
-    /// asked worker and genuinely new dependencies are written.
     #[test]
     fn an_add_leaves_already_declared_dependencies_alone() {
         let declared = crate::ComposeFile::parse(

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -40,6 +40,10 @@ use crate::{
 /// Fast enough that a crash is reported while the operator is still watching,
 /// slow enough that an idle daemon costs nothing.
 const SUPERVISION_INTERVAL: Duration = Duration::from_millis(250);
+/// How many times `add_configured` redoes its unlocked plan because the file
+/// changed before it took the mutation lock. Beyond this it edits anyway,
+/// keeping declared pins; a file that busy is an operator problem, not a loop.
+const ADD_REPLAN_LIMIT: u32 = 2;
 
 #[derive(Debug, Clone)]
 pub enum EnginePolicy {
@@ -438,134 +442,52 @@ impl Daemon {
 
         let path = self.resolve_file(file)?;
         self.validate_engine_policy_file(path)?;
-        let declared = ComposeFile::load(path)?;
-        let mut path_workers: BTreeSet<String> = declared
-            .containers
-            .iter()
-            .filter(|(_, container)| {
-                matches!(&container.worker, crate::config::WorkerSource::Path { .. })
-            })
-            .map(|(key, _)| key.clone())
-            .collect();
         let asked = workers
             .iter()
             .map(crate::edit::WorkerInput::parse)
             .collect::<Result<Vec<_>>>()?;
         let declarations = coalesce_containers(asked.clone())?;
-        path_workers.extend(
-            declarations
-                .iter()
-                .filter(|worker| matches!(worker.source, crate::edit::Source::Path { .. }))
-                .map(|worker| worker.key.clone()),
-        );
-        // A worker is not useful alone: its manifest names what it calls, and
-        // the registry answers with that whole graph already pinned to versions
-        // that satisfy each other. They are declared rather than started
-        // behind the file, so what runs is still what the file says.
-        //
-        // Dependencies first and the worker last: with no `start_after`, start
-        // order is declaration order, so this is what makes a worker start
-        // after the things it calls.
-        let path_workers = &path_workers;
-        let mut expanded = futures::stream::iter(asked.clone().into_iter().enumerate().map(
-            |(index, mut worker)| async move {
-                // Coalesce registry graphs before applying explicit settings.
-                // A requested worker can also be another worker's dependency.
-                worker.fields.clear();
-                worker.start_after.clear();
-                let graph = self.expand(&worker, path_workers).await;
-                (index, graph)
-            },
-        ))
-        .buffer_unordered(4)
-        .collect::<Vec<_>>()
-        .await;
-        expanded.sort_by_key(|(index, _)| *index);
-        let mut wanted = Vec::new();
-        for (_, graph) in expanded {
-            wanted.extend(graph?);
-        }
-        let wanted = coalesce_containers(wanted)?;
         let asked_keys: BTreeSet<String> = asked.iter().map(|worker| worker.key.clone()).collect();
-        // Against the snapshot read above, so the registry artifacts acquired
-        // below are only the ones this add can actually declare. The decision
-        // that matters is repeated under the mutation lock against the text
-        // being edited: another add may declare a dependency in between.
-        let mut wanted = keep_declared_dependencies(wanted, &asked_keys, &declared);
-        for worker in &mut wanted {
-            if let Some(declaration) = declarations.iter().find(|item| item.key == worker.key) {
-                worker.fields = declaration.fields.clone();
-                worker
-                    .start_after
-                    .extend(declaration.start_after.iter().cloned());
-                worker.start_after.sort();
-                worker.start_after.dedup();
-            }
-        }
-
-        // Acquire registry artifacts before taking either the file mutation lock
-        // or the project's runtime lock. `lifecycle::start_one` calls install
-        // again, but that second call is a cheap verified cache hit.
-        let package_cache = crate::state::StateStore::package_cache()?;
         let operation = crate::operation::active(&operation_id);
-        let installs: Vec<(String, String, String)> = wanted
-            .iter()
-            .filter_map(|worker| match &worker.source {
-                crate::edit::Source::Package {
-                    reference,
-                    version: Some(version),
-                } => Some((worker.key.clone(), reference.clone(), version.clone())),
-                _ => None,
-            })
-            .collect();
-        let acquired: Vec<Result<()>> =
-            futures::stream::iter(installs.into_iter().map(|(key, reference, version)| {
-                let package_cache = package_cache.clone();
-                let operation = operation.clone();
-                async move {
-                    if let Some(operation) = operation {
-                        operation
-                            .emit(
-                                Some(&key),
-                                "installing",
-                                format!("acquiring {reference}@{version}"),
-                            )
-                            .await;
-                    }
-                    crate::registry::install(&key, &reference, &version, &package_cache)
-                        .await
-                        .map(|_| ())
-                }
-            }))
-            .buffer_unordered(4)
-            .collect()
-            .await;
-        for result in acquired {
-            result?;
-        }
-
-        if operation
-            .as_ref()
-            .is_some_and(|operation| operation.is_cancelled())
-        {
-            return Err(ComposeError::OperationCancelled { operation_id });
-        }
-
-        let _mutation = self.lock_mutation(path).await;
-        if operation
-            .as_ref()
-            .is_some_and(|operation| operation.is_cancelled())
-        {
-            return Err(ComposeError::OperationCancelled { operation_id });
-        }
-        let text = std::fs::read_to_string(path).map_err(|source| ComposeError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        // The plan is made against a snapshot, unlocked. If the file moved
+        // underneath — another add declared a dependency of this graph as
+        // `path://`, whose own dependencies this plan would now write below an
+        // operator-owned boundary — the plan is stale, so it is redone against
+        // the fresh text; the artifact cache makes the second pass cheap.
+        // Bounded: a file that keeps changing falls through to the declared-
+        // dependency filter below, which still keeps every existing pin.
+        let mut replans = 0;
+        let (_mutation, text, wanted) = loop {
+            let (snapshot, wanted) = self
+                .plan_add(path, &asked, &declarations, &asked_keys, &operation_id)
+                .await?;
+            let mutation = self.lock_mutation(path).await;
+            if operation
+                .as_ref()
+                .is_some_and(|operation| operation.is_cancelled())
+            {
+                return Err(ComposeError::OperationCancelled { operation_id });
+            }
+            let text = std::fs::read_to_string(path).map_err(|source| ComposeError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+            if text == snapshot || replans == ADD_REPLAN_LIMIT {
+                break (mutation, text, wanted);
+            }
+            replans += 1;
+            crate::report::daemon_line(
+                &format!(
+                    "{}: changed while this add resolved its graph; planning again",
+                    path.display()
+                ),
+                true,
+            );
+        };
         self.validate_engine_policy_text(path, &text)?;
-        // The declaration this edit lands on, not the pre-lock snapshot: a
-        // dependency another add declared while this one resolved its graph
-        // and acquired artifacts must keep its pin too.
+        // Against the declaration this edit lands on, not the snapshot: after
+        // the replan limit the two may still differ, and a dependency another
+        // add declared meanwhile must keep its pin.
         let current = ComposeFile::parse(&text, path.to_path_buf())?;
         let wanted = keep_declared_dependencies(wanted, &asked_keys, &current);
         let mut edited = text.clone();
@@ -652,6 +574,133 @@ impl Daemon {
             version,
             operations,
         ))
+    }
+
+    /// Everything `add_configured` does before it takes the mutation lock:
+    /// expand the asked workers into their registry graphs against the
+    /// declaration as it stands, keep the pins the operator already wrote, and
+    /// acquire the artifacts. Slow (registry calls), so it runs unlocked.
+    /// Returns the text the plan was made against with the plan, so the caller
+    /// can tell whether that declaration is still the one it is editing.
+    async fn plan_add(
+        &self,
+        path: &Path,
+        asked: &[crate::edit::NewContainer],
+        declarations: &[crate::edit::NewContainer],
+        asked_keys: &BTreeSet<String>,
+        operation_id: &str,
+    ) -> Result<(String, Vec<crate::edit::NewContainer>)> {
+        let snapshot = std::fs::read_to_string(path).map_err(|source| ComposeError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let declared = ComposeFile::parse(&snapshot, path.to_path_buf())?;
+        let mut path_workers: BTreeSet<String> = declared
+            .containers
+            .iter()
+            .filter(|(_, container)| {
+                matches!(&container.worker, crate::config::WorkerSource::Path { .. })
+            })
+            .map(|(key, _)| key.clone())
+            .collect();
+        path_workers.extend(
+            declarations
+                .iter()
+                .filter(|worker| matches!(worker.source, crate::edit::Source::Path { .. }))
+                .map(|worker| worker.key.clone()),
+        );
+        // A worker is not useful alone: its manifest names what it calls, and
+        // the registry answers with that whole graph already pinned to versions
+        // that satisfy each other. They are declared rather than started
+        // behind the file, so what runs is still what the file says.
+        //
+        // Dependencies first and the worker last: with no `start_after`, start
+        // order is declaration order, so this is what makes a worker start
+        // after the things it calls.
+        let path_workers = &path_workers;
+        let mut expanded = futures::stream::iter(asked.iter().cloned().enumerate().map(
+            |(index, mut worker)| async move {
+                // Coalesce registry graphs before applying explicit settings.
+                // A requested worker can also be another worker's dependency.
+                worker.fields.clear();
+                worker.start_after.clear();
+                let graph = self.expand(&worker, path_workers).await;
+                (index, graph)
+            },
+        ))
+        .buffer_unordered(4)
+        .collect::<Vec<_>>()
+        .await;
+        expanded.sort_by_key(|(index, _)| *index);
+        let mut wanted = Vec::new();
+        for (_, graph) in expanded {
+            wanted.extend(graph?);
+        }
+        let wanted = coalesce_containers(wanted)?;
+        // Against the snapshot read above, so the registry artifacts acquired
+        // below are only the ones this add can actually declare.
+        let mut wanted = keep_declared_dependencies(wanted, asked_keys, &declared);
+        for worker in &mut wanted {
+            if let Some(declaration) = declarations.iter().find(|item| item.key == worker.key) {
+                worker.fields = declaration.fields.clone();
+                worker
+                    .start_after
+                    .extend(declaration.start_after.iter().cloned());
+                worker.start_after.sort();
+                worker.start_after.dedup();
+            }
+        }
+
+        // Acquire registry artifacts before taking either the file mutation lock
+        // or the project's runtime lock. `lifecycle::start_one` calls install
+        // again, but that second call is a cheap verified cache hit.
+        let package_cache = crate::state::StateStore::package_cache()?;
+        let operation = crate::operation::active(operation_id);
+        let installs: Vec<(String, String, String)> = wanted
+            .iter()
+            .filter_map(|worker| match &worker.source {
+                crate::edit::Source::Package {
+                    reference,
+                    version: Some(version),
+                } => Some((worker.key.clone(), reference.clone(), version.clone())),
+                _ => None,
+            })
+            .collect();
+        let acquired: Vec<Result<()>> =
+            futures::stream::iter(installs.into_iter().map(|(key, reference, version)| {
+                let package_cache = package_cache.clone();
+                let operation = operation.clone();
+                async move {
+                    if let Some(operation) = operation {
+                        operation
+                            .emit(
+                                Some(&key),
+                                "installing",
+                                format!("acquiring {reference}@{version}"),
+                            )
+                            .await;
+                    }
+                    crate::registry::install(&key, &reference, &version, &package_cache)
+                        .await
+                        .map(|_| ())
+                }
+            }))
+            .buffer_unordered(4)
+            .collect()
+            .await;
+        for result in acquired {
+            result?;
+        }
+
+        if operation
+            .as_ref()
+            .is_some_and(|operation| operation.is_cancelled())
+        {
+            return Err(ComposeError::OperationCancelled {
+                operation_id: operation_id.to_string(),
+            });
+        }
+        Ok((snapshot, wanted))
     }
 
     /// The worker asked for, plus everything it needs, in start order.

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -41,8 +41,8 @@ use crate::{
 /// slow enough that an idle daemon costs nothing.
 const SUPERVISION_INTERVAL: Duration = Duration::from_millis(250);
 /// How many times `add_configured` redoes its unlocked plan because the file
-/// changed before it took the mutation lock. Beyond this it edits anyway,
-/// keeping declared pins; a file that busy is an operator problem, not a loop.
+/// changed before it took the mutation lock. Beyond this it fails with
+/// `AddPlanStale` rather than edit from a plan made against another file.
 const ADD_REPLAN_LIMIT: u32 = 2;
 
 #[derive(Debug, Clone)]
@@ -453,9 +453,9 @@ impl Daemon {
         // underneath — another add declared a dependency of this graph as
         // `path://`, whose own dependencies this plan would now write below an
         // operator-owned boundary — the plan is stale, so it is redone against
-        // the fresh text; the artifact cache makes the second pass cheap.
-        // Bounded: a file that keeps changing falls through to the declared-
-        // dependency filter below, which still keeps every existing pin.
+        // the fresh text; the artifact cache makes the second pass cheap. Only
+        // the file the plan was made against is ever edited: past the replan
+        // limit the add fails instead, and the caller retries.
         let mut replans = 0;
         let (_mutation, text, wanted) = loop {
             let (snapshot, wanted) = self
@@ -472,8 +472,14 @@ impl Daemon {
                 path: path.to_path_buf(),
                 source,
             })?;
-            if text == snapshot || replans == ADD_REPLAN_LIMIT {
+            if text == snapshot {
                 break (mutation, text, wanted);
+            }
+            if replans == ADD_REPLAN_LIMIT {
+                return Err(ComposeError::AddPlanStale {
+                    path: path.to_path_buf(),
+                    replans,
+                });
             }
             replans += 1;
             crate::report::daemon_line(
@@ -485,11 +491,6 @@ impl Daemon {
             );
         };
         self.validate_engine_policy_text(path, &text)?;
-        // Against the declaration this edit lands on, not the snapshot: after
-        // the replan limit the two may still differ, and a dependency another
-        // add declared meanwhile must keep its pin.
-        let current = ComposeFile::parse(&text, path.to_path_buf())?;
-        let wanted = keep_declared_dependencies(wanted, &asked_keys, &current);
         let mut edited = text.clone();
         let mut added: Vec<String> = Vec::new();
         let mut replaced: Vec<String> = Vec::new();
@@ -637,8 +638,9 @@ impl Daemon {
             wanted.extend(graph?);
         }
         let wanted = coalesce_containers(wanted)?;
-        // Against the snapshot read above, so the registry artifacts acquired
-        // below are only the ones this add can actually declare.
+        // Against the snapshot read above, which is also the text the caller
+        // edits, so the registry artifacts acquired below are only the ones
+        // this add actually declares.
         let mut wanted = keep_declared_dependencies(wanted, asked_keys, &declared);
         for worker in &mut wanted {
             if let Some(declaration) = declarations.iter().find(|item| item.key == worker.key) {
@@ -1364,10 +1366,8 @@ fn open_private_temp(path: &Path) -> std::io::Result<std::fs::File> {
 /// `compose::update worker=<dep>` is how a version moves. Only nodes that are
 /// NOT yet declared are added, plus whatever the caller explicitly asked for.
 /// A declared dependency whose pin differs from what the registry resolved is
-/// logged, never silently rewritten. `add_configured` runs this twice: once on
-/// its pre-lock snapshot to size the artifact fetch, and again under the
-/// mutation lock against the text it is about to edit, which is the call that
-/// decides what gets written.
+/// logged, never silently rewritten. `add_configured` applies this to the
+/// snapshot it plans against, and only ever edits that same text.
 fn keep_declared_dependencies(
     wanted: Vec<crate::edit::NewContainer>,
     asked: &BTreeSet<String>,

--- a/crates/iii-compose/src/error.rs
+++ b/crates/iii-compose/src/error.rs
@@ -446,6 +446,15 @@ pub enum ComposeError {
     #[error("operation cancelled")]
     OperationCancelled { operation_id: String },
 
+    /// `compose::add` plans (graph expansion, artifact acquisition) against a
+    /// snapshot of the file, unlocked, and only edits the file it planned
+    /// against. A file that keeps changing underneath is not edited from a
+    /// stale plan; the caller retries.
+    #[error(
+        "{path} changed {replans} times while compose::add was resolving its graph; nothing was          written. Retry the add."
+    )]
+    AddPlanStale { path: PathBuf, replans: u32 },
+
     /// A relative `file=` that missed. The path is resolved by the daemon, in
     /// the directory the daemon was started in — which is rarely the directory
     /// the caller is standing in, and never obvious from the caller's side.
@@ -569,6 +578,7 @@ impl ComposeError {
             Self::InvalidState { .. } => "INVALID_STATE_FILE",
             Self::UnknownProject { .. } => "UNKNOWN_PROJECT",
             Self::OperationCancelled { .. } => "OPERATION_CANCELLED",
+            Self::AddPlanStale { .. } => "ADD_PLAN_STALE",
             Self::RelativeFileMissing { .. } => "COMPOSE_FILE_UNREADABLE",
             Self::DaemonAlreadyServing { .. } => "DAEMON_ALREADY_SERVING",
             Self::DaemonNamespaceTaken { .. } => "DAEMON_NAMESPACE_TAKEN",

--- a/crates/iii-compose/src/error.rs
+++ b/crates/iii-compose/src/error.rs
@@ -80,6 +80,14 @@ pub enum ComposeError {
     #[error("container '{container}' depends on itself")]
     SelfDependency { container: String },
 
+    #[error(
+        "compose::stop stops every project this daemon holds and exits; it takes no container. \
+         '{container}' was ignored by earlier versions and the whole project went down with the \
+         engine. Use compose::down container={container} to stop one container, or \
+         compose::stop with no target to stop the daemon."
+    )]
+    StopTakesNoContainer { container: String },
+
     #[error("dependency cycle: {path}")]
     DependencyCycle { path: String },
 
@@ -511,6 +519,7 @@ impl ComposeError {
             Self::EngineAlreadyOwned { .. } => "ENGINE_ALREADY_OWNED",
             Self::UnknownDependency { .. } => "UNKNOWN_DEPENDENCY",
             Self::SelfDependency { .. } => "SELF_DEPENDENCY",
+            Self::StopTakesNoContainer { .. } => "STOP_TAKES_NO_CONTAINER",
             Self::DependencyCycle { .. } => "DEPENDENCY_CYCLE",
             Self::UnsupportedWorkerSource { .. } => "UNSUPPORTED_WORKER_SOURCE",
             Self::RunNotAllowedForPackage { .. } => "RUN_NOT_ALLOWED_FOR_PACKAGE",

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -317,6 +317,9 @@ impl Project {
                         }
                     }
                 },
+                // Stopped by this daemon and recorded as such: the expected
+                // state after `down`, not an anomaly worth a line.
+                Reconciliation::Stopped => {}
                 Reconciliation::Gone => {
                     daemon_line(
                         &self.project_namespace,

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -590,10 +590,8 @@ async fn dispatch(
             Err(err) => Err(compose_error(&err)),
         },
         // Answers first, exits after: the serve loop picks the request up and
-        // runs the same teardown a signal would. A target on this call is a
-        // mistake worth refusing: `compose::stop container=harness` used to
-        // ignore the field and take the whole project — and its managed
-        // engine — down (MOT-4723).
+        // runs the same teardown a signal would. Stop takes the whole daemon
+        // down, so a request that names a container is refused, not ignored.
         Operation::Stop => match stop_target(&request) {
             Some(container) => Err(compose_error(&ComposeError::StopTakesNoContainer {
                 container: container.to_string(),

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -325,6 +325,17 @@ impl Operation {
     }
 }
 
+/// The container a `compose::stop` request names, if any. Both fields are
+/// checked in turn: a blank `container` must not hide a `worker`, or
+/// `{"container": " ", "worker": "api"}` would stop the whole daemon.
+fn stop_target(request: &ComposeRequest) -> Option<&str> {
+    [request.container.as_deref(), request.worker.as_deref()]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+}
+
 /// Canonical list of functions exposed by the compose daemon.
 const REGISTERED_OPERATIONS: &[(&str, Operation)] = &[
     ("up", Operation::Up),
@@ -583,13 +594,11 @@ async fn dispatch(
         // mistake worth refusing: `compose::stop container=harness` used to
         // ignore the field and take the whole project — and its managed
         // engine — down (MOT-4723).
-        Operation::Stop => match request.container.as_deref().or(request.worker.as_deref()) {
-            Some(container) if !container.trim().is_empty() => {
-                Err(compose_error(&ComposeError::StopTakesNoContainer {
-                    container: container.to_string(),
-                }))
-            }
-            _ => Ok(daemon.request_stop().await),
+        Operation::Stop => match stop_target(&request) {
+            Some(container) => Err(compose_error(&ComposeError::StopTakesNoContainer {
+                container: container.to_string(),
+            })),
+            None => Ok(daemon.request_stop().await),
         },
         // Validation is a question about a file, so it holds nothing: naming a
         // file here must not leave the daemon owning a project, and must not
@@ -1097,6 +1106,36 @@ mod tests {
             .unwrap_err();
             assert!(matches!(error, Error::Remote { code, .. } if code == "INVALID_WORKER_SPEC"));
         }
+    }
+
+    #[test]
+    fn stop_target_checks_both_fields_and_ignores_blanks() {
+        let bare = ComposeRequest::default();
+        assert_eq!(stop_target(&bare), None);
+
+        let blank = ComposeRequest {
+            container: Some("   ".to_string()),
+            worker: Some("".to_string()),
+            ..ComposeRequest::default()
+        };
+        assert_eq!(stop_target(&blank), None, "blanks are no target");
+
+        let hidden = ComposeRequest {
+            container: Some(" ".to_string()),
+            worker: Some("api".to_string()),
+            ..ComposeRequest::default()
+        };
+        assert_eq!(
+            stop_target(&hidden),
+            Some("api"),
+            "a blank container must not hide the worker"
+        );
+
+        let container = ComposeRequest {
+            container: Some(" harness ".to_string()),
+            ..ComposeRequest::default()
+        };
+        assert_eq!(stop_target(&container), Some("harness"));
     }
 
     fn schema_entry(id: &str) -> &'static SchemaTriple {

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -579,8 +579,18 @@ async fn dispatch(
             Err(err) => Err(compose_error(&err)),
         },
         // Answers first, exits after: the serve loop picks the request up and
-        // runs the same teardown a signal would.
-        Operation::Stop => Ok(daemon.request_stop().await),
+        // runs the same teardown a signal would. A target on this call is a
+        // mistake worth refusing: `compose::stop container=harness` used to
+        // ignore the field and take the whole project — and its managed
+        // engine — down (MOT-4723).
+        Operation::Stop => match request.container.as_deref().or(request.worker.as_deref()) {
+            Some(container) if !container.trim().is_empty() => {
+                Err(compose_error(&ComposeError::StopTakesNoContainer {
+                    container: container.to_string(),
+                }))
+            }
+            _ => Ok(daemon.request_stop().await),
+        },
         // Validation is a question about a file, so it holds nothing: naming a
         // file here must not leave the daemon owning a project, and must not
         // write the durable state that would bind that id to it.

--- a/crates/iii-compose/src/state.rs
+++ b/crates/iii-compose/src/state.rs
@@ -150,11 +150,20 @@ pub enum Reconciliation {
     /// A live PID that is not provably the recorded process — a recycled PID, or
     /// a platform that cannot fingerprint. Never signalled; reported instead.
     Unverifiable,
+    /// This daemon stopped it on purpose and recorded that. Nothing to adopt,
+    /// nothing to mourn: `down` leaves the record behind, and a
+    /// `compose::restart` re-opens the project right after its own `down`, so
+    /// every container used to be reported as "exited while the daemon was
+    /// away" on every restart (Linkly e2e, MOT-4723).
+    Stopped,
 }
 
 /// Read-only: inspects the recorded child and returns what to do. Signals
 /// nothing, kills nothing.
 pub fn reconcile(record: &ChildRecord) -> Reconciliation {
+    if record.status == ChildStatus::Stopped {
+        return Reconciliation::Stopped;
+    }
     if !crate::process::is_running(record.pid) {
         return Reconciliation::Gone;
     }
@@ -307,4 +316,34 @@ fn now_unix() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|elapsed| elapsed.as_secs())
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod reconcile_tests {
+    use super::{ChildRecord, ChildStatus, Reconciliation, reconcile};
+    use crate::process::BirthIdentity;
+
+    /// Prevents: `compose::restart` (down → forget → up) reporting every
+    /// container as "exited while the daemon was away" — the records it just
+    /// stopped are Stopped on purpose, whatever their old pid is doing now.
+    #[test]
+    fn a_record_this_daemon_stopped_is_neither_gone_nor_adoptable() {
+        let dead = ChildRecord::new(
+            u32::MAX - 7,
+            BirthIdentity::Unavailable,
+            ChildStatus::Stopped,
+        );
+        assert_eq!(reconcile(&dead), Reconciliation::Stopped);
+        // A live, even verifiable-looking pid does not turn a deliberate stop
+        // back into an adoption.
+        let alive = ChildRecord::new(
+            std::process::id(),
+            BirthIdentity::Unavailable,
+            ChildStatus::Stopped,
+        );
+        assert_eq!(reconcile(&alive), Reconciliation::Stopped);
+        // Anything else still goes through the liveness check.
+        let failed = ChildRecord::new(u32::MAX - 7, BirthIdentity::Unavailable, ChildStatus::Ready);
+        assert_eq!(reconcile(&failed), Reconciliation::Gone);
+    }
 }

--- a/crates/iii-compose/src/state.rs
+++ b/crates/iii-compose/src/state.rs
@@ -150,11 +150,9 @@ pub enum Reconciliation {
     /// A live PID that is not provably the recorded process — a recycled PID, or
     /// a platform that cannot fingerprint. Never signalled; reported instead.
     Unverifiable,
-    /// This daemon stopped it on purpose and recorded that. Nothing to adopt,
-    /// nothing to mourn: `down` leaves the record behind, and a
-    /// `compose::restart` re-opens the project right after its own `down`, so
-    /// every container used to be reported as "exited while the daemon was
-    /// away" on every restart (Linkly e2e, MOT-4723).
+    /// This daemon stopped it on purpose and recorded that: nothing to adopt,
+    /// nothing to report. `down` leaves the record behind and `restart`
+    /// re-opens the project right after it.
     Stopped,
 }
 
@@ -323,9 +321,6 @@ mod reconcile_tests {
     use super::{ChildRecord, ChildStatus, Reconciliation, reconcile};
     use crate::process::BirthIdentity;
 
-    /// Prevents: `compose::restart` (down → forget → up) reporting every
-    /// container as "exited while the daemon was away" — the records it just
-    /// stopped are Stopped on purpose, whatever their old pid is doing now.
     #[test]
     fn a_record_this_daemon_stopped_is_neither_gone_nor_adoptable() {
         let dead = ChildRecord::new(


### PR DESCRIPTION
## Why

Three compose findings from the Linkly e2e run (Linear MOT-4723, parent MOT-4717):

1. **`compose::add` re-pinned an unrelated dependency.** The Linkly agentic scaffold declares `state: package://state version: "0.22.8"`. After `iii trigger compose::add worker=provider-openai-codex` the file read `package://api.workers.iii.dev/state version: "0.22.9"`. `expand_graph` returns every node of the resolved graph as a `NewContainer` and `upsert_container` rewrites whatever differs.
2. **`compose::restart` logs every container as gone.** `restart_project` is `down → forget → up`; `down` leaves the records as `Stopped`, `Project::open` reconciles them, and `state::reconcile` only checked pid liveness — so `[compose:default] <x> exited while the daemon was away` ×N on every restart.
3. **`compose::stop container=harness` stopped everything.** `ComposeRequest` is `#[serde(default)]` and `stop` never read `container`; the whole project and its managed engine went down while swapping one worker.

## What

- `keep_declared_dependencies` (daemon.rs) filters the expanded graph before the file edit: nodes already declared in the compose file are left untouched (worker line and version); the asked worker and genuinely new dependencies are still pinned and written. A declared pin that differs from the registry's resolution gets a `[compose]` warn line naming `compose::update worker=<dep>` as the way to move it. Unit tests cover both the kept dependency and the explicitly-asked declared worker.
- `Reconciliation::Stopped`: `reconcile` returns it for `ChildStatus::Stopped` records before probing the pid; `reconcile_recovered` treats it as the expected post-`down` state. Unit test.
- `compose::stop` with a `container`/`worker` is refused with `STOP_TAKES_NO_CONTAINER` (new `ComposeError` variant + code) pointing at `compose::down container=<key>`.

Deferred (tracked in MOT-4723 / MOT-4491): an `exclude` / protect-caller option for project-wide `restart`/`down`; the client-side guard landed in the harness (iii-hq/workers#1116).

## Verification

`cargo fmt`, `cargo clippy -p iii-compose --all-targets -D warnings`, `cargo test -p iii-compose` (all suites), `cargo test -p iii --test compose_daemon_e2e` (18 passed).

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer handling for deliberately stopped services during project recovery.
  - Compose updates now use a consistent file snapshot during planning and editing.

- **Bug Fixes**
  - `compose stop` now reports an error when given a container or worker target instead of stopping the entire project.
  - Blank or whitespace-only targets are handled correctly.
  - Updates now report an error when the compose file remains changed after allowed replanning attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->