### PR TITLE
(MOT-4724) fix(engine): keep read-only observability builtins in engine::functions::list

### DIFF
--- a/engine/src/workers/engine_fn/mod.rs
+++ b/engine/src/workers/engine_fn/mod.rs
@@ -76,6 +76,17 @@ pub struct CreateChannelOutput {
     pub reader: StreamChannelRef,
 }
 
+/// Read-only observability builtins that stay in the default
+/// `engine::functions::list` alongside `engine::queue::*`. The `*::clear`
+/// siblings and the rest of `engine::` remain `include_internal`-only.
+const DISCOVERABLE_ENGINE_FUNCTIONS: [&str; 5] = [
+    "engine::traces::list",
+    "engine::traces::spans",
+    "engine::traces::tree",
+    "engine::traces::group_by",
+    "engine::logs::list",
+];
+
 #[derive(Debug, Clone, Deserialize, Serialize, Default, JsonSchema)]
 pub struct FunctionsListInput {
     /// Case-insensitive substring matched against `function_id` and
@@ -1632,16 +1643,20 @@ impl EngineFunctionsWorker {
         if !input.include_internal.unwrap_or(false) {
             // Hide engine-internal builtins by default, EXCEPT the caller-facing
             // queue ops (`engine::queue::*`: list_topics / topic_stats /
-            // dlq_topics / dlq_messages). Those are a public queue/DLQ API a
-            // client legitimately needs to discover — keeping them out of the
-            // default list left agents unable to find the DLQ-inspection surface.
+            // dlq_topics / dlq_messages) and the read side of observability
+            // (`DISCOVERABLE_ENGINE_FUNCTIONS`). Those are public APIs a client
+            // legitimately needs to discover — keeping them out of the default
+            // list left agents unable to find the DLQ-inspection surface, and
+            // shelling out to the CLI to read traces `functions::info` would
+            // happily describe.
             // Also hide any handler explicitly tagged `metadata.internal == true`
             // (e.g. `iii-observability::on-config-change`,
             // `iii-http::on-config-change`). These are configuration-trigger
             // fan-out targets, invoked by id — never meant for discovery.
             functions.retain(|f| {
                 let is_engine_internal = f.function_id.starts_with("engine::")
-                    && !f.function_id.starts_with("engine::queue::");
+                    && !f.function_id.starts_with("engine::queue::")
+                    && !DISCOVERABLE_ENGINE_FUNCTIONS.contains(&f.function_id.as_str());
                 let is_tagged_internal = f
                     .metadata
                     .as_ref()
@@ -3325,6 +3340,52 @@ mod tests {
         match all {
             FunctionResult::Success(result) => {
                 assert_eq!(result.functions.len(), 2);
+            }
+            _ => panic!("expected functions_list success"),
+        }
+    }
+
+    #[tokio::test]
+    async fn functions_list_keeps_read_only_observability_discoverable() {
+        let (engine, module) = setup_engine_and_module();
+
+        for function_id in [
+            "engine::traces::list",
+            "engine::traces::tree",
+            "engine::logs::list",
+            "engine::traces::clear",
+            "engine::logs::clear",
+            "engine::functions::list",
+        ] {
+            register_simple_function(&engine, function_id, None);
+        }
+
+        let filtered = module
+            .functions_list(
+                FunctionsListInput {
+                    include_internal: None,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await;
+        match filtered {
+            FunctionResult::Success(result) => {
+                let mut ids: Vec<&str> = result
+                    .functions
+                    .iter()
+                    .map(|f| f.function_id.as_str())
+                    .collect();
+                ids.sort_unstable();
+                assert_eq!(
+                    ids,
+                    vec![
+                        "engine::logs::list",
+                        "engine::traces::list",
+                        "engine::traces::tree"
+                    ],
+                    "read side visible, clear + plumbing hidden"
+                );
             }
             _ => panic!("expected functions_list success"),
         }


### PR DESCRIPTION
## Why

`engine::functions::list` hides every `engine::*` id except `engine::queue::*` unless `include_internal: true`, while `engine::functions::info` describes `engine::traces::list` fine when asked by id. An agent that discovers through `list` (the harness does) cannot find the trace/log readers; in the Linkly agentic run (MOT-4717, A6) it shelled out to `iii trigger engine::traces::list` instead.

## What

- `DISCOVERABLE_ENGINE_FUNCTIONS` — `engine::traces::{list,spans,tree,group_by}`, `engine::logs::list` — stays in the default list next to `engine::queue::*`. `engine::traces::clear`, `engine::logs::clear` and the rest of `engine::` remain `include_internal`-only.
- Unit test `functions_list_keeps_read_only_observability_discoverable`.

## Not in this PR — `_caller_worker_id` (E10)

The engine stamps `_caller_worker_id` into every invoke payload (`engine/src/engine/mod.rs` `spawn_invoke_function`). Moving it to the metadata channel is a protocol change: `engine_fn` reads it for `register_trigger`/namespace attribution, and 20+ workers in `iii-hq/workers` (queue, llm-router, fp, a2ui, sandbox-code-runner, security-scan, …) either read it or carry explicit tolerance for it. Tracked on MOT-4724 as a follow-up with that inventory; the Linkly tutorial fix is to not forward a delivered payload verbatim into `stream::set`.

## Tests

`SKIP_UI_BUILD=1 cargo test -p iii --lib engine_fn::tests::functions_list` 7/7, `cargo test -p iii --test builtin_functions_e2e` 7/7. Clippy adds no warnings in the touched file.

Part of MOT-4717 · MOT-4724

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Read-only tracing and logging tools are now discoverable by default.
  * Queue-related tools remain discoverable, while clearing and other internal engine tools stay restricted.

* **Tests**
  * Added coverage confirming read-only observability tools are visible and clearing tools remain hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->