### PR TITLE
fix(python-sdk): allow bounded invocation messages above 1 MiB

### DIFF
--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -422,6 +422,7 @@ class III:
             self._ws = await websockets.connect(
                 self._address,
                 additional_headers=self._options.headers,
+                max_size=16 * 1024 * 1024,  # Bounded engine-message envelope, not library 1 MiB default.
             )
             log.info(f"Connected to {self._address}")
             await self._on_connected()

--- a/sdk/packages/python/iii/tests/test_websocket_receive_bound.py
+++ b/sdk/packages/python/iii/tests/test_websocket_receive_bound.py
@@ -1,0 +1,64 @@
+"""Real WebSocket receive-bound regressions for the Python SDK connection.
+
+These tests exercise _do_connect without registration or reconnection machinery.
+Full worker/Engine request-and-response qualification is separate evidence.
+"""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from websockets.asyncio.server import serve
+from websockets.exceptions import ConnectionClosedError
+
+from iii.iii import III
+
+
+class WebSocketReceiveBoundTests(unittest.IsolatedAsyncioTestCase):
+    async def connect(self, port):
+        client = object.__new__(III)
+        client._address = f"ws://127.0.0.1:{port}"
+        client._options = SimpleNamespace(headers=None)
+        client._running = False
+        client._on_connected = AsyncMock()
+        client._ws = None
+        await client._do_connect()
+        self.assertIsNotNone(client._ws)
+        client._on_connected.assert_awaited_once()
+        return client._ws
+
+    async def test_messages_larger_than_library_default_round_trip(self):
+        async def echo(ws):
+            async for message in ws:
+                await ws.send(message)
+
+        async with serve(echo, "127.0.0.1", 0, max_size=16 * 1024 * 1024) as server:
+            ws = await self.connect(server.sockets[0].getsockname()[1])
+            try:
+                for size in (1024 * 1024 + 1, 8_000_000):
+                    with self.subTest(bytes=size):
+                        message = "x" * size
+                        await ws.send(message)
+                        self.assertEqual(await asyncio.wait_for(ws.recv(), 5), message)
+            finally:
+                await ws.close()
+
+    async def test_receive_bound_remains_finite(self):
+        async def oversized(ws):
+            await ws.send("x" * (16 * 1024 * 1024 + 1))
+            await ws.wait_closed()
+
+        async with serve(oversized, "127.0.0.1", 0, compression=None) as server:
+            ws = await self.connect(server.sockets[0].getsockname()[1])
+            try:
+                with self.assertRaises(ConnectionClosedError) as caught:
+                    await asyncio.wait_for(ws.recv(), 5)
+                self.assertIsNotNone(caught.exception.sent)
+                self.assertEqual(caught.exception.sent.code, 1009)
+            finally:
+                await ws.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The Python SDK calls `websockets.connect` without `max_size`, inheriting the library's 1 MiB receive limit. Valid larger invocation inputs or results therefore close the worker transport before the handler can receive them. The caller can see only `invocation_stopped`, which obscures the actual limit.

## Fix

Set an explicit finite 16 MiB receive envelope on the SDK connection. This is an internal connection-default correction, not a new public SDK option or protocol/Engine change. Oversized messages remain rejected with WebSocket close code 1009. Add real-loopback WebSocket regressions for larger round trips and the finite bound.

## Evidence

- Unmodified current-main source: the new >1 MiB round-trip regression fails with close code 1009.
- Exact changed source: both regression tests pass, including 8,000,000-byte round-trip and rejection above 16 MiB.
- Separately, actual Engine 0.23.0 plus Python SDK 0.21.6 reproduced the dropped invocation before its handler. The same one-line connection fix passed full worker/Engine request-and-result round trips at ~1.06 MB and 8 MB.
- The current 0.23.0 SDK source was separately overlaid into that existing dependency environment and passed those native checks. This is source-level compatibility evidence, not a freshly installed whole 0.23.0 dependency-closure or production acceptance claim.
- Product checks ran in isolated, bounded Linux sandboxes. No Engine changes or broad monorepo build were made.

This PR intentionally leaves retries, invocation semantics, and public configuration unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum supported incoming WebSocket message size to 16 MB.
  * Messages exceeding this limit are now closed safely with the appropriate WebSocket error code.
  * Receive operations continue to enforce a finite timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->