### PR TITLE
(MOT-4728) fix(observability): bound the hot span cache and cap traced payloads

### DIFF
--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -34,6 +34,12 @@ type: "reference"
   - The Console adds observability configuration and live trace updates.
   - `engine::traces::list` now returns compact trace summaries. Use `engine::traces::spans` for full
     span details.
+  - The in-memory span cache is a hard-bounded FIFO: a burst of traced invocations can no longer
+    grow it without limit or stall the engine's WebSocket accept loop. Finalized spans evicted
+    before the archive wrote them are reported in `known_dropped_spans` (`completeness: partial`),
+    and the health check exposes `dirty_backlog_spans`.
+  - Attribute values are capped at ingest (`trace_storage.max_attribute_bytes`, default 64 KiB);
+    a cut `iii.payload.json` sets `iii.payload.truncated`.
 
   ## Reliability
 

--- a/engine/src/workers/observability/README.md
+++ b/engine/src/workers/observability/README.md
@@ -112,6 +112,14 @@ engine restart. Memory-backed stores are unaffected.
 | `level`                     | string      | Minimum log level: `trace`, `debug`, `info`, `warn`, `error`. Defaults to `info`.                                                                                            |
 | `format`                    | string      | Log output format: `default` or `json`. Defaults to `default`.                                                                                                               |
 | `alerts`                    | AlertRule[] | Alert rules evaluated against metrics.                                                                                                                                       |
+| `trace_storage.enabled`     | boolean     | Persist completed spans to SQLite (`traces.sqlite3`). Defaults to `true`.                                                                                                     |
+| `trace_storage.directory`   | string      | Directory for the archive and its WAL sidecars. Defaults to `./data/observability/traces`.                                                                                    |
+| `trace_storage.max_disk_bytes` | number   | Physical cap on the archive directory; oldest traces are evicted at 90% and the file shrunk to 80%. Defaults to `1073741824` (1 GiB), minimum 64 MiB.                         |
+| `trace_storage.retention_seconds` | number | Age limit for archived traces; `0` disables it. Defaults to `2592000` (30 days).                                                                                             |
+| `trace_storage.memory_max_bytes` | number | Hard cap on the in-memory hot cache (an RSS estimate). Oldest spans are evicted first — including finalized spans the archive has not written yet, which are counted in `known_dropped_spans` and turn `completeness` to `partial`. Defaults to `268435456` (256 MiB), minimum 16 MiB. |
+| `trace_storage.memory_low_watermark_ratio` | number | Fraction of `memory_max_bytes` the cache shrinks to under pressure (`0.5`–`0.95`). Defaults to `0.75`.                                                                  |
+| `trace_storage.pending_max_age_seconds` | number | Age after which a live (pending) snapshot that never closed is dropped from the hot cache. Defaults to `3600`.                                                            |
+| `trace_storage.max_attribute_bytes` | number | Cap on one attribute value (span, event or link) at ingest. Longer values are cut on a char boundary and end in `…[truncated N bytes]`; a cut `iii.payload.json` also sets `iii.payload.truncated`. `0` disables. Defaults to `65536`. |
 
 ### OTLP Transport
 

--- a/engine/src/workers/observability/config.rs
+++ b/engine/src/workers/observability/config.rs
@@ -222,6 +222,14 @@ pub struct TraceStorageConfig {
     /// Maximum age for in-flight snapshots that never receive a final span.
     #[serde(default = "default_trace_storage_pending_max_age_seconds")]
     pub pending_max_age_seconds: u64,
+
+    /// Cap on one attribute value (span, event or link) at ingest, in bytes.
+    /// Longer values are cut on a char boundary and end in
+    /// `…[truncated N bytes]`; a cut `iii.payload.json` also sets
+    /// `iii.payload.truncated`. Bounds what a single span can cost the hot
+    /// cache and the archive. Zero disables the cap.
+    #[serde(default = "default_trace_storage_max_attribute_bytes")]
+    pub max_attribute_bytes: u64,
 }
 
 const TRACE_STORAGE_DEFAULT_DIRECTORY: &str = "./data/observability/traces";
@@ -230,6 +238,7 @@ const TRACE_STORAGE_DEFAULT_RETENTION_SECONDS: u64 = 2_592_000;
 const TRACE_STORAGE_DEFAULT_MEMORY_MAX_BYTES: u64 = 268_435_456;
 const TRACE_STORAGE_DEFAULT_MEMORY_LOW_WATERMARK: f64 = 0.75;
 const TRACE_STORAGE_DEFAULT_PENDING_MAX_AGE_SECONDS: u64 = 3_600;
+pub(crate) const TRACE_STORAGE_DEFAULT_MAX_ATTRIBUTE_BYTES: u64 = 65_536;
 
 fn default_trace_storage_enabled() -> bool {
     true
@@ -259,6 +268,10 @@ fn default_trace_storage_pending_max_age_seconds() -> u64 {
     TRACE_STORAGE_DEFAULT_PENDING_MAX_AGE_SECONDS
 }
 
+fn default_trace_storage_max_attribute_bytes() -> u64 {
+    TRACE_STORAGE_DEFAULT_MAX_ATTRIBUTE_BYTES
+}
+
 impl Default for TraceStorageConfig {
     fn default() -> Self {
         Self {
@@ -269,6 +282,7 @@ impl Default for TraceStorageConfig {
             memory_max_bytes: default_trace_storage_memory_max_bytes(),
             memory_low_watermark_ratio: default_trace_storage_memory_low_watermark(),
             pending_max_age_seconds: default_trace_storage_pending_max_age_seconds(),
+            max_attribute_bytes: default_trace_storage_max_attribute_bytes(),
         }
     }
 }

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -1476,6 +1476,7 @@ impl ObservabilityWorker {
         {
             storage.set_low_watermark_ratio(trace_storage.memory_low_watermark_ratio);
             storage.set_max_bytes(trace_storage.memory_max_bytes);
+            storage.set_max_attribute_bytes(trace_storage.max_attribute_bytes);
         }
         // No `enabled` guard: after the swap tier a disabled config leaves no
         // installed archive, so the `get_trace_disk_storage()` gate suffices.
@@ -3484,6 +3485,10 @@ impl ObservabilityWorker {
             let details = serde_json::json!({
                 "stored_spans": storage.len(),
                 "hot_bytes": storage.hot_bytes(),
+                // Finalized spans the archive writer has not acknowledged:
+                // a growing number means ingestion outruns the writer and
+                // the oldest of them are about to be dropped.
+                "dirty_backlog_spans": storage.dirty_len(),
                 "archive": trace_storage_status,
             });
             if trace_storage_status.archive == "degraded" {
@@ -5425,9 +5430,8 @@ mod tests {
         assert!(t3_spans.is_empty());
     }
 
-    // Serial: eviction protects dirty spans whenever the GLOBAL archive is
-    // attached (`evict_to_capacity` consults it), so this must not overlap
-    // the `#[serial]` archive tests.
+    // Serial: eviction reports dropped spans to the GLOBAL archive when one
+    // is attached, so this must not overlap the `#[serial]` archive tests.
     #[test]
     #[serial]
     fn test_span_storage_eviction() {
@@ -6435,9 +6439,8 @@ mod tests {
     // Span storage: eviction updates secondary index correctly
     // =========================================================================
 
-    // Serial: eviction protects dirty spans whenever the GLOBAL archive is
-    // attached (`evict_to_capacity` consults it), so this must not overlap
-    // the `#[serial]` archive tests.
+    // Serial: eviction reports dropped spans to the GLOBAL archive when one
+    // is attached, so this must not overlap the `#[serial]` archive tests.
     #[test]
     #[serial]
     fn test_span_storage_eviction_index_integrity() {

--- a/engine/src/workers/observability/otel.rs
+++ b/engine/src/workers/observability/otel.rs
@@ -31,10 +31,10 @@ use opentelemetry_sdk::{
 };
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::env;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
@@ -45,6 +45,9 @@ use tracing_subscriber::registry::LookupSpan;
 /// Default maximum number of spans to keep in memory.
 const DEFAULT_MEMORY_MAX_SPANS: usize = 1000;
 const DEFAULT_MEMORY_MAX_BYTES: u64 = 268_435_456;
+/// Engine-side cap on one attribute value at ingest; see
+/// `TraceStorageConfig::max_attribute_bytes`.
+const DEFAULT_MAX_ATTRIBUTE_BYTES: u64 = super::config::TRACE_STORAGE_DEFAULT_MAX_ATTRIBUTE_BYTES;
 
 /// Global OTEL configuration. Seeded from YAML config (or the persisted
 /// configuration entry) at boot, and swappable at runtime by the
@@ -539,10 +542,45 @@ pub fn now_unix_nanos() -> u64 {
         .as_nanos() as u64
 }
 
+/// Approximate heap footprint of a span: the sum of its string lengths plus
+/// the fixed size of every record. This is an RSS estimate for the hot-cache
+/// byte cap, not a serialized length — the archive measures the JSON it writes
+/// itself. It allocates nothing and never serializes: it runs on the ingest
+/// path for every span.
 fn approx_span_size(span: &StoredSpan) -> u64 {
-    serde_json::to_vec(span)
-        .map(|payload| payload.len() as u64)
-        .unwrap_or(0)
+    fn opt_len(value: &Option<String>) -> usize {
+        value.as_ref().map_or(0, String::len)
+    }
+    fn pairs(attributes: &[(String, String)]) -> usize {
+        attributes
+            .iter()
+            .map(|(key, value)| std::mem::size_of::<(String, String)>() + key.len() + value.len())
+            .sum()
+    }
+    let mut total = std::mem::size_of::<StoredSpan>()
+        + span.trace_id.len()
+        + span.span_id.len()
+        + opt_len(&span.parent_span_id)
+        + span.name.len()
+        + span.status.len()
+        + opt_len(&span.status_description)
+        + span.service_name.len()
+        + opt_len(&span.instrumentation_scope_name)
+        + opt_len(&span.instrumentation_scope_version)
+        + opt_len(&span.trace_state)
+        + pairs(&span.attributes);
+    for event in &span.events {
+        total +=
+            std::mem::size_of::<StoredSpanEvent>() + event.name.len() + pairs(&event.attributes);
+    }
+    for link in &span.links {
+        total += std::mem::size_of::<StoredSpanLink>()
+            + link.trace_id.len()
+            + link.span_id.len()
+            + opt_len(&link.trace_state)
+            + pairs(&link.attributes);
+    }
+    total as u64
 }
 
 fn sensitive_attribute_key(key: &str) -> bool {
@@ -571,116 +609,239 @@ fn sanitize_attributes(attributes: &mut [(String, String)]) {
     }
 }
 
-fn sanitize_span(span: &mut StoredSpan) {
-    sanitize_attributes(&mut span.attributes);
-    for event in &mut span.events {
-        sanitize_attributes(&mut event.attributes);
+/// Attribute the SDKs use for a captured invocation payload, and the flag they
+/// set when they truncated it themselves. The engine raises the same flag when
+/// its own cap cuts the payload, so readers see one signal either way.
+const PAYLOAD_ATTRIBUTE_KEY: &str = "iii.payload.json";
+const PAYLOAD_TRUNCATED_KEY: &str = "iii.payload.truncated";
+
+/// Cut `value` down to `max_bytes` on a char boundary and say how much went.
+/// Returns whether anything was cut. Zero disables the cap.
+fn truncate_attribute_value(value: &mut String, max_bytes: usize) -> bool {
+    if max_bytes == 0 || value.len() <= max_bytes {
+        return false;
     }
-    for link in &mut span.links {
-        sanitize_attributes(&mut link.attributes);
+    let mut cut = max_bytes;
+    while !value.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let removed = value.len() - cut;
+    value.truncate(cut);
+    value.push_str(&format!("…[truncated {removed} bytes]"));
+    true
+}
+
+fn truncate_attributes(attributes: &mut Vec<(String, String)>, max_bytes: usize) {
+    if max_bytes == 0 {
+        return;
+    }
+    let mut payload_cut = false;
+    for (key, value) in attributes.iter_mut() {
+        if truncate_attribute_value(value, max_bytes) && key == PAYLOAD_ATTRIBUTE_KEY {
+            payload_cut = true;
+        }
+    }
+    if payload_cut {
+        match attributes
+            .iter_mut()
+            .find(|(key, _)| key == PAYLOAD_TRUNCATED_KEY)
+        {
+            Some((_, flag)) => *flag = "true".to_string(),
+            None => attributes.push((PAYLOAD_TRUNCATED_KEY.to_string(), "true".to_string())),
+        }
     }
 }
 
-/// In-memory span storage with circular buffer and broadcast channel.
+/// Redact sensitive attributes and cap every attribute value at
+/// `max_attribute_bytes` (zero = uncapped). Runs once per span at ingest,
+/// before the span is measured or stored.
+fn sanitize_span(span: &mut StoredSpan, max_attribute_bytes: usize) {
+    sanitize_attributes(&mut span.attributes);
+    truncate_attributes(&mut span.attributes, max_attribute_bytes);
+    for event in &mut span.events {
+        sanitize_attributes(&mut event.attributes);
+        truncate_attributes(&mut event.attributes, max_attribute_bytes);
+    }
+    for link in &mut span.links {
+        sanitize_attributes(&mut link.attributes);
+        truncate_attributes(&mut link.attributes, max_attribute_bytes);
+    }
+}
+
+struct Slot {
+    bytes: u64,
+    span: StoredSpan,
+}
+
+/// The hot cache proper: a bounded FIFO of spans keyed by a monotonic sequence
+/// number, plus the indexes every operation needs, all O(log n).
+///
+/// Every mutation adjusts `hot_bytes` by the slot's cached size, so the byte
+/// account never drifts and never needs a recount. `next_seq` only grows —
+/// `clear` keeps it — so a sequence the writer thread holds from an earlier
+/// `dirty_spans` snapshot can never alias a newer span.
+#[derive(Default)]
+struct HotCache {
+    /// seq -> slot; iteration order is insertion order.
+    slots: BTreeMap<u64, Slot>,
+    next_seq: u64,
+    /// Ascending seqs per trace, for the trace lookups.
+    by_trace: HashMap<String, VecDeque<u64>>,
+    /// Live snapshots awaiting their final span, `(trace_id, span_id)` -> seq.
+    /// Span ids are only unique within a trace, so both ids key the map.
+    pending: HashMap<(String, String), u64>,
+    /// Finalized spans the archive writer has not acknowledged yet, oldest first.
+    dirty: BTreeSet<u64>,
+    hot_bytes: u64,
+}
+
+impl HotCache {
+    fn push(&mut self, bytes: u64, span: StoredSpan, pending: bool) -> u64 {
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        self.by_trace
+            .entry(span.trace_id.clone())
+            .or_default()
+            .push_back(seq);
+        if pending {
+            self.pending
+                .insert((span.trace_id.clone(), span.span_id.clone()), seq);
+        } else {
+            self.dirty.insert(seq);
+        }
+        self.hot_bytes = self.hot_bytes.saturating_add(bytes);
+        self.slots.insert(seq, Slot { bytes, span });
+        seq
+    }
+
+    /// A final span replacing its live snapshot overwrites in place: same seq,
+    /// same trace, so neither index moves. `Err` hands the span back when no
+    /// snapshot is tracked (never pending, or its slot already left the cache)
+    /// and the caller appends it as a fresh span.
+    fn replace_pending(&mut self, bytes: u64, span: StoredSpan) -> Result<(), StoredSpan> {
+        if self.pending.is_empty() {
+            return Err(span);
+        }
+        let key = (span.trace_id.clone(), span.span_id.clone());
+        let Some(seq) = self.pending.remove(&key) else {
+            return Err(span);
+        };
+        let Some(slot) = self.slots.get_mut(&seq) else {
+            return Err(span);
+        };
+        self.hot_bytes = self
+            .hot_bytes
+            .saturating_sub(slot.bytes)
+            .saturating_add(bytes);
+        slot.bytes = bytes;
+        slot.span = span;
+        self.dirty.insert(seq);
+        Ok(())
+    }
+
+    /// Drop `seq` from the cache and every index. `Some(true)` when the span
+    /// was finalized but not yet acknowledged by the archive.
+    fn remove(&mut self, seq: u64) -> Option<bool> {
+        let slot = self.slots.remove(&seq)?;
+        Some(self.detach(seq, slot))
+    }
+
+    fn detach(&mut self, seq: u64, slot: Slot) -> bool {
+        self.hot_bytes = self.hot_bytes.saturating_sub(slot.bytes);
+        let trace_emptied = match self.by_trace.get_mut(&slot.span.trace_id) {
+            Some(seqs) => {
+                if seqs.front() == Some(&seq) {
+                    seqs.pop_front();
+                } else {
+                    seqs.retain(|candidate| *candidate != seq);
+                }
+                seqs.is_empty()
+            }
+            None => false,
+        };
+        if trace_emptied {
+            self.by_trace.remove(&slot.span.trace_id);
+        }
+        if slot.span.pending {
+            // A newer snapshot for the same ids may own the map entry by now.
+            let key = (slot.span.trace_id, slot.span.span_id);
+            if self.pending.get(&key) == Some(&seq) {
+                self.pending.remove(&key);
+            }
+        }
+        self.dirty.remove(&seq)
+    }
+
+    /// Evict oldest-first until both limits hold with `incoming_spans` /
+    /// `incoming_bytes` about to land. Under byte pressure the cache shrinks
+    /// to the low watermark so it does not evict on every insert. Returns how
+    /// many finalized spans left before the archive acknowledged them — the
+    /// caller reports those as dropped.
+    fn evict_for(
+        &mut self,
+        incoming_spans: usize,
+        incoming_bytes: u64,
+        max_spans: usize,
+        max_bytes: u64,
+        low_watermark_ratio: f64,
+    ) -> u64 {
+        let byte_pressure =
+            max_bytes > 0 && self.hot_bytes.saturating_add(incoming_bytes) > max_bytes;
+        let byte_target = if byte_pressure {
+            ((max_bytes as f64) * low_watermark_ratio.clamp(0.5, 0.95)) as u64
+        } else {
+            max_bytes
+        };
+        let mut dropped = 0;
+        while self.slots.len() + incoming_spans > max_spans
+            || (max_bytes > 0 && self.hot_bytes.saturating_add(incoming_bytes) > byte_target)
+        {
+            let Some((seq, slot)) = self.slots.pop_first() else {
+                break;
+            };
+            if self.detach(seq, slot) {
+                dropped += 1;
+            }
+        }
+        dropped
+    }
+}
+
+/// In-memory span storage: a bounded FIFO hot cache plus a broadcast channel.
+///
+/// Memory is the hard limit. Finalized spans the archive has not written yet
+/// are evicted like any other once `memory_max_bytes` / `max_spans` is hit;
+/// they are counted on the archive as dropped (`known_dropped_spans`,
+/// `completeness: "partial"`) instead of pinning the cache. The critical
+/// section takes no other lock and does no size-proportional work: sanitizing,
+/// measuring and broadcasting happen before it, archive notifications after.
+/// This code runs inside tracing-layer callbacks on whichever runtime thread
+/// closes a span, so anything slow here parks that thread.
 pub struct InMemorySpanStorage {
-    spans: RwLock<VecDeque<StoredSpan>>,
+    cache: RwLock<HotCache>,
     /// Capacity limit. Atomic so the configuration-worker apply path can
     /// retune it at runtime; enforcement happens on every insert.
-    max_spans: std::sync::atomic::AtomicUsize,
+    max_spans: AtomicUsize,
     /// Byte limit for the hot cache. `memory_max_spans` remains as a
     /// compatibility guard, but bytes are the primary RSS protection.
     max_bytes: AtomicU64,
     low_watermark_ratio: AtomicU64,
-    hot_bytes: AtomicU64,
-    /// Secondary index: trace_id -> set of span indices for O(1) trace lookups
-    spans_by_trace_id: RwLock<HashMap<String, HashSet<usize>>>,
-    /// `(trace_id, span_id)` pairs currently stored as pending (live
-    /// snapshots awaiting their final span). Keyed by both ids — span ids
-    /// are only unique within a trace, so a colliding final from another
-    /// trace must not replace the wrong snapshot. Gates the replace-scan in
-    /// `add_spans` so the hot append path (OTLP ingest, exporters) stays
-    /// O(1) when no pending predecessor exists. Lock order everywhere:
-    /// `spans` → `spans_by_trace_id` → this.
-    pending_span_ids: RwLock<HashSet<(String, String)>>,
-    /// Finalized spans waiting for the asynchronous disk writer.
-    dirty_span_ids: RwLock<HashSet<(String, String)>>,
+    /// Cap on a single attribute value at ingest; zero = uncapped.
+    max_attribute_bytes: AtomicU64,
     /// Broadcast of every span as it lands, driving the `trace` trigger
     /// fan-out. Mirrors `InMemoryLogStorage`'s log broadcast.
     tx: broadcast::Sender<StoredSpan>,
 }
 
-/// Evict oldest spans until `len < max_spans`, maintaining the trace index
-/// (shift-down on every pop) and purging evicted ids from the pending set.
-/// Callers hold all three storage locks (see the lock-order note above).
-fn evict_to_capacity(
-    spans: &mut VecDeque<StoredSpan>,
-    index: &mut HashMap<String, HashSet<usize>>,
-    pending: &mut HashSet<(String, String)>,
-    dirty: &mut HashSet<(String, String)>,
-    max_spans: usize,
-    max_bytes: u64,
-    low_watermark_ratio: f64,
-    incoming_bytes: u64,
-    hot_bytes: &AtomicU64,
-) {
-    let archive = get_trace_disk_storage();
-    let protect_pending = archive.is_some();
-    let protect_dirty = archive.as_ref().is_some_and(|store| !store.is_degraded());
-    let current = hot_bytes.load(Ordering::Relaxed);
-    let byte_pressure = max_bytes > 0 && current.saturating_add(incoming_bytes) > max_bytes;
-    let byte_target = if byte_pressure {
-        ((max_bytes as f64) * low_watermark_ratio.clamp(0.5, 0.95)) as u64
-    } else {
-        max_bytes
-    };
-
-    // Loop converges after a shrink. Pending snapshots and finalized spans
-    // that have not reached SQLite are protected. If every resident span is
-    // protected, retaining correctness wins over forcing the hot cache below
-    // its configured limit; the archive health surface reports the eventual
-    // write failure instead of silently losing data.
-    while spans.len() >= max_spans
-        || (max_bytes > 0
-            && hot_bytes
-                .load(Ordering::Relaxed)
-                .saturating_add(incoming_bytes)
-                > byte_target)
-    {
-        let Some(index_to_remove) = spans.iter().position(|old| {
-            let key = (old.trace_id.clone(), old.span_id.clone());
-            (!protect_pending || !pending.contains(&key))
-                && (!protect_dirty || !dirty.contains(&key))
-        }) else {
-            break;
-        };
-        let Some(old) = spans.remove(index_to_remove) else {
-            break;
-        };
-        pending.remove(&(old.trace_id.clone(), old.span_id.clone()));
-        let was_dirty = dirty.remove(&(old.trace_id.clone(), old.span_id.clone()));
-        if was_dirty
-            && let Some(archive) = &archive
-            && archive.is_degraded()
-        {
-            archive.record_dropped_spans(1);
-        }
-        hot_bytes.fetch_sub(approx_span_size(&old), Ordering::Relaxed);
-        index.clear();
-        for (idx, span) in spans.iter().enumerate() {
-            index.entry(span.trace_id.clone()).or_default().insert(idx);
-        }
-    }
-}
-
 impl std::fmt::Debug for InMemorySpanStorage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let cache = self.read();
         f.debug_struct("InMemorySpanStorage")
-            .field("spans", &self.spans)
-            .field(
-                "max_spans",
-                &self.max_spans.load(std::sync::atomic::Ordering::Relaxed),
-            )
-            .field("spans_by_trace_id", &self.spans_by_trace_id)
+            .field("spans", &cache.slots.len())
+            .field("hot_bytes", &cache.hot_bytes)
+            .field("dirty", &cache.dirty.len())
+            .field("max_spans", &self.max_spans.load(Ordering::Relaxed))
+            .field("max_bytes", &self.max_bytes.load(Ordering::Relaxed))
             .finish()
     }
 }
@@ -701,101 +862,124 @@ impl InMemorySpanStorage {
     ) -> Self {
         let (tx, _) = broadcast::channel(1024);
         Self {
-            // Do not reserve the configured span count up front: legacy
-            // configurations can contain very large values.
-            spans: RwLock::new(VecDeque::new()),
-            max_spans: std::sync::atomic::AtomicUsize::new(max_spans),
+            cache: RwLock::new(HotCache::default()),
+            max_spans: AtomicUsize::new(max_spans),
             max_bytes: AtomicU64::new(max_bytes),
             low_watermark_ratio: AtomicU64::new(low_watermark_ratio.clamp(0.5, 0.95).to_bits()),
-            hot_bytes: AtomicU64::new(0),
-            spans_by_trace_id: RwLock::new(HashMap::new()),
-            pending_span_ids: RwLock::new(HashSet::new()),
-            dirty_span_ids: RwLock::new(HashSet::new()),
+            max_attribute_bytes: AtomicU64::new(DEFAULT_MAX_ATTRIBUTE_BYTES),
             tx,
         }
     }
 
-    /// Retune the capacity at runtime. A shrink evicts oldest spans in one
-    /// O(n) pass (drain + index rebuild) under the same lock order as
-    /// `add_spans` (spans, then index) to avoid lock-order inversion.
-    pub fn set_max_spans(&self, max: usize) {
-        let max = max.max(1);
-        self.max_spans
-            .store(max, std::sync::atomic::Ordering::Relaxed);
-        let mut spans = self.spans.write().unwrap();
-        if spans.len() > max {
-            let mut index = self.spans_by_trace_id.write().unwrap();
-            let mut pending = self.pending_span_ids.write().unwrap();
-            let mut dirty = self.dirty_span_ids.write().unwrap();
-            let archive = get_trace_disk_storage();
-            let protect_pending = archive.is_some();
-            let protect_dirty = archive.as_ref().is_some_and(|store| !store.is_degraded());
-            while spans.len() > max {
-                let Some(index_to_remove) = spans.iter().position(|old| {
-                    let key = (old.trace_id.clone(), old.span_id.clone());
-                    (!protect_pending || !pending.contains(&key))
-                        && (!protect_dirty || !dirty.contains(&key))
-                }) else {
-                    break;
-                };
-                let Some(old) = spans.remove(index_to_remove) else {
-                    break;
-                };
-                pending.remove(&(old.trace_id.clone(), old.span_id.clone()));
-                let was_dirty = dirty.remove(&(old.trace_id, old.span_id));
-                if was_dirty
-                    && let Some(archive) = &archive
-                    && archive.is_degraded()
-                {
-                    archive.record_dropped_spans(1);
-                }
-            }
-            index.clear();
-            for (idx, span) in spans.iter().enumerate() {
-                index.entry(span.trace_id.clone()).or_default().insert(idx);
-            }
-            self.hot_bytes
-                .store(spans.iter().map(approx_span_size).sum(), Ordering::Relaxed);
+    fn read(&self) -> RwLockReadGuard<'_, HotCache> {
+        self.cache
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn write(&self) -> RwLockWriteGuard<'_, HotCache> {
+        self.cache
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn limits(&self) -> (usize, u64, f64) {
+        (
+            self.max_spans.load(Ordering::Relaxed).max(1),
+            self.max_bytes.load(Ordering::Relaxed),
+            self.low_watermark_ratio(),
+        )
+    }
+
+    /// The one ingest path. Pending snapshots and finals differ only in how
+    /// they are indexed and in whether the archive is woken.
+    fn insert(&self, spans: Vec<StoredSpan>, pending: bool) {
+        if spans.is_empty() {
+            return;
         }
+        let archive = get_trace_disk_storage();
+        let (max_spans, max_bytes, ratio) = self.limits();
+        let max_attribute_bytes = self.max_attribute_bytes.load(Ordering::Relaxed) as usize;
+        let broadcast = self.tx.receiver_count() > 0;
+        // Everything proportional to the span's size happens before the lock.
+        let prepared: Vec<(u64, StoredSpan)> = spans
+            .into_iter()
+            .map(|mut span| {
+                sanitize_span(&mut span, max_attribute_bytes);
+                let bytes = approx_span_size(&span);
+                if broadcast {
+                    let _ = self.tx.send(span.clone());
+                }
+                (bytes, span)
+            })
+            .collect();
+
+        let mut dropped = 0u64;
+        {
+            let mut cache = self.write();
+            for (bytes, span) in prepared {
+                // A final replacing its live snapshot overwrites in place and
+                // needs no room. The reverse never happens: `on_start` always
+                // precedes `on_end`, and a worker's start snapshot ingests
+                // before its final on the same FIFO telemetry connection.
+                let span = if pending {
+                    span
+                } else {
+                    match cache.replace_pending(bytes, span) {
+                        Ok(()) => continue,
+                        Err(span) => span,
+                    }
+                };
+                dropped += cache.evict_for(1, bytes, max_spans, max_bytes, ratio);
+                cache.push(bytes, span, pending);
+            }
+        }
+
+        if let Some(archive) = archive {
+            if dropped > 0 {
+                archive.record_dropped_spans(dropped);
+            }
+            if !pending {
+                archive.notify();
+            }
+        }
+    }
+
+    pub fn add_spans(&self, new_spans: Vec<StoredSpan>) {
+        self.insert(new_spans, false);
+    }
+
+    /// Record an in-progress span snapshot (`LiveSpanProcessor::on_start`).
+    /// Appends + broadcasts exactly like `add_spans` and marks the
+    /// `(trace_id, span_id)` pair pending so the final span replaces it in
+    /// place when it closes. Pending spans live ONLY in this store and the
+    /// streams fed from it — the OTLP export path never sees them.
+    pub fn add_pending_span(&self, span: StoredSpan) {
+        debug_assert!(span.pending && span.end_time_unix_nano == 0);
+        self.insert(vec![span], true);
+    }
+
+    /// Enforce the current limits without an insert (after a retune).
+    fn shrink_to_limits(&self) {
+        let archive = get_trace_disk_storage();
+        let (max_spans, max_bytes, ratio) = self.limits();
+        let dropped = self.write().evict_for(0, 0, max_spans, max_bytes, ratio);
+        if dropped > 0
+            && let Some(archive) = archive
+        {
+            archive.record_dropped_spans(dropped);
+        }
+    }
+
+    /// Retune the capacity at runtime; a shrink evicts oldest spans.
+    pub fn set_max_spans(&self, max: usize) {
+        self.max_spans.store(max.max(1), Ordering::Relaxed);
+        self.shrink_to_limits();
     }
 
     pub fn set_max_bytes(&self, max: u64) {
         self.max_bytes.store(max, Ordering::Relaxed);
-        let mut spans = self.spans.write().unwrap();
-        let mut index = self.spans_by_trace_id.write().unwrap();
-        let mut pending = self.pending_span_ids.write().unwrap();
-        let mut dirty = self.dirty_span_ids.write().unwrap();
-        let archive = get_trace_disk_storage();
-        let protect_pending = archive.is_some();
-        let protect_dirty = archive.as_ref().is_some_and(|store| !store.is_degraded());
-        let mut current = self.hot_bytes.load(Ordering::Relaxed);
-        let target = ((max as f64) * self.low_watermark_ratio()).round() as u64;
-        while current > target {
-            let Some(index_to_remove) = spans.iter().position(|old| {
-                let key = (old.trace_id.clone(), old.span_id.clone());
-                (!protect_pending || !pending.contains(&key))
-                    && (!protect_dirty || !dirty.contains(&key))
-            }) else {
-                break;
-            };
-            let Some(old) = spans.remove(index_to_remove) else {
-                break;
-            };
-            pending.remove(&(old.trace_id.clone(), old.span_id.clone()));
-            let was_dirty = dirty.remove(&(old.trace_id.clone(), old.span_id.clone()));
-            if was_dirty
-                && let Some(archive) = &archive
-                && archive.is_degraded()
-            {
-                archive.record_dropped_spans(1);
-            }
-            current = current.saturating_sub(approx_span_size(&old));
-        }
-        index.clear();
-        for (idx, span) in spans.iter().enumerate() {
-            index.entry(span.trace_id.clone()).or_default().insert(idx);
-        }
-        self.hot_bytes.store(current, Ordering::Relaxed);
+        self.shrink_to_limits();
     }
 
     pub fn set_low_watermark_ratio(&self, ratio: f64) {
@@ -807,151 +991,41 @@ impl InMemorySpanStorage {
         f64::from_bits(self.low_watermark_ratio.load(Ordering::Relaxed))
     }
 
-    pub fn add_spans(&self, new_spans: Vec<StoredSpan>) {
-        let mut spans = self.spans.write().unwrap();
-        let mut index = self.spans_by_trace_id.write().unwrap();
-        let mut pending = self.pending_span_ids.write().unwrap();
-        let mut dirty = self.dirty_span_ids.write().unwrap();
-
-        let max_spans = self
-            .max_spans
-            .load(std::sync::atomic::Ordering::Relaxed)
-            .max(1);
-        for mut span in new_spans {
-            sanitize_span(&mut span);
-            let incoming_bytes = approx_span_size(&span);
-            // A final span replacing its live (pending) snapshot overwrites in
-            // place: same idx, same trace_id, so neither index changes. Keys
-            // are `(trace_id, span_id)` — span ids are only unique within a
-            // trace, so a colliding final from another trace must not steal
-            // the snapshot. The emptiness gate keeps the key clone + scan off
-            // the hot append path, and pending spans are by construction
-            // recent, so scan from the back. The reverse never happens — a
-            // pending snapshot must not overwrite a final (`on_start` always
-            // precedes `on_end`, and a worker's start snapshot always ingests
-            // before its final: same FIFO telemetry connection, see
-            // `ingest_otlp_json`).
-            if !pending.is_empty()
-                && pending.remove(&(span.trace_id.clone(), span.span_id.clone()))
-                && let Some(slot) = spans
-                    .iter_mut()
-                    .rev()
-                    .find(|s| s.span_id == span.span_id && s.trace_id == span.trace_id)
-            {
-                let _ = self.tx.send(span.clone());
-                self.hot_bytes
-                    .fetch_sub(approx_span_size(slot), Ordering::Relaxed);
-                let key = (span.trace_id.clone(), span.span_id.clone());
-                *slot = span;
-                self.hot_bytes.fetch_add(incoming_bytes, Ordering::Relaxed);
-                dirty.insert(key);
-                if let Some(archive) = get_trace_disk_storage() {
-                    archive.notify();
-                }
-                continue;
-            }
-            // A tracked pending whose slot was already evicted falls through
-            // and appends as a fresh span.
-
-            evict_to_capacity(
-                &mut spans,
-                &mut index,
-                &mut pending,
-                &mut dirty,
-                max_spans,
-                self.max_bytes.load(Ordering::Relaxed),
-                self.low_watermark_ratio(),
-                incoming_bytes,
-                &self.hot_bytes,
-            );
-
-            let idx = spans.len();
-            let trace_id = span.trace_id.clone();
-
-            // Broadcast to any listeners (ignore send errors if no receivers).
-            // Mirrors InMemoryLogStorage::add_logs so the `trace` trigger fans
-            // out uniformly across every ingestion path (OTLP ingest, the
-            // in-memory exporter, and the tee exporter all funnel through here).
-            let _ = self.tx.send(span.clone());
-
-            let key = (span.trace_id.clone(), span.span_id.clone());
-            spans.push_back(span);
-            self.hot_bytes.fetch_add(incoming_bytes, Ordering::Relaxed);
-            dirty.insert(key);
-            index.entry(trace_id).or_default().insert(idx);
-            if let Some(archive) = get_trace_disk_storage() {
-                archive.notify();
-            }
-        }
-    }
-
-    /// Record an in-progress span snapshot (`LiveSpanProcessor::on_start`).
-    /// Appends + broadcasts exactly like `add_spans` and marks the
-    /// `(trace_id, span_id)` pair pending so the final span replaces it in
-    /// place when it closes. Pending spans live ONLY in this store and the
-    /// streams fed from it — the OTLP export path never sees them.
-    pub fn add_pending_span(&self, span: StoredSpan) {
-        debug_assert!(span.pending && span.end_time_unix_nano == 0);
-        let mut span = span;
-        sanitize_span(&mut span);
-        let incoming_bytes = approx_span_size(&span);
-        let mut spans = self.spans.write().unwrap();
-        let mut index = self.spans_by_trace_id.write().unwrap();
-        let mut pending = self.pending_span_ids.write().unwrap();
-        let mut dirty = self.dirty_span_ids.write().unwrap();
-
-        let max_spans = self
-            .max_spans
-            .load(std::sync::atomic::Ordering::Relaxed)
-            .max(1);
-        evict_to_capacity(
-            &mut spans,
-            &mut index,
-            &mut pending,
-            &mut dirty,
-            max_spans,
-            self.max_bytes.load(Ordering::Relaxed),
-            self.low_watermark_ratio(),
-            incoming_bytes,
-            &self.hot_bytes,
-        );
-
-        let idx = spans.len();
-        let trace_id = span.trace_id.clone();
-        pending.insert((trace_id.clone(), span.span_id.clone()));
-        let _ = self.tx.send(span.clone());
-        spans.push_back(span);
-        self.hot_bytes.fetch_add(incoming_bytes, Ordering::Relaxed);
-        index.entry(trace_id).or_default().insert(idx);
+    /// Cap on a single attribute value at ingest; zero disables it. Applies to
+    /// spans ingested from now on.
+    pub fn set_max_attribute_bytes(&self, max: u64) {
+        self.max_attribute_bytes.store(max, Ordering::Relaxed);
     }
 
     pub fn get_spans(&self) -> Vec<StoredSpan> {
-        self.spans.read().unwrap().iter().cloned().collect()
+        self.read()
+            .slots
+            .values()
+            .map(|slot| slot.span.clone())
+            .collect()
     }
 
     pub fn get_spans_by_trace_id(&self, trace_id: &str) -> Vec<StoredSpan> {
-        let spans = self.spans.read().unwrap();
-        let index = self.spans_by_trace_id.read().unwrap();
-
-        match index.get(trace_id) {
-            Some(indices) => indices
+        let cache = self.read();
+        match cache.by_trace.get(trace_id) {
+            Some(seqs) => seqs
                 .iter()
-                .filter_map(|&i| spans.get(i).cloned())
+                .filter_map(|seq| cache.slots.get(seq))
+                .map(|slot| slot.span.clone())
                 .collect(),
             None => Vec::new(),
         }
     }
 
+    /// Drop every span. Sequence numbers keep counting so a writer batch
+    /// snapshotted before the clear can never acknowledge a later span.
     pub fn clear(&self) {
-        let mut spans = self.spans.write().unwrap();
-        let mut index = self.spans_by_trace_id.write().unwrap();
-        let mut pending = self.pending_span_ids.write().unwrap();
-        let mut dirty = self.dirty_span_ids.write().unwrap();
-        spans.clear();
-        index.clear();
-        pending.clear();
-        dirty.clear();
-        self.hot_bytes.store(0, Ordering::Relaxed);
+        let mut cache = self.write();
+        cache.slots.clear();
+        cache.by_trace.clear();
+        cache.pending.clear();
+        cache.dirty.clear();
+        cache.hot_bytes = 0;
     }
 
     /// Subscribe to a broadcast of every span as it lands in storage. Drives
@@ -961,44 +1035,49 @@ impl InMemorySpanStorage {
     }
 
     pub fn len(&self) -> usize {
-        self.spans.read().unwrap().len()
+        self.read().slots.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.spans.read().unwrap().is_empty()
+        self.read().slots.is_empty()
     }
 
     pub fn hot_bytes(&self) -> u64 {
-        self.hot_bytes.load(Ordering::Relaxed)
+        self.read().hot_bytes
     }
 
-    /// Snapshot dirty spans without removing them. The writer acknowledges
-    /// them only after a committed SQLite transaction.
-    pub fn dirty_spans(&self, limit: usize, max_bytes: u64) -> Vec<StoredSpan> {
-        let spans = self.spans.read().unwrap();
-        let dirty = self.dirty_span_ids.read().unwrap();
+    /// Finalized spans the archive has not acknowledged yet.
+    pub fn dirty_len(&self) -> usize {
+        self.read().dirty.len()
+    }
+
+    /// Snapshot the oldest dirty spans without removing them, as `(seq, span)`
+    /// pairs. The writer acknowledges them by sequence only after a committed
+    /// SQLite transaction; a span evicted in between is simply not there
+    /// anymore and its sequence acknowledges nothing.
+    pub fn dirty_spans(&self, limit: usize, max_bytes: u64) -> Vec<(u64, StoredSpan)> {
+        let cache = self.read();
         let mut bytes = 0u64;
         let mut result = Vec::new();
-        for span in spans.iter() {
-            if !dirty.contains(&(span.trace_id.clone(), span.span_id.clone())) {
+        for seq in &cache.dirty {
+            let Some(slot) = cache.slots.get(seq) else {
                 continue;
-            }
-            let span_bytes = approx_span_size(span);
+            };
             if !result.is_empty()
-                && (result.len() >= limit || bytes.saturating_add(span_bytes) > max_bytes)
+                && (result.len() >= limit || bytes.saturating_add(slot.bytes) > max_bytes)
             {
                 break;
             }
-            bytes = bytes.saturating_add(span_bytes);
-            result.push(span.clone());
+            bytes = bytes.saturating_add(slot.bytes);
+            result.push((*seq, slot.span.clone()));
         }
         result
     }
 
-    pub fn mark_durable(&self, keys: &[(String, String)]) {
-        let mut dirty = self.dirty_span_ids.write().unwrap();
-        for key in keys {
-            dirty.remove(key);
+    pub fn mark_durable(&self, seqs: &[u64]) {
+        let mut cache = self.write();
+        for seq in seqs {
+            cache.dirty.remove(seq);
         }
     }
 
@@ -1009,70 +1088,66 @@ impl InMemorySpanStorage {
     /// upsert on `(epoch, trace_id, span_id)`, so re-marking already-durable
     /// spans against the same directory is safe.
     pub fn mark_all_dirty(&self) {
-        let spans = self.spans.read().unwrap();
-        let mut dirty = self.dirty_span_ids.write().unwrap();
-        for span in spans.iter() {
-            if !span.pending {
-                dirty.insert((span.trace_id.clone(), span.span_id.clone()));
-            }
-        }
+        let mut cache = self.write();
+        let finals: Vec<u64> = cache
+            .slots
+            .iter()
+            .filter(|(_, slot)| !slot.span.pending)
+            .map(|(seq, _)| *seq)
+            .collect();
+        cache.dirty.extend(finals);
     }
 
     pub fn pending_trace_ids(&self) -> HashSet<String> {
-        self.pending_span_ids
-            .read()
-            .unwrap()
-            .iter()
+        self.read()
+            .pending
+            .keys()
             .map(|(trace_id, _)| trace_id.clone())
             .collect()
     }
 
     /// Remove live snapshots that never received a final span. These records
-    /// are intentionally not written to the durable archive, but they must
-    /// not pin the hot cache forever when a worker crashes or a producer
-    /// abandons a span.
+    /// are intentionally not written to the durable archive, and a worker
+    /// that crashed or abandoned a span must not leave them rendering as
+    /// in-progress forever.
     pub fn expire_pending(&self, max_age_seconds: u64) -> usize {
         if max_age_seconds == 0 {
             return 0;
         }
         let cutoff = now_unix_nanos().saturating_sub(max_age_seconds.saturating_mul(1_000_000_000));
-        let mut spans = self.spans.write().unwrap();
-        let mut index = self.spans_by_trace_id.write().unwrap();
-        let mut pending = self.pending_span_ids.write().unwrap();
-        let mut removed = 0;
-        spans.retain(|span| {
-            let expired = span.pending && span.start_time_unix_nano < cutoff;
-            if expired {
-                pending.remove(&(span.trace_id.clone(), span.span_id.clone()));
-                removed += 1;
-            }
-            !expired
-        });
-        if removed > 0 {
-            index.clear();
-            for (idx, span) in spans.iter().enumerate() {
-                index.entry(span.trace_id.clone()).or_default().insert(idx);
-            }
-            self.hot_bytes
-                .store(spans.iter().map(approx_span_size).sum(), Ordering::Relaxed);
+        let mut cache = self.write();
+        let expired: Vec<u64> = cache
+            .pending
+            .values()
+            .copied()
+            .filter(|seq| {
+                cache.slots.get(seq).is_some_and(|slot| {
+                    slot.span.pending && slot.span.start_time_unix_nano < cutoff
+                })
+            })
+            .collect();
+        for seq in &expired {
+            cache.remove(*seq);
         }
-        removed
+        expired.len()
     }
 
     /// Calculate performance metrics (duration statistics) from stored spans.
     /// Returns (avg_ms, p50_ms, p95_ms, p99_ms, min_ms, max_ms).
     pub fn calculate_performance_metrics(&self) -> (f64, f64, f64, f64, f64, f64) {
-        let spans = self.spans.read().unwrap();
+        let cache = self.read();
 
-        if spans.is_empty() {
+        if cache.slots.is_empty() {
             return (0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
         }
 
         // Calculate duration in milliseconds for each span. In-flight
         // (pending) spans are excluded — their duration isn't known yet, and
         // counting them as 0/partial would drag down min/percentiles.
-        let mut durations: Vec<f64> = spans
-            .iter()
+        let mut durations: Vec<f64> = cache
+            .slots
+            .values()
+            .map(|slot| &slot.span)
             .filter(|span| !span.pending)
             .map(|span| {
                 let duration_nanos = span
@@ -2183,6 +2258,12 @@ where
 
     let resource = resource_builder.build();
 
+    let attribute_cap = config
+        .trace_storage
+        .as_ref()
+        .map(|storage| storage.max_attribute_bytes)
+        .unwrap_or(DEFAULT_MAX_ATTRIBUTE_BYTES);
+
     // Build tracer provider based on exporter type
     let provider = match config.exporter {
         ExporterType::Otlp => {
@@ -2205,6 +2286,7 @@ where
                                 .map(|storage| storage.memory_low_watermark_ratio)
                                 .unwrap_or(0.75),
                         ));
+                    memory_storage.set_max_attribute_bytes(attribute_cap);
                     attach_trace_disk_storage(&memory_storage);
                     let _ = IN_MEMORY_STORAGE.set(memory_storage);
 
@@ -2240,6 +2322,7 @@ where
                                 .map(|storage| storage.memory_low_watermark_ratio)
                                 .unwrap_or(0.75),
                         ));
+                    memory_storage.set_max_attribute_bytes(attribute_cap);
                     attach_trace_disk_storage(&memory_storage);
                     if IN_MEMORY_STORAGE.set(memory_storage.clone()).is_err() {
                         tracing::debug!("In-memory span storage already initialized");
@@ -2283,6 +2366,7 @@ where
                     .map(|storage| storage.memory_low_watermark_ratio)
                     .unwrap_or(0.75),
             ));
+            memory_storage.set_max_attribute_bytes(attribute_cap);
             attach_trace_disk_storage(&memory_storage);
             if IN_MEMORY_STORAGE.set(memory_storage.clone()).is_err() {
                 tracing::debug!("In-memory span storage already initialized");
@@ -2324,6 +2408,7 @@ where
                     .map(|storage| storage.memory_low_watermark_ratio)
                     .unwrap_or(0.75),
             ));
+            memory_storage.set_max_attribute_bytes(attribute_cap);
             attach_trace_disk_storage(&memory_storage);
             if IN_MEMORY_STORAGE.set(memory_storage.clone()).is_err() {
                 tracing::debug!("In-memory span storage already initialized");
@@ -6093,7 +6178,7 @@ mod tests {
         storage.add_spans(vec![make_stored_span("t1", "a", "op-a", 1_000, 2_000)]);
         storage.add_pending_span(make_pending_span("t1", "p", "op-p", 3_000));
         storage.add_spans(vec![make_stored_span("t1", "b", "op-b", 4_000, 5_000)]);
-        assert_eq!(storage.pending_span_ids.read().unwrap().len(), 1);
+        assert_eq!(storage.pending_trace_ids().len(), 1);
 
         // Final arrives: replaces the pending snapshot at its original position.
         storage.add_spans(vec![make_stored_span("t1", "p", "op-p", 3_000, 9_000)]);
@@ -6103,7 +6188,7 @@ mod tests {
         assert_eq!(spans[1].span_id, "p", "position preserved");
         assert!(!spans[1].pending);
         assert_eq!(spans[1].end_time_unix_nano, 9_000);
-        assert!(storage.pending_span_ids.read().unwrap().is_empty());
+        assert!(storage.pending_trace_ids().is_empty());
         assert_eq!(storage.get_spans_by_trace_id("t1").len(), 3);
 
         // The id is no longer pending-tracked: a duplicate final appends
@@ -6127,7 +6212,7 @@ mod tests {
         assert_eq!(spans[0].trace_id, "t1");
         assert!(spans[0].pending, "t1's snapshot untouched");
         assert_eq!(storage.get_spans_by_trace_id("t2").len(), 1);
-        assert_eq!(storage.pending_span_ids.read().unwrap().len(), 1);
+        assert_eq!(storage.pending_trace_ids().len(), 1);
 
         // t1's own final still replaces its snapshot in place.
         storage.add_spans(vec![make_stored_span("t1", "p", "op-p", 1_000, 4_000)]);
@@ -6136,7 +6221,7 @@ mod tests {
         assert_eq!(spans[0].trace_id, "t1");
         assert!(!spans[0].pending);
         assert_eq!(spans[0].end_time_unix_nano, 4_000);
-        assert!(storage.pending_span_ids.read().unwrap().is_empty());
+        assert!(storage.pending_trace_ids().is_empty());
     }
 
     #[test]
@@ -6149,7 +6234,7 @@ mod tests {
             // Third insert evicts the oldest (the pending snapshot).
             make_stored_span("t3", "b", "op-b", 4_000, 5_000),
         ]);
-        assert!(storage.pending_span_ids.read().unwrap().is_empty());
+        assert!(storage.pending_trace_ids().is_empty());
 
         // The late final no longer has a pending predecessor — plain append.
         storage.add_spans(vec![make_stored_span("t1", "p", "op-p", 1_000, 6_000)]);
@@ -6169,17 +6254,152 @@ mod tests {
 
         storage.set_max_spans(1); // drains p1
         assert_eq!(storage.len(), 1);
-        let pending: Vec<(String, String)> = storage
-            .pending_span_ids
-            .read()
-            .unwrap()
-            .iter()
-            .cloned()
-            .collect();
-        assert_eq!(pending, vec![("t2".to_string(), "p2".to_string())]);
+        assert_eq!(
+            storage.pending_trace_ids(),
+            std::collections::HashSet::from(["t2".to_string()])
+        );
 
         storage.clear();
-        assert!(storage.pending_span_ids.read().unwrap().is_empty());
+        assert!(storage.pending_trace_ids().is_empty());
+    }
+
+    #[test]
+    fn hot_cache_stays_bounded_and_fast_when_nothing_is_marked_durable() {
+        // Nothing acknowledges these spans (no archive attached), so before
+        // the FIFO rewrite every insert rescanned the whole cache. 50k inserts
+        // must stay bounded by bytes and finish in linear time.
+        let cap = 256 * 1024;
+        let storage = InMemorySpanStorage::new_with_limits_and_watermark(1_000_000, cap, 0.75);
+        let started = std::time::Instant::now();
+        for index in 0..50_000u64 {
+            let mut span =
+                make_stored_span("t-bounded", &format!("s{index}"), "op", index, index + 1);
+            span.attributes
+                .push(("payload".to_string(), "x".repeat(1024)));
+            storage.add_spans(vec![span]);
+        }
+        let elapsed = started.elapsed();
+        assert!(
+            storage.hot_bytes() <= cap + 2048,
+            "hot bytes {} over the cap {cap}",
+            storage.hot_bytes()
+        );
+        assert!(storage.len() < 50_000);
+        assert!(!storage.is_empty());
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "50k inserts took {elapsed:?}"
+        );
+        // Every resident span is still reachable through the trace index.
+        assert_eq!(
+            storage.get_spans_by_trace_id("t-bounded").len(),
+            storage.len()
+        );
+    }
+
+    #[test]
+    fn expired_pending_then_final_appends_fresh_and_sequences_survive_clear() {
+        let storage = InMemorySpanStorage::new(10);
+        // A start time of 1 ns is older than any cutoff.
+        storage.add_pending_span(make_pending_span("t1", "p", "op-p", 1));
+        storage.add_spans(vec![make_stored_span("t1", "a", "op-a", 5_000, 6_000)]);
+        assert_eq!(storage.len(), 2);
+        let bytes_with_pending = storage.hot_bytes();
+
+        assert_eq!(storage.expire_pending(1), 1);
+        assert_eq!(storage.len(), 1);
+        assert!(storage.hot_bytes() < bytes_with_pending);
+        assert!(storage.pending_trace_ids().is_empty());
+        assert_eq!(
+            storage.get_spans_by_trace_id("t1").len(),
+            1,
+            "the expired snapshot left the trace index"
+        );
+
+        // Its late final has no snapshot to replace: plain append.
+        storage.add_spans(vec![make_stored_span("t1", "p", "op-p", 1, 9_000)]);
+        let spans = storage.get_spans();
+        assert_eq!(spans.len(), 2);
+        assert!(!spans[1].pending);
+        assert_eq!(spans[1].span_id, "p");
+
+        // clear() keeps counting sequences: a writer batch snapshotted before
+        // the clear cannot acknowledge spans inserted after it.
+        let stale: Vec<u64> = storage
+            .dirty_spans(16, u64::MAX)
+            .into_iter()
+            .map(|(seq, _)| seq)
+            .collect();
+        assert_eq!(stale.len(), 2);
+        storage.clear();
+        storage.add_spans(vec![make_stored_span("t2", "b", "op-b", 1, 2)]);
+        storage.mark_durable(&stale);
+        assert_eq!(storage.dirty_len(), 1, "the post-clear span is still dirty");
+    }
+
+    #[test]
+    fn long_attribute_values_are_truncated_and_flagged() {
+        let storage = InMemorySpanStorage::new(10);
+        storage.set_max_attribute_bytes(64 * 1024);
+        let mut span = make_stored_span("t1", "a", "op", 1, 2);
+        // Two-byte chars: the cut must land on a char boundary.
+        span.attributes
+            .push(("big".to_string(), "é".repeat(100 * 1024)));
+        span.events.push(StoredSpanEvent {
+            name: "iii.invocation.input".to_string(),
+            timestamp_unix_nano: 1,
+            attributes: vec![
+                ("iii.payload.json".to_string(), "x".repeat(200 * 1024)),
+                ("iii.payload.truncated".to_string(), "false".to_string()),
+            ],
+        });
+        storage.add_spans(vec![span]);
+
+        let stored = &storage.get_spans()[0];
+        let big = &stored
+            .attributes
+            .iter()
+            .find(|(key, _)| key == "big")
+            .expect("big attribute")
+            .1;
+        assert!(big.len() <= 64 * 1024 + 40, "{} bytes", big.len());
+        assert!(big.ends_with("bytes]"), "{}", &big[big.len() - 40..]);
+        let event = &stored.events[0];
+        let payload = &event
+            .attributes
+            .iter()
+            .find(|(key, _)| key == "iii.payload.json")
+            .expect("payload attribute")
+            .1;
+        assert!(payload.len() <= 64 * 1024 + 40);
+        assert!(payload.contains("…[truncated"));
+        assert_eq!(
+            event
+                .attributes
+                .iter()
+                .find(|(key, _)| key == "iii.payload.truncated")
+                .expect("truncated flag")
+                .1,
+            "true"
+        );
+
+        // Zero disables the cap.
+        let uncapped = InMemorySpanStorage::new(10);
+        uncapped.set_max_attribute_bytes(0);
+        let mut span = make_stored_span("t1", "b", "op", 1, 2);
+        span.attributes
+            .push(("big".to_string(), "x".repeat(200 * 1024)));
+        uncapped.add_spans(vec![span]);
+        assert_eq!(
+            uncapped.get_spans()[0]
+                .attributes
+                .iter()
+                .find(|(key, _)| key == "big")
+                .expect("big attribute")
+                .1
+                .len(),
+            200 * 1024
+        );
     }
 
     #[test]

--- a/engine/src/workers/observability/trace_store.rs
+++ b/engine/src/workers/observability/trace_store.rs
@@ -13,7 +13,7 @@
 use super::{config::TraceStorageConfig, otel::InMemorySpanStorage};
 use rusqlite::{Connection, ToSql, params, params_from_iter};
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
     fs,
     path::{Path, PathBuf},
     sync::{
@@ -919,6 +919,7 @@ impl TraceDiskStore {
         self.notify();
     }
 
+    #[cfg(test)]
     pub(crate) fn is_degraded(&self) -> bool {
         self.state
             .lock()
@@ -1010,14 +1011,11 @@ fn persist_dirty_batch(store: &Arc<TraceDiskStore>, connection: &mut Connection)
         return;
     }
 
-    let keys: Vec<(String, String)> = batch
-        .iter()
-        .map(|span| (span.trace_id.clone(), span.span_id.clone()))
-        .collect();
+    let (seqs, spans): (Vec<u64>, Vec<StoredSpan>) = batch.into_iter().unzip();
     for attempt in 0..=RETRY_DELAYS.len() {
-        match write_batch(store, connection, &batch) {
+        match write_batch(store, connection, &spans) {
             Ok(()) => {
-                hot.mark_durable(&keys);
+                hot.mark_durable(&seqs);
                 store.record_success();
                 return;
             }
@@ -1048,12 +1046,9 @@ fn drain_dirty(store: &Arc<TraceDiskStore>, connection: &mut Connection) -> Resu
         if batch.is_empty() {
             return Ok(());
         }
-        let keys: Vec<(String, String)> = batch
-            .iter()
-            .map(|span| (span.trace_id.clone(), span.span_id.clone()))
-            .collect();
-        write_batch(store, connection, &batch)?;
-        hot.mark_durable(&keys);
+        let (seqs, spans): (Vec<u64>, Vec<StoredSpan>) = batch.into_iter().unzip();
+        write_batch(store, connection, &spans)?;
+        hot.mark_durable(&seqs);
         store.record_success();
     }
     Err("shutdown drain reached the bounded batch limit".to_string())
@@ -1064,20 +1059,44 @@ fn write_batch(
     connection: &mut Connection,
     batch: &[StoredSpan],
 ) -> Result<(), String> {
-    let incoming_bytes: u64 = batch.iter().map(approx_span_bytes).sum();
+    // Serialize once: the payload column, the capacity check and the
+    // `approx_bytes` accounting all read the same string.
+    let payloads: Vec<Option<String>> = batch
+        .iter()
+        .map(|span| {
+            if span.pending {
+                return Ok(None);
+            }
+            serde_json::to_string(span)
+                .map(Some)
+                .map_err(|err| format!("cannot serialize trace {}: {err}", span.trace_id))
+        })
+        .collect::<Result<_, String>>()?;
+    let incoming_bytes: u64 = payloads.iter().flatten().map(|p| p.len() as u64).sum();
     ensure_capacity(store, connection, incoming_bytes, batch)?;
     let epoch = store.epoch.load(Ordering::Acquire) as i64;
+    let ingest_time_ns = super::otel::now_unix_nanos() as i64;
     let tx = connection
         .transaction()
         .map_err(|err| database_error(&store.database_path, "write transaction start", err))?;
 
-    for span in batch {
-        if span.pending {
+    // trace_id -> (first_start_ns, last_end_ns) over this batch; the per-trace
+    // aggregate below runs once per trace, not once per span.
+    let mut touched: BTreeMap<&str, (i64, i64)> = BTreeMap::new();
+    for (span, payload) in batch.iter().zip(&payloads) {
+        let Some(payload) = payload else {
             continue;
-        }
-        let payload = serde_json::to_string(span)
-            .map_err(|err| format!("cannot serialize trace {}: {err}", span.trace_id))?;
-        let approx_bytes = approx_span_bytes(span) as i64;
+        };
+        let approx_bytes = payload.len() as i64;
+        let start = span.start_time_unix_nano as i64;
+        let end = span.end_time_unix_nano as i64;
+        touched
+            .entry(span.trace_id.as_str())
+            .and_modify(|(first, last)| {
+                *first = (*first).min(start);
+                *last = (*last).max(end);
+            })
+            .or_insert((start, end));
         tx.execute(
             "INSERT INTO spans (
                 epoch, trace_id, span_id, parent_span_id, name, start_time_ns,
@@ -1108,7 +1127,7 @@ fn write_batch(
                 span.status_description,
                 span.service_name,
                 payload,
-                super::otel::now_unix_nanos() as i64,
+                ingest_time_ns,
                 approx_bytes,
             ],
         )
@@ -1152,29 +1171,31 @@ fn write_batch(
                 )
             })?;
         }
+    }
 
+    // One aggregate per trace touched by the batch. The subqueries walk the
+    // trace's rows once here instead of once per inserted span, which for a
+    // 30k-span trace was the difference between milliseconds and minutes.
+    for (trace_id, (first_start_ns, last_end_ns)) in touched {
         tx.execute(
             "INSERT INTO trace_meta (epoch, trace_id, first_start_ns, last_end_ns, last_ingest_ns, span_count, approx_bytes)
-             VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6)
+             VALUES (
+                ?1, ?2, ?3, ?4, ?5,
+                (SELECT COUNT(*) FROM spans WHERE epoch = ?1 AND trace_id = ?2),
+                (SELECT COALESCE(SUM(approx_bytes), 0) FROM spans WHERE epoch = ?1 AND trace_id = ?2)
+             )
              ON CONFLICT(epoch, trace_id) DO UPDATE SET
                 first_start_ns = MIN(trace_meta.first_start_ns, excluded.first_start_ns),
                 last_end_ns = MAX(trace_meta.last_end_ns, excluded.last_end_ns),
                 last_ingest_ns = excluded.last_ingest_ns,
-                span_count = (SELECT COUNT(*) FROM spans WHERE epoch = excluded.epoch AND trace_id = excluded.trace_id),
-                approx_bytes = (SELECT COALESCE(SUM(approx_bytes), 0) FROM spans WHERE epoch = excluded.epoch AND trace_id = excluded.trace_id)",
-            params![
-                epoch,
-                span.trace_id,
-                span.start_time_unix_nano as i64,
-                span.end_time_unix_nano as i64,
-                super::otel::now_unix_nanos() as i64,
-                approx_bytes,
-            ],
+                span_count = excluded.span_count,
+                approx_bytes = excluded.approx_bytes",
+            params![epoch, trace_id, first_start_ns, last_end_ns, ingest_time_ns],
         )
         .map_err(|err| {
             database_error(
                 &store.database_path,
-                &format!("update metadata for trace '{}'", span.trace_id),
+                &format!("update metadata for trace '{trace_id}'"),
                 err,
             )
         })?;
@@ -1619,12 +1640,6 @@ fn directory_size(directory: &Path) -> std::io::Result<u64> {
     Ok(total)
 }
 
-fn approx_span_bytes(span: &StoredSpan) -> u64 {
-    serde_json::to_vec(span)
-        .map(|payload| payload.len() as u64)
-        .unwrap_or(0)
-}
-
 fn set_private_permissions(path: &Path, directory: bool) -> Result<(), String> {
     #[cfg(unix)]
     {
@@ -1717,6 +1732,9 @@ mod tests {
         config.max_disk_bytes = 512 * 1024 * 1024;
         let store = TraceDiskStore::open(&config).expect("open trace store");
         let hot = Arc::new(InMemorySpanStorage::new_with_limits(512, 64 * 1024 * 1024));
+        // These exercise the DISK cap with multi-MiB payloads: keep the
+        // ingest-time attribute cap out of the way.
+        hot.set_max_attribute_bytes(0);
         store.attach_hot_storage(&hot);
 
         // ~24 MiB of history across distinct traces, oldest ingested first.
@@ -2013,6 +2031,55 @@ mod tests {
         store.shutdown();
     }
 
+    /// The per-trace aggregate runs once per trace touched by a batch, not
+    /// once per span; the counts it leaves behind must still be exact.
+    #[test]
+    fn trace_meta_aggregates_once_per_trace_and_stays_correct() {
+        let directory = tempfile::tempdir().expect("temp trace directory");
+        let store = TraceDiskStore::open(&test_config(directory.path())).expect("open trace store");
+        let hot = Arc::new(InMemorySpanStorage::new_with_limits(64, 16 * 1024 * 1024));
+        store.attach_hot_storage(&hot);
+
+        hot.add_spans(vec![
+            test_span("trace-a", "span-1", "a1"),
+            test_span("trace-a", "span-2", "a2"),
+            test_span("trace-b", "span-1", "b1"),
+            test_span("trace-a", "span-3", "a3"),
+        ]);
+        store.flush().expect("persist first batch");
+        // A later batch touches trace-a again: the aggregate must see all four rows.
+        hot.add_spans(vec![test_span("trace-a", "span-4", "a4")]);
+        store.flush().expect("persist second batch");
+
+        let probe =
+            Connection::open(directory.path().join("traces.sqlite3")).expect("probe connection");
+        let (count, bytes): (i64, i64) = probe
+            .query_row(
+                "SELECT span_count, approx_bytes FROM trace_meta WHERE trace_id = 'trace-a'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("trace-a meta");
+        let expected_bytes: i64 = probe
+            .query_row(
+                "SELECT COALESCE(SUM(approx_bytes), 0) FROM spans WHERE trace_id = 'trace-a'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("trace-a byte sum");
+        assert_eq!(count, 4);
+        assert_eq!(bytes, expected_bytes);
+        let count_b: i64 = probe
+            .query_row(
+                "SELECT span_count FROM trace_meta WHERE trace_id = 'trace-b'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("trace-b meta");
+        assert_eq!(count_b, 1);
+        store.shutdown();
+    }
+
     #[test]
     fn hot_cache_preserves_the_existing_memory_only_eviction_contract() {
         let storage = InMemorySpanStorage::new_with_limits_and_watermark(1, 1_000, 0.75);
@@ -2063,6 +2130,9 @@ mod tests {
         config.max_disk_bytes = 1;
         let store = TraceDiskStore::open(&config).expect("open trace store");
         let hot = Arc::new(InMemorySpanStorage::new_with_limits(16, 20 * 1024 * 1024));
+        // These exercise the DISK cap with multi-MiB payloads: keep the
+        // ingest-time attribute cap out of the way.
+        hot.set_max_attribute_bytes(0);
         store.attach_hot_storage(&hot);
 
         let mut committed = test_span("trace-protected", "span-1", "large");
@@ -2120,6 +2190,9 @@ mod tests {
             );
             let store = TraceDiskStore::open(&test_config(&directory)).expect("open trace store");
             let hot = Arc::new(InMemorySpanStorage::new_with_limits(16, 20 * 1024 * 1024));
+            // These exercise the DISK cap with multi-MiB payloads: keep the
+            // ingest-time attribute cap out of the way.
+            hot.set_max_attribute_bytes(0);
             store.attach_hot_storage(&hot);
 
             let mut span = test_span("trace-file-limit", "span-1", "large");

--- a/engine/tests/trace_storage_e2e.rs
+++ b/engine/tests/trace_storage_e2e.rs
@@ -91,6 +91,9 @@ fn start_archive(config: TraceStorageConfig) -> Arc<InMemorySpanStorage> {
         10_000,
         128 * MIB as u64,
     ));
+    // These tests size spans in MiB to exercise the disk cap; keep the
+    // ingest-time attribute cap out of the way.
+    hot.set_max_attribute_bytes(0);
     trace_store::attach(&hot);
     hot
 }
@@ -526,4 +529,51 @@ fn disk_full_degrades_without_partial_commit_and_keeps_committed_data() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+/// Memory is the hard limit: a burst larger than the hot cache evicts
+/// finalized spans the archive never saw, and says so.
+#[test]
+#[serial]
+fn burst_above_memory_cap_stays_bounded_and_reports_partial() {
+    let _reset = ResetTraceStorage;
+    trace_store::reset();
+    let root = tempfile::tempdir().expect("temp root");
+    trace_store::configure(Some(config(root.path())));
+    assert_eq!(trace_store::status()["archive"], "healthy");
+    let hot = Arc::new(InMemorySpanStorage::new_with_limits(
+        10_000,
+        16 * MIB as u64,
+    ));
+    hot.set_max_attribute_bytes(0);
+    trace_store::attach(&hot);
+
+    // One call holds the lock for the whole burst, so the writer cannot
+    // interleave: most of these 40 MiB-sized spans leave before the archive
+    // ever sees them.
+    let burst: Vec<StoredSpan> = (0..40)
+        .map(|index| {
+            span(
+                &format!("burst-{index:02}"),
+                "span-1",
+                index as u64 + 1,
+                MIB,
+            )
+        })
+        .collect();
+    hot.add_spans(burst);
+
+    assert!(
+        hot.hot_bytes() <= 16 * MIB as u64 + (MIB as u64 * 11 / 10),
+        "hot cache above its cap: {}",
+        hot.hot_bytes()
+    );
+    assert!(hot.len() < 40, "{} spans resident", hot.len());
+    let status = trace_store::status();
+    assert!(
+        status["known_dropped_spans"].as_u64().unwrap_or(0) > 0,
+        "{status}"
+    );
+    assert_eq!(status["completeness"], "partial");
+    trace_store::flush().expect("the survivors still persist");
 }


### PR DESCRIPTION
## Why

During the Linkly e2e re-run (MOT-4717) a burst of ~30k traced invocations in three minutes wedged the engine: one tokio worker at 100 % CPU in userspace for >6 min, the other 35 parked, accept queue full (129/128), `engine.log` silent, every worker reconnect-looping. Full evidence on MOT-4728.

## Root cause

`InMemorySpanStorage::evict_to_capacity` protected `pending` and `dirty` (not-yet-archived) spans from eviction. Once the SQLite writer fell behind, every resident span was protected, so the eviction scan walked the whole deque (two `String` clones per element) for **every** incoming span while `hot_bytes` stayed above the cap forever ("retaining correctness wins over forcing the hot cache below its configured limit"), rebuilt the trace index per evicted span, and JSON-serialized each span 3–5× (`approx_span_size` at ingest + the writer). All of it ran under four `std::sync::RwLock` write guards taken from tracing-layer callbacks (`LiveSpanProcessor::on_start`, `SimpleSpanProcessor` → `InMemorySpanExporter::export`) on whichever runtime thread closed a span. O(n²) with unbounded n, holding the lock every runtime thread needs to create a span → no thread left for the accept loop; the log went silent because the span above each `info!` blocked first.

## What changes

**Behavior (deliberate, confirmed with the team):** the hot cache is a hard-bounded FIFO. Memory wins over durability — finalized spans the archive has not written yet are evicted like any other once `memory_max_bytes` / `max_spans` is hit, and reported through the existing `known_dropped_spans` / `completeness: "partial"` surface instead of pinning the cache. In normal operation the writer keeps up and FIFO only evicts already-durable spans.

- One `RwLock<HotCache>` (`BTreeMap` keyed by a monotonic sequence, per-trace seq lists, pending map, dirty `BTreeSet`, cached per-slot bytes) replaces the four locks. Every operation is O(log n); the critical section takes no other lock and does no size-proportional work. Sanitizing, sizing and the broadcast (only with receivers) happen before the lock; the archive lookup once per call; drop accounting and `notify` after.
- `approx_span_size` is a heap estimate (no serde on the ingest path); the writer serializes each span once and reuses that length for `approx_bytes`.
- `dirty_spans` walks the dirty set (O(batch)) and returns `(seq, span)`; the writer acknowledges by sequence. `expire_pending` is O(pending). `clear()` keeps counting sequences so a stale writer batch can never acknowledge a newer span.
- `trace_meta` aggregates once per trace touched by a batch instead of once per span (two correlated subqueries per span was O(k²) per trace — the runaway trace had 29.7k spans).
- New `trace_storage.max_attribute_bytes` (default 64 KiB, `0` = off, hot-reloadable) caps attribute values at ingest; a cut `iii.payload.json` sets `iii.payload.truncated` so readers see one signal whether the SDK or the engine cut it.
- Health `spans` details gain `dirty_backlog_spans`. README documents every `trace_storage.*` knob (none was documented before); changelog bullet under 0.23.0 Observability.

## Tests

- New: `hot_cache_stays_bounded_and_fast_when_nothing_is_marked_durable` (50k inserts, cache stays under the byte cap, finishes in linear time), `expired_pending_then_final_appends_fresh_and_sequences_survive_clear`, `long_attribute_values_are_truncated_and_flagged`, `trace_meta_aggregates_once_per_trace_and_stays_correct`, e2e `burst_above_memory_cap_stays_bounded_and_reports_partial`.
- Adjusted: the disk-cap tests size spans in MiB and now disable the attribute cap; tests that peeked at `pending_span_ids` use `pending_trace_ids()`.
- `SKIP_UI_BUILD=1 cargo test -p iii --lib` 1764/1764; `--test trace_storage_e2e` 23/23, `--test observability_configuration_e2e` 13/13, `--test otel_ws_no_worker_registration_test` 1/1. Clippy adds no warnings in the touched files.

## Follow-ups (on MOT-4728)

`ensure_capacity`/`VACUUM` on the writer thread; `TraceDiskStore::status()` walking the directory under `state` on every traces response; `get_spans()` cloning the whole cache per request; the unbounded window in `run_trace_trigger_subscriber`; SDK default for `III_TRACE_PAYLOAD_MAX_BYTES`; a UI input for the new knob.

MOT-4728

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded trace storage to prevent unbounded memory growth during high-volume ingestion.
  * Added reporting for evicted spans through `known_dropped_spans` with partial completeness status.
  * Added the `dirty_backlog_spans` health-check metric.
  * Added configurable attribute-size limits, defaulting to 64 KiB, with truncation indicators for oversized payloads.
* **Documentation**
  * Documented trace-storage limits, retention, SQLite archiving, and attribute truncation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->