### PR TITLE
(MOT-4712) feat(engine): allow_dynamic_port on iii-worker-manager

### DIFF
--- a/engine/src/workers/config.rs
+++ b/engine/src/workers/config.rs
@@ -2350,6 +2350,54 @@ modules:
     }
 
     #[tokio::test]
+    async fn worker_manager_moves_to_a_free_port_only_when_allowed() {
+        let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve port");
+        let port = occupied.local_addr().expect("local addr").port();
+
+        for (allow, expect_ok) in [(false, false), (true, true)] {
+            let builder = EngineBuilder::new()
+                .add_worker(
+                    "iii-worker-manager",
+                    Some(serde_json::json!({
+                        "host": "127.0.0.1",
+                        "port": port,
+                        "allow_dynamic_port": allow,
+                    })),
+                )
+                .build()
+                .await
+                .expect("build should succeed");
+
+            let manager = builder
+                .running()
+                .iter()
+                .find(|rw| rw.entry.name == "iii-worker-manager")
+                .expect("iii-worker-manager should be running");
+
+            let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+            let result = manager
+                .worker
+                .start_background_tasks(shutdown_rx, shutdown_tx.clone())
+                .await;
+            let _ = shutdown_tx.send(true);
+            std::mem::forget(shutdown_tx);
+
+            assert_eq!(
+                result.is_ok(),
+                expect_ok,
+                "allow_dynamic_port={allow}: {result:?}"
+            );
+            if !expect_ok {
+                let message = result.err().map(|e| e.to_string()).unwrap_or_default();
+                assert!(
+                    message.contains(&format!("127.0.0.1:{port}")),
+                    "unexpected error message: {message}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn engine_builder_reports_worker_name_on_stream_bind_failure() {
         let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve port");
         let port = occupied.local_addr().expect("local addr").port();

--- a/engine/src/workers/worker/mod.rs
+++ b/engine/src/workers/worker/mod.rs
@@ -77,6 +77,13 @@ pub struct WorkerManagerConfig {
     /// are closed and logged instead of leaking the fd (MOT-3967).
     #[serde(default = "default_handshake_timeout_ms")]
     pub handshake_timeout_ms: u64,
+    /// When `port` is already in use, bind an OS-assigned free port instead
+    /// of failing. The chosen address is logged at warn level; nothing else
+    /// is told, so anything that connects must read it from the log. Off by
+    /// default: a listener that silently moves breaks every `III_URL` that
+    /// points at the declared port.
+    #[serde(default)]
+    pub allow_dynamic_port: bool,
 }
 
 fn default_port() -> u16 {
@@ -99,6 +106,7 @@ impl Default for WorkerManagerConfig {
             middleware_function_id: None,
             rbac: None,
             handshake_timeout_ms: default_handshake_timeout_ms(),
+            allow_dynamic_port: false,
         }
     }
 }
@@ -142,9 +150,27 @@ impl Worker for WorkerManager {
         };
 
         let addr = format!("{}:{}", config.host, config.port);
-        let listener = TcpListener::bind(&addr)
-            .await
-            .map_err(|err| crate::workers::traits::bind_address_error(&addr, err))?;
+        let listener = match TcpListener::bind(&addr).await {
+            Ok(listener) => listener,
+            Err(err)
+                if config.allow_dynamic_port && err.kind() == std::io::ErrorKind::AddrInUse =>
+            {
+                let dynamic = format!("{}:0", config.host);
+                let listener = TcpListener::bind(&dynamic)
+                    .await
+                    .map_err(|err| crate::workers::traits::bind_address_error(&dynamic, err))?;
+                let chosen = listener.local_addr()?;
+                tracing::warn!(
+                    declared = %addr,
+                    chosen = %chosen,
+                    "declared address is in use; allow_dynamic_port moved the listener. \
+                     Point III_URL and `iii trigger --engine` at the chosen address"
+                );
+                listener
+            }
+            Err(err) => return Err(crate::workers::traits::bind_address_error(&addr, err)),
+        };
+        let addr = listener.local_addr()?.to_string();
         tracing::info!("Engine listening on address: {}", addr.purple());
 
         let app = Router::new()
@@ -397,6 +423,14 @@ mod tests {
         assert!(config.middleware_function_id.is_none());
         assert!(config.rbac.is_none());
         assert_eq!(config.handshake_timeout_ms, DEFAULT_HANDSHAKE_TIMEOUT_MS);
+        assert!(!config.allow_dynamic_port);
+    }
+
+    #[test]
+    fn worker_config_allow_dynamic_port_is_opt_in() {
+        let config: WorkerManagerConfig =
+            serde_json::from_str(r#"{"allow_dynamic_port":true}"#).unwrap();
+        assert!(config.allow_dynamic_port);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- New `allow_dynamic_port` key on the `iii-worker-manager` config. Default `false`.
- When `true` and the declared `host:port` is already in use, the listener binds `host:0` and the OS assigns a free port. Any other bind error still fails as before.
- The chosen address is logged at warn level next to the declared one, and the `Engine listening on address` line shows the real address. Nothing is published elsewhere: whoever connects must point `III_URL` or `iii trigger --engine` at the logged address.

```yaml
- name: iii-worker-manager
  config:
    port: 49134
    allow_dynamic_port: true
```

## Test plan
- [x] `WorkerManagerConfig` defaults to `false`, opt-in parses
- [x] Lifecycle test: with an occupied port, `start_background_tasks` fails when `false` and succeeds when `true`
- [ ] Manual: start two engines with the same declared port, second logs the moved address

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting that allows the worker manager to select an available port when the configured port is occupied.

* **Bug Fixes**
  * Worker startup now continues with an automatically assigned port when dynamic port selection is enabled.
  * Startup still reports the configured address when dynamic port selection is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->