### PR TITLE
(MOT-4732) fix(engine): forward a null function result as null, not as no result

### DIFF
--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -43,6 +43,9 @@ type: "reference"
 
   ## Reliability
 
+  - A function that returns `null` now reaches its caller as `null`. The engine used to drop the
+    field on the way through, so the Node SDK resolved `undefined` and a strict `=== null` check on
+    a `state::get` miss never fired. The Python SDK keeps a `None` return on the wire the same way.
   - Improved queue routing across namespaces.
   - Improved trace archive cleanup and summary pagination.
   - Reduced CLI telemetry traffic.

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -4459,6 +4459,97 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_null_result_from_the_executor_reaches_the_caller_as_null() {
+        // A worker-routed function (state::get on a missing key) answers
+        // `"result": null`. The caller must receive `null`, not an omitted
+        // field: the TS SDK resolves an omitted field as `undefined` and a
+        // strict `=== null` check never fires (MOT-4732).
+        ensure_default_meter();
+        let engine = Engine::new();
+        let (tx, mut rx) = mpsc::channel::<Outbound>(8);
+        let worker = WorkerConnection::new(tx);
+
+        engine
+            .router_msg(
+                &worker,
+                &Message::RegisterFunction {
+                    id: "kv::get".to_string(),
+                    description: None,
+                    request_format: None,
+                    response_format: None,
+                    metadata: None,
+                    invocation: None,
+                },
+            )
+            .await
+            .expect("register");
+
+        let caller_invocation_id = uuid::Uuid::new_v4();
+        engine
+            .router_msg(
+                &worker,
+                &Message::InvokeFunction {
+                    invocation_id: Some(caller_invocation_id),
+                    function_id: "kv::get".to_string(),
+                    data: json!({ "key": "missing" }),
+                    traceparent: None,
+                    baggage: None,
+                    action: None,
+                    metadata: None,
+                    namespace: None,
+                },
+            )
+            .await
+            .expect("invoke");
+
+        // The executor side of the same worker receives the dispatch.
+        let dispatched = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for the dispatch")
+            .expect("channel open");
+        let executor_invocation_id = match dispatched {
+            Outbound::Protocol(Message::InvokeFunction {
+                invocation_id: Some(id),
+                ..
+            }) => id,
+            other => panic!("expected InvokeFunction, got {other:?}"),
+        };
+
+        // Reply exactly as the wire carries it: the frame says `null`.
+        let frame = format!(
+            r#"{{"type":"invocationresult","invocation_id":"{executor_invocation_id}","function_id":"kv::get","result":null}}"#
+        );
+        let reply: Message = serde_json::from_str(&frame).expect("frame parses");
+        engine.router_msg(&worker, &reply).await.expect("reply");
+
+        let answered = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for the caller's result")
+            .expect("channel open");
+        match &answered {
+            Outbound::Protocol(Message::InvocationResult {
+                invocation_id,
+                result,
+                error,
+                ..
+            }) => {
+                assert_eq!(*invocation_id, caller_invocation_id);
+                assert_eq!(*result, Some(serde_json::Value::Null));
+                assert!(error.is_none());
+            }
+            other => panic!("expected InvocationResult, got {other:?}"),
+        }
+        let Outbound::Protocol(message) = answered else {
+            unreachable!()
+        };
+        let wire = serde_json::to_string(&message).expect("serializes");
+        assert!(
+            wire.contains(r#""result":null"#),
+            "caller must see null: {wire}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_router_msg_invoke_function_success_sends_invocation_result() {
         ensure_default_meter();
         let engine = Engine::new();

--- a/engine/src/engine/mod.rs
+++ b/engine/src/engine/mod.rs
@@ -4460,10 +4460,6 @@ mod tests {
 
     #[tokio::test]
     async fn a_null_result_from_the_executor_reaches_the_caller_as_null() {
-        // A worker-routed function (state::get on a missing key) answers
-        // `"result": null`. The caller must receive `null`, not an omitted
-        // field: the TS SDK resolves an omitted field as `undefined` and a
-        // strict `=== null` check never fires (MOT-4732).
         ensure_default_meter();
         let engine = Engine::new();
         let (tx, mut rx) = mpsc::channel::<Outbound>(8);

--- a/engine/src/protocol.rs
+++ b/engine/src/protocol.rs
@@ -88,9 +88,8 @@ pub enum TriggerAction {
     Void,
 }
 
-/// Deserialize a field that is present as `Some(value)` even when the value is
-/// `null`. Pair with `#[serde(default)]` so an absent field still reads as
-/// `None`; the pair keeps "returned null" and "returned nothing" distinct.
+/// Deserialize a present field as `Some(value)` even when the value is `null`.
+/// Pair with `#[serde(default)]` so an absent field still reads as `None`.
 fn deserialize_present<'de, D>(deserializer: D) -> Result<Option<Value>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -194,12 +193,9 @@ pub enum Message {
     InvocationResult {
         invocation_id: Uuid,
         function_id: String,
-        /// The executor's return value. `"result": null` (a handler that
-        /// returned null) and an absent field (a handler that returned
-        /// nothing) are different answers: `state::get` on a missing key is
-        /// `null`, and a TypeScript caller checks `=== null`. serde folds a
-        /// JSON `null` into `None` by default, which would forward the miss
-        /// with the field omitted and the caller would see `undefined`.
+        /// The executor's return value. `"result": null` (returned null) and
+        /// an absent field (returned nothing) are different answers, and the
+        /// caller distinguishes them: `state::get` on a miss is `null`.
         #[serde(
             default,
             deserialize_with = "deserialize_present",

--- a/engine/src/protocol.rs
+++ b/engine/src/protocol.rs
@@ -88,6 +88,16 @@ pub enum TriggerAction {
     Void,
 }
 
+/// Deserialize a field that is present as `Some(value)` even when the value is
+/// `null`. Pair with `#[serde(default)]` so an absent field still reads as
+/// `None`; the pair keeps "returned null" and "returned nothing" distinct.
+fn deserialize_present<'de, D>(deserializer: D) -> Result<Option<Value>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Value::deserialize(deserializer).map(Some)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum Message {
@@ -184,7 +194,17 @@ pub enum Message {
     InvocationResult {
         invocation_id: Uuid,
         function_id: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
+        /// The executor's return value. `"result": null` (a handler that
+        /// returned null) and an absent field (a handler that returned
+        /// nothing) are different answers: `state::get` on a missing key is
+        /// `null`, and a TypeScript caller checks `=== null`. serde folds a
+        /// JSON `null` into `None` by default, which would forward the miss
+        /// with the field omitted and the caller would see `undefined`.
+        #[serde(
+            default,
+            deserialize_with = "deserialize_present",
+            skip_serializing_if = "Option::is_none"
+        )]
         result: Option<Value>,
         #[serde(skip_serializing_if = "Option::is_none")]
         error: Option<ErrorBody>,
@@ -332,6 +352,39 @@ mod tests {
         invocation::{auth::HttpAuthConfig, method::HttpMethod},
         protocol::HttpInvocationRef,
     };
+
+    #[test]
+    fn invocation_result_null_stays_null_and_absent_stays_absent() {
+        let id = "8d3c6f9e-0f4b-4e6a-9c1d-2b3a4c5d6e7f";
+        let with_null = format!(
+            r#"{{"type":"invocationresult","invocation_id":"{id}","function_id":"state::get","result":null}}"#
+        );
+        let message: Message = serde_json::from_str(&with_null).expect("null result parses");
+        let Message::InvocationResult { result, error, .. } = &message else {
+            panic!("unexpected variant");
+        };
+        assert_eq!(result, &Some(serde_json::Value::Null));
+        assert!(error.is_none());
+        let wire = serde_json::to_string(&message).expect("serializes");
+        assert!(
+            wire.contains(r#""result":null"#),
+            "null must stay on the wire: {wire}"
+        );
+
+        let absent = format!(
+            r#"{{"type":"invocationresult","invocation_id":"{id}","function_id":"fire::forget"}}"#
+        );
+        let message: Message = serde_json::from_str(&absent).expect("absent result parses");
+        let Message::InvocationResult { result, .. } = &message else {
+            panic!("unexpected variant");
+        };
+        assert_eq!(result, &None);
+        let wire = serde_json::to_string(&message).expect("serializes");
+        assert!(
+            !wire.contains(r#""result""#),
+            "absent must stay absent: {wire}"
+        );
+    }
 
     #[test]
     fn deserialize_unregister_trigger_without_type() {

--- a/sdk/packages/node/iii/tests/invocation-result-null.test.ts
+++ b/sdk/packages/node/iii/tests/invocation-result-null.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { registerWorker } from '../src/iii'
+import { MessageType } from '../src/iii-types'
+
+/**
+ * `null` and "no result" are different answers (MOT-4732). `state::get` on a
+ * missing key is `null`; the engine forwards it as `"result": null` and the
+ * SDK must resolve `null` so the natural `=== null` check fires. A handler
+ * that returned nothing omits the field, and that still resolves `undefined`.
+ */
+type InternalSdk = {
+  trigger: (request: Record<string, unknown>) => Promise<unknown>
+  onMessage: (data: string) => void
+  sendMessage: ReturnType<typeof vi.fn>
+  shutdown: () => Promise<void>
+}
+
+function makeSdk(): InternalSdk {
+  return registerWorker('ws://127.0.0.1:0', {
+    enableMetricsReporting: false,
+    reconnectionConfig: { maxRetries: 0 },
+  }) as unknown as InternalSdk
+}
+
+function answer(sdk: InternalSdk, pending: Promise<unknown>, reply: Record<string, unknown>) {
+  const invoke = sdk.sendMessage.mock.calls.find(([type]) => type === MessageType.InvokeFunction)
+  expect(invoke).toBeDefined()
+  const { invocation_id, function_id } = invoke?.[1] as { invocation_id: string; function_id: string }
+  sdk.onMessage(
+    JSON.stringify({ type: MessageType.InvocationResult, invocation_id, function_id, ...reply }),
+  )
+  return pending
+}
+
+describe('invocation result: null vs absent', () => {
+  let sdk: InternalSdk
+
+  afterEach(async () => {
+    await sdk.shutdown()
+  })
+
+  it('resolves null when the frame carries "result": null', async () => {
+    sdk = makeSdk()
+    sdk.sendMessage = vi.fn()
+
+    const pending = sdk.trigger({ function_id: 'state::get', payload: { scope: 's', key: 'missing' } })
+
+    await expect(answer(sdk, pending, { result: null })).resolves.toBeNull()
+  })
+
+  it('resolves undefined when the frame omits result', async () => {
+    sdk = makeSdk()
+    sdk.sendMessage = vi.fn()
+
+    const pending = sdk.trigger({ function_id: 'side::effect', payload: {} })
+
+    await expect(answer(sdk, pending, {})).resolves.toBeUndefined()
+  })
+
+  it('sends "result": null when a handler returns null, and omits it for undefined', async () => {
+    sdk = makeSdk()
+    sdk.sendMessage = vi.fn()
+    const internal = sdk as unknown as {
+      registerFunction: (id: string, handler: () => Promise<unknown>) => unknown
+      onInvokeFunction: (invocation_id: string, function_id: string, input: unknown) => Promise<unknown>
+    }
+    internal.registerFunction('kv::get', async () => null)
+    internal.registerFunction('kv::touch', async () => undefined)
+
+    await internal.onInvokeFunction('inv-null', 'kv::get', {})
+    await internal.onInvokeFunction('inv-void', 'kv::touch', {})
+
+    const replies = sdk.sendMessage.mock.calls
+      .filter(([type]) => type === MessageType.InvocationResult)
+      .map(([, message]) => message as Record<string, unknown>)
+    const forNull = replies.find((m) => m.invocation_id === 'inv-null')
+    const forVoid = replies.find((m) => m.invocation_id === 'inv-void')
+    expect(forNull).toMatchObject({ result: null })
+    expect(JSON.stringify(forNull)).toContain('"result":null')
+    expect(JSON.stringify(forVoid)).not.toContain('result')
+  })
+})

--- a/sdk/packages/node/iii/tests/state.test.ts
+++ b/sdk/packages/node/iii/tests/state.test.ts
@@ -80,7 +80,10 @@ describe('State Operations', () => {
         payload: { scope, key: 'non-existent-item' },
       })
 
-      expect(result).toBeUndefined()
+      // The state worker answers `null` for a miss and the engine forwards it
+      // as-is (MOT-4732); `undefined` is reserved for functions that return
+      // nothing.
+      expect(result).toBeNull()
     })
   })
 
@@ -93,7 +96,7 @@ describe('State Operations', () => {
       await iii.trigger({ function_id: 'state::delete', payload: { scope, key } })
       await expect(
         iii.trigger({ function_id: 'state::get', payload: { scope, key } }),
-      ).resolves.toBeUndefined()
+      ).resolves.toBeNull()
     })
 
     it('should handle deleting non-existent item gracefully', async () => {

--- a/sdk/packages/node/iii/tests/state.test.ts
+++ b/sdk/packages/node/iii/tests/state.test.ts
@@ -80,9 +80,7 @@ describe('State Operations', () => {
         payload: { scope, key: 'non-existent-item' },
       })
 
-      // The state worker answers `null` for a miss and the engine forwards it
-      // as-is (MOT-4732); `undefined` is reserved for functions that return
-      // nothing.
+      // A miss is `null`; `undefined` is reserved for returning nothing.
       expect(result).toBeNull()
     })
   })

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -533,6 +533,14 @@ class III:
             data: dict[str, Any] = msg.model_dump(by_alias=True, exclude_none=True)
             if "type" in data and hasattr(data["type"], "value"):
                 data["type"] = data["type"].value
+            # A handler that returned None answered `null`, not "nothing":
+            # keep it on the wire so a TypeScript caller sees null instead
+            # of undefined (MOT-4732). Error replies never set `result`.
+            if (
+                isinstance(msg, InvocationResultMessage)
+                and "result" in msg.model_fields_set
+            ):
+                data.setdefault("result", None)
             return data
         return {"data": msg}
 

--- a/sdk/packages/python/iii/src/iii/iii.py
+++ b/sdk/packages/python/iii/src/iii/iii.py
@@ -533,9 +533,6 @@ class III:
             data: dict[str, Any] = msg.model_dump(by_alias=True, exclude_none=True)
             if "type" in data and hasattr(data["type"], "value"):
                 data["type"] = data["type"].value
-            # A handler that returned None answered `null`, not "nothing":
-            # keep it on the wire so a TypeScript caller sees null instead
-            # of undefined (MOT-4732). Error replies never set `result`.
             if (
                 isinstance(msg, InvocationResultMessage)
                 and "result" in msg.model_fields_set

--- a/sdk/packages/python/iii/tests/test_invocation_result_wire.py
+++ b/sdk/packages/python/iii/tests/test_invocation_result_wire.py
@@ -1,0 +1,46 @@
+"""Wire shape of InvocationResult replies (MOT-4732).
+
+A handler that returns ``None`` answered ``null``; the engine forwards that to
+the caller as ``"result": null``. Dropping the key would reach a TypeScript
+caller as ``undefined`` and break the natural ``=== null`` check.
+"""
+
+from __future__ import annotations
+
+from iii.iii import III
+from iii.iii_types import InvocationResultMessage
+
+
+def _wire(msg: InvocationResultMessage) -> dict[str, object]:
+    return III.__new__(III)._to_dict(msg)
+
+
+def test_none_result_is_sent_as_null() -> None:
+    wire = _wire(
+        InvocationResultMessage(invocation_id="inv-1", function_id="kv::get", result=None)
+    )
+
+    assert "result" in wire
+    assert wire["result"] is None
+    assert "error" not in wire
+
+
+def test_value_result_is_untouched() -> None:
+    wire = _wire(
+        InvocationResultMessage(invocation_id="inv-1", function_id="kv::get", result={"a": 1})
+    )
+
+    assert wire["result"] == {"a": 1}
+
+
+def test_error_reply_has_no_result_key() -> None:
+    wire = _wire(
+        InvocationResultMessage(
+            invocation_id="inv-1",
+            function_id="kv::get",
+            error={"code": "invocation_failed", "message": "boom"},
+        )
+    )
+
+    assert "result" not in wire
+    assert wire["error"] == {"code": "invocation_failed", "message": "boom"}


### PR DESCRIPTION
Closes [MOT-4732](https://linear.app/motia/issue/MOT-4732)

## Problem

`state::get` on a missing key answers `null`. `InvocationResult.result` is `Option<Value>`, and serde folds a JSON `null` into `None`, so the engine forwarded the reply with the field omitted and the Node SDK resolved `undefined`. The Linkly agent's natural `if (existing === null)` never matched and one `link::create` spun on `state::get` at ~575 calls/s: the span storms behind MOT-4728 and run-3 finding F-R3-1.

## Fix

- **engine** (`protocol.rs`): `result` deserializes through `deserialize_present` together with `#[serde(default)]`, so a present `null` is `Some(Value::Null)` and only an absent field is `None`. Serialization is unchanged: `Some(Null)` goes out as `"result": null`, `None` stays omitted, so a void reply still resolves `undefined` in Node.
- **python sdk**: `_to_dict` keeps an explicit `result=None` on the wire instead of dropping it through `exclude_none`. Error replies never set `result` and are untouched.
- **node sdk**: no code change; regression tests pin both directions (frame → promise, handler → frame).
- Checked the other SDKs: Rust `trigger` already does `unwrap_or(Value::Null)`; Go marshals a `nil` return as `null` inside `json.RawMessage`.

## Tests

- `protocol::tests::invocation_result_null_stays_null_and_absent_stays_absent`
- `engine::tests::a_null_result_from_the_executor_reaches_the_caller_as_null`: a worker replies with a raw `"result": null` frame; the caller's frame carries `"result":null`.
- Node `tests/invocation-result-null.test.ts` (3 tests), Python `tests/test_invocation_result_wire.py` (3 tests).

## Live check

Release build of this branch, iii-sdk 0.23.0 worker registering three functions and triggering them:

```
probe::null:  typeof=object    ===null=true   json=null
probe::void:  typeof=undefined ===null=false  json=undefined
probe::value: typeof=object    ===null=false  json={"ok":true}
```

Before (main, from the ticket): `typeof: undefined | r === null: false`.

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Explicit `null` invocation results are now preserved and delivered to callers as `null`.
  - Missing results remain distinguishable from explicit `null` values.
  - State lookups for missing items now consistently return `null`.
  - Python responses preserve `None` as `null`, while error responses remain unchanged.

- **Documentation**
  - Added a changelog entry describing improved reliability for null-valued invocation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->