### PR TITLE
(MOT-4725) docs(linkly): pin the Ch. 4 analytics table name in the agentic prompt

### DIFF
--- a/docs/next/tutorials/linkly/agentic.mdx
+++ b/docs/next/tutorials/linkly/agentic.mdx
@@ -375,15 +375,16 @@ Make redirects fast and add analytics.
 - Define a standard "clicks" queue with queue::define and enqueue click records instead of writing them inline on the redirect path.
 - Add the pubsub worker. link::create publishes a link.created event.
 - Add a second SQLite database named "analytics" for the analytics worker.
-- Create a Python analytics worker that subscribes to link.created and counts links per day, and add
-  it with compose.
+- Create a Python analytics worker that subscribes to link.created and counts links per day in a
+  daily_link_counts table (day TEXT PRIMARY KEY, count INTEGER NOT NULL) in the analytics database,
+  and add it with compose.
 - Add link::update and a PUT /links/:code route, publish link.updated durably, and refresh the cache
   from a durable subscriber.
 
 Add the pubsub worker and the second database yourself first, then split the rest across two
 subagents that work on separate files at the same time:
-- Subagent A: the Python analytics worker (subscribe to link.created, count links per day, write to
-  the analytics database) and add it with compose.
+- Subagent A: the Python analytics worker (subscribe to link.created, count links per day, write the
+  daily_link_counts rows to the analytics database) and add it with compose.
 - Subagent B: the link worker changes in link/src/index.ts (define and enqueue the clicks queue,
   publish link.created, add link::update with the PUT /links/:code route, publish link.updated
   durably, and refresh the cache from a durable subscriber).

--- a/docs/next/tutorials/linkly/agentic.mdx.skill.md
+++ b/docs/next/tutorials/linkly/agentic.mdx.skill.md
@@ -373,15 +373,16 @@ Make redirects fast and add analytics.
 - Define a standard "clicks" queue with queue::define and enqueue click records instead of writing them inline on the redirect path.
 - Add the pubsub worker. link::create publishes a link.created event.
 - Add a second SQLite database named "analytics" for the analytics worker.
-- Create a Python analytics worker that subscribes to link.created and counts links per day, and add
-  it with compose.
+- Create a Python analytics worker that subscribes to link.created and counts links per day in a
+  daily_link_counts table (day TEXT PRIMARY KEY, count INTEGER NOT NULL) in the analytics database,
+  and add it with compose.
 - Add link::update and a PUT /links/:code route, publish link.updated durably, and refresh the cache
   from a durable subscriber.
 
 Add the pubsub worker and the second database yourself first, then split the rest across two
 subagents that work on separate files at the same time:
-- Subagent A: the Python analytics worker (subscribe to link.created, count links per day, write to
-  the analytics database) and add it with compose.
+- Subagent A: the Python analytics worker (subscribe to link.created, count links per day, write the
+  daily_link_counts rows to the analytics database) and add it with compose.
 - Subagent B: the link worker changes in link/src/index.ts (define and enqueue the clicks queue,
   publish link.created, add link::update with the PUT /links/:code route, publish link.updated
   durably, and refresh the cache from a durable subscriber).


### PR DESCRIPTION
Part of [MOT-4725](https://linear.app/motia/issue/MOT-4725) (T11).

Ch. 4's agentic try-it reads `SELECT day, count FROM daily_link_counts`, but the prompt only asked for "links per day". Run 3's agent created `links_per_day`, so the documented query failed with `no such table: daily_link_counts`. The prompt now names the table and its columns (`daily_link_counts (day TEXT PRIMARY KEY, count INTEGER NOT NULL)`) both in the top-level bullet and in Subagent A's brief, matching the exploration path's schema in `durable-execution.mdx`.

`agentic.mdx.skill.md` re-rendered with iii-skill-render v0.4.32; `iii-skill-check verify-rendered docs/next` passes.

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the Chapter 4 Agentic Linkly tutorial to specify that the Python analytics worker records daily link counts in the `daily_link_counts` table.
  - Documented the table schema, including the day and count fields.
  - Updated the Subagent A description to state that it writes daily link-count records to the analytics database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->