### PR TITLE
(MOT-4733) fix(engine): return freed heap to the OS after span bursts

### DIFF
--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -40,6 +40,8 @@ type: "reference"
     and the health check exposes `dirty_backlog_spans`.
   - Attribute values are capped at ingest (`trace_storage.max_attribute_bytes`, default 64 KiB);
     a cut `iii.payload.json` sets `iii.payload.truncated`.
+  - On Linux with glibc the engine returns freed heap to the OS once a minute, so its memory
+    follows the bounded span cache instead of staying at the last burst's peak.
 
   ## Reliability
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -13,6 +13,7 @@ pub mod function;
 pub mod invocation;
 mod legacy_worker_functions;
 pub mod logging;
+pub mod memory;
 pub mod protocol;
 pub mod services;
 pub mod telemetry;

--- a/engine/src/memory.rs
+++ b/engine/src/memory.rs
@@ -1,0 +1,55 @@
+//! Give freed heap back to the operating system.
+//!
+//! glibc malloc keeps freed chunks inside its per-thread arenas and only
+//! returns the top of the main arena on its own. After a burst of small
+//! allocations, such as a span storm churning through the bounded hot span
+//! cache, the process keeps its peak RSS long after the live data is back
+//! under its cap: one Linkly run left the engine at 14 GB with 236 MB of
+//! spans in memory (MOT-4733). `malloc_trim(0)` walks every arena and
+//! `madvise`s the freed pages away, so the observability sweep calls
+//! [`release_freed_memory`] once a minute.
+
+/// Resident set size of this process in bytes, read from `/proc/self/statm`.
+/// `None` where that file does not exist.
+pub fn resident_bytes() -> Option<u64> {
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+    Some(pages * page_size())
+}
+
+#[cfg(unix)]
+fn page_size() -> u64 {
+    // SAFETY: sysconf has no preconditions and only reads a constant.
+    let size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if size > 0 { size as u64 } else { 4096 }
+}
+
+#[cfg(not(unix))]
+fn page_size() -> u64 {
+    4096
+}
+
+/// Return freed heap pages to the OS. Returns the RSS before and after the
+/// trim, in bytes, on Linux with glibc; `None` where the allocator already
+/// releases memory on its own (musl, macOS, Windows) or RSS cannot be read.
+///
+/// Cheap on a small heap. On a heap that just churned through gigabytes it
+/// takes an arena lock at a time while it `madvise`s, so call it off the
+/// async executor.
+pub fn release_freed_memory() -> Option<(u64, u64)> {
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    {
+        let before = resident_bytes()?;
+        // SAFETY: malloc_trim only touches allocator bookkeeping; it is safe
+        // to call from any thread at any time.
+        unsafe {
+            libc::malloc_trim(0);
+        }
+        let after = resident_bytes()?;
+        Some((before, after))
+    }
+    #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+    {
+        None
+    }
+}

--- a/engine/src/memory.rs
+++ b/engine/src/memory.rs
@@ -1,3 +1,9 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+// This software is patent protected. We welcome discussions - reach out at team@iii.dev
+// See LICENSE and PATENTS files for details.
+
 //! Give freed heap back to the operating system.
 //!
 //! glibc malloc keeps freed chunks inside its per-thread arenas and only

--- a/engine/src/workers/observability/mod.rs
+++ b/engine/src/workers/observability/mod.rs
@@ -4047,6 +4047,21 @@ impl Worker for ObservabilityWorker {
                                 archive.mark_degraded(error);
                             }
                         }
+                        // The hot cache is bounded, but glibc keeps the pages
+                        // its churn freed. Hand them back so RSS follows the
+                        // cache instead of the last burst (MOT-4733).
+                        if let Ok(Some((before, after))) =
+                            tokio::task::spawn_blocking(crate::memory::release_freed_memory).await
+                        {
+                            let released = before.saturating_sub(after);
+                            if released >= 64 << 20 {
+                                tracing::info!(
+                                    released_mb = released >> 20,
+                                    rss_mb = after >> 20,
+                                    "returned freed heap to the OS"
+                                );
+                            }
+                        }
                     }
                 }
             }

--- a/engine/tests/memory_trim.rs
+++ b/engine/tests/memory_trim.rs
@@ -1,0 +1,42 @@
+//! `release_freed_memory` must hand fragmented, freed heap back to the OS
+//! (MOT-4733). Lives in its own test binary so no other test's allocations
+//! move the RSS readings.
+#![cfg(all(target_os = "linux", target_env = "gnu"))]
+
+use iii::memory::{release_freed_memory, resident_bytes};
+
+const MIB: u64 = 1 << 20;
+
+#[test]
+fn trim_returns_fragmented_freed_heap_to_the_os() {
+    // 16 KiB chunks sit below glibc's mmap threshold, so they live inside the
+    // arenas like span payloads do. Freeing every other one leaves the heap
+    // fragmented the way a span storm does: no top chunk to trim, and glibc
+    // keeps every page resident until something calls malloc_trim.
+    const CHUNK: usize = 16 * 1024;
+    const COUNT: usize = 32 * 1024; // 512 MiB live at the peak
+
+    let baseline = resident_bytes().expect("statm readable");
+    let mut chunks: Vec<Option<Vec<u8>>> = (0..COUNT)
+        .map(|i| Some(vec![(i & 0xff) as u8; CHUNK]))
+        .collect();
+    let peak = resident_bytes().expect("statm readable");
+    assert!(
+        peak - baseline >= 400 * MIB,
+        "allocation should be resident: baseline {baseline} peak {peak}"
+    );
+
+    for slot in chunks.iter_mut().step_by(2) {
+        *slot = None;
+    }
+    let after_free = resident_bytes().expect("statm readable");
+
+    let (before, after) = release_freed_memory().expect("glibc target");
+    assert!(
+        after_free.saturating_sub(after) >= 128 * MIB,
+        "trim should release most of the 256 MiB freed: after_free {after_free} before {before} after {after}"
+    );
+
+    // The live half is intact.
+    assert!(chunks.iter().flatten().all(|c| c.len() == CHUNK));
+}


### PR DESCRIPTION
Closes [MOT-4733](https://linear.app/motia/issue/MOT-4733). Follow-up of MOT-4728 (#2154).

## Problem

With the hot span cache bounded, the Linkly run-3 span storm (109k spans in 94 s, 1.47 M dropped) no longer wedged the engine, but the process sat at 14 GB RSS for the rest of the run with 236 MB of spans in memory and 0 % CPU at idle.

`/proc/<pid>/smaps` of that engine: no anonymous mapping above 200 MB; 7.6 GB spread over 159 mappings of ≤ 64 MB and 6.4 GB over 50 mappings between 64 MB and 1 GB. That is the shape of glibc malloc arenas holding freed chunks, not a live structure. glibc only trims the top of the main arena on its own; fragmented free pages inside the arenas stay resident until something calls `malloc_trim`.

## Fix

- `engine/src/memory.rs`: `release_freed_memory()` calls `malloc_trim(0)` on Linux + glibc and returns RSS before/after (from `/proc/self/statm`); a no-op elsewhere (musl, macOS and Windows allocators already release on their own).
- The observability sweeper (the 60 s tick that already runs `expire_pending` and archive retention) calls it through `spawn_blocking` and logs `returned freed heap to the OS` when at least 64 MB came back.
- No allocator switch: jemalloc/mimalloc would touch every target's build, and `libc` is already a dependency.

## Tests

- `engine/tests/memory_trim.rs`, in its own test binary so other tests' allocations do not move the readings: allocates 512 MiB as 16 KiB chunks, frees every other one (fragmented, no top chunk for glibc to trim by itself), asserts `release_freed_memory` releases at least 128 MiB. Passes in 0.15 s.
- Clippy clean on the new files.

## Live check

Standalone engine with the `iii-observability` defaults (hot cache 256 MB, archive on), one iii-sdk 0.23.0 worker triggering its own `burst::echo` 1 000 000 times at 64-way concurrency (~35k calls/s, ~28 s; every call traced by the worker's OTel exporter).

| build | peak during burst (VmHWM) | idle after the burst |
| -- | -- | -- |
| main (no trim) | 842 MB | **844 MB** three minutes later, still creeping up |
| this branch | 852 MB | **479 MB** from the first tick on (`released_mb: 371, rss_mb: 480`), flat for the next three minutes |

The 14 GB run-3 engine predates this change; the same mechanism applies at that scale, bounded by what the archive writer and SQLite page cache still hold live.

## Not in this PR

- A pressure-driven trigger (trim as soon as `hot_bytes` falls back under the watermark); the 60 s tick covers the observed pattern.
- `M_ARENA_MAX` tuning or an allocator swap.

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On Linux with glibc, freed engine memory is returned to the operating system during periodic archive cleanup.
  * Engine memory usage more closely reflects the bounded span cache instead of remaining at the previous peak.
  * Significant memory reclamation is recorded in observability logs with released and current RSS values.

* **Documentation**
  * Updated the 0.23.0 changelog with details about improved memory reclamation and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->