### PR TITLE
MOT-4730: fix(compose): store runtime state beside the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ target/
 .bin/
 
 # Runtime data
+.iii/compose/
 tmp/
 data/
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ target/
 .bin/
 
 # Runtime data
-.iii/compose/
+**/.iii/compose/
 tmp/
 data/
 *.log

--- a/crates/iii-compose/Cargo.toml
+++ b/crates/iii-compose/Cargo.toml
@@ -46,7 +46,7 @@ indexmap = { version = "2", features = ["serde"] }
 # to be stable across machines and rust versions, so DefaultHasher is out.
 sha2 = "0.10"
 hex = "0.4"
-# One managed engine owns a compose namespace at a time. The kernel-backed
+# One managed engine owns a project's compose namespace at a time. The kernel-backed
 # lock is released automatically if the foreground compose process crashes.
 fslock = "0.2"
 

--- a/crates/iii-compose/src/cli.rs
+++ b/crates/iii-compose/src/cli.rs
@@ -223,7 +223,7 @@ impl ComposeCli {
     /// `--namespace`, or `default` when no compose file is available.
     ///
     /// Validated here rather than at first use: it is both a namespace the
-    /// engine routes on and a directory under `~/.iii/compose`, so a separator
+    /// engine routes on and a project state directory, so a separator
     /// or an empty string is a daemon that half-works until the first write.
     pub fn daemon_namespace(&self) -> Result<String> {
         let explicit = self.validated_namespace()?;

--- a/crates/iii-compose/src/error.rs
+++ b/crates/iii-compose/src/error.rs
@@ -478,7 +478,7 @@ pub enum ComposeError {
     DaemonAlreadyServing { engine_url: String, detail: String },
 
     #[error(
-        "another managed compose invocation already owns namespace '{namespace}'. \
+        "another managed compose invocation already owns namespace '{namespace}' in this project. \
          Stop it, wait for it to finish, or choose a different --namespace"
     )]
     DaemonNamespaceTaken { namespace: String },

--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -407,7 +407,8 @@ async fn serve(
             let Some(spec) = owner.engine.as_ref() else {
                 unreachable!("managed mode is selected only from an engine section");
             };
-            let engine = managed_engine::ManagedEngine::start(spec, &daemon_namespace).await?;
+            let engine =
+                managed_engine::ManagedEngine::start(spec, &daemon_namespace, &owner.path).await?;
             if let Some(project) = &start_project {
                 project.progress.engine_waiting();
             }

--- a/crates/iii-compose/src/managed_engine.rs
+++ b/crates/iii-compose/src/managed_engine.rs
@@ -44,16 +44,20 @@ pub struct ManagedEngine {
 
 impl ManagedEngine {
     /// Starts the current `iii` executable with output detached from compose's
-    /// terminal and captured below this daemon namespace's state directory.
-    pub async fn start(spec: &EngineSpec, daemon_namespace: &str) -> Result<Self> {
+    /// terminal and captured in the owning project's namespace directory.
+    pub async fn start(
+        spec: &EngineSpec,
+        daemon_namespace: &str,
+        compose_path: &Path,
+    ) -> Result<Self> {
         ensure_listener_available(spec)?;
         let executable =
             std::env::current_exe().map_err(|err| ComposeError::EngineSpawnFailed {
                 message: format!("could not locate the current iii executable: {err}"),
             })?;
-        let state_root = StateStore::root()?;
-        let namespace_dir = state_root.join(daemon_namespace);
-        let lock_dir = namespace_dir.clone();
+        let store = StateStore::for_project(daemon_namespace, compose_path)?;
+        let namespace_dir = store.dir();
+        let lock_dir = namespace_dir.to_path_buf();
         let namespace = daemon_namespace.to_string();
         let namespace_lock =
             tokio::task::spawn_blocking(move || NamespaceLock::acquire(&lock_dir, &namespace))
@@ -61,8 +65,8 @@ impl ManagedEngine {
                 .map_err(|source| ComposeError::EngineSpawnFailed {
                     message: format!("could not claim the managed engine namespace: {source}"),
                 })??;
-        let config_path = materialize_engine_config(spec, &namespace_dir)?;
-        let log_path = engine_log_path(&state_root, daemon_namespace);
+        let config_path = materialize_engine_config(spec, namespace_dir)?;
+        let log_path = engine_log_path(namespace_dir);
         let mut engine = Self::spawn_with_materialized_config(
             &executable,
             &config_path,
@@ -419,7 +423,7 @@ fn worker_manager_config_from_url(engine_url: &str) -> Result<serde_yaml::Value>
     Ok(serde_yaml::Value::Mapping(config))
 }
 
-/// Cross-process ownership of one managed engine namespace.
+/// Cross-process ownership of one managed engine in a project and namespace.
 ///
 /// The lock file persists, but the kernel lock is released with this guard or
 /// when the process exits, so a crash cannot strand the namespace.
@@ -791,8 +795,8 @@ fn archive_path(path: &Path, index: usize) -> PathBuf {
     PathBuf::from(archive)
 }
 
-fn engine_log_path(root: &Path, daemon_namespace: &str) -> PathBuf {
-    root.join(daemon_namespace).join("engine.log")
+fn engine_log_path(namespace_dir: &Path) -> PathBuf {
+    namespace_dir.join("engine.log")
 }
 
 #[cfg(unix)]
@@ -1063,15 +1067,15 @@ port: 60123
     }
 
     #[test]
-    fn engine_log_lives_under_the_daemon_namespace() {
+    fn engine_log_lives_in_the_project_namespace_directory() {
         assert_eq!(
-            engine_log_path(Path::new("/state"), "blue-whale"),
-            Path::new("/state/blue-whale/engine.log")
+            engine_log_path(Path::new("/project/.iii/compose/blue-whale")),
+            Path::new("/project/.iii/compose/blue-whale/engine.log")
         );
     }
 
     #[test]
-    fn concurrent_managed_engines_cannot_claim_the_same_namespace() {
+    fn concurrent_managed_engines_cannot_claim_the_same_project_namespace() {
         let dir = tempfile::tempdir().unwrap();
         let namespace_dir = dir.path().join("orders");
         std::fs::create_dir(&namespace_dir).unwrap();

--- a/crates/iii-compose/src/project.rs
+++ b/crates/iii-compose/src/project.rs
@@ -88,9 +88,8 @@ impl Project {
 
         let recovered = store.load()?;
         if let Some(state) = &recovered {
-            // The directory is derived from the path, so this only fires on a
-            // slug collision — and adopting another project's children is
-            // exactly what it must not do.
+            // Two compose files in one directory must not adopt each other's
+            // children when they use the same namespace.
             state.check_binding(&file.path)?;
         }
         let mut state =
@@ -359,10 +358,8 @@ impl Project {
     /// Everything this project owns on disk: its durable record, the
     /// configuration it was handed, and each container's output.
     ///
-    /// Reported by `compose::status` because the directory is derived from the
-    /// compose file rather than named by anyone — so asking is the only way to
-    /// know, and an operator looking for a container's log should not have to
-    /// reproduce a hash to find it.
+    /// Reported by `compose::status`, including when the operator relocates
+    /// state with `III_COMPOSE_STATE_DIR`.
     pub fn state_dir(&self) -> &Path {
         self.store.dir()
     }

--- a/crates/iii-compose/src/state.rs
+++ b/crates/iii-compose/src/state.rs
@@ -31,10 +31,10 @@ use crate::{
 
 pub const STATE_FILE: &str = "state.json";
 
-/// Directory name for one project's state, derived from its compose file.
+/// Directory name for relocated project state, derived from its compose file.
 ///
 /// Two halves for two jobs: the parent directory's name so an operator
-/// browsing `~/.iii/compose` recognises what they are looking at, and a hash of
+/// browsing `$III_COMPOSE_STATE_DIR` recognises what they are looking at, and a hash of
 /// the canonical path so two projects that happen to share a directory name
 /// stay apart. The file name itself is nearly always `worker-compose.yaml`, so
 /// it carries nothing.
@@ -102,8 +102,7 @@ impl ChildRecord {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DaemonState {
     /// Compose file this state belongs to, canonicalized. It is also what the
-    /// state directory is derived from, so the two can only disagree if the
-    /// derivation collided — see [`DaemonState::check_binding`].
+    /// state is bound to — see [`DaemonState::check_binding`].
     pub compose_path: PathBuf,
     pub namespace: String,
     #[serde(default)]
@@ -121,10 +120,8 @@ impl DaemonState {
 
     /// Refuses state recorded for a different compose file.
     ///
-    /// Not an operator error any more: the directory is derived from the path,
-    /// so reaching this means two paths produced one slug. Rare enough to be a
-    /// surprise and dangerous enough to refuse — adopting it would let one
-    /// project kill another's children.
+    /// Two compose files in the same directory must use different namespaces.
+    /// Adopting another file's state would let one project kill its children.
     pub fn check_binding(&self, compose_path: &Path) -> Result<()> {
         if self.compose_path == compose_path {
             return Ok(());
@@ -132,7 +129,7 @@ impl DaemonState {
         Err(ComposeError::InvalidState {
             path: compose_path.to_path_buf(),
             message: format!(
-                "it records {} instead. Two compose files resolved to one state directory",
+                "it records {} instead. Use a different namespace for each compose file in this directory",
                 self.compose_path.display()
             ),
         })
@@ -179,8 +176,8 @@ pub struct StateStore {
 }
 
 impl StateStore {
-    /// Everything compose keeps on this machine: `~/.iii/compose`, or
-    /// `$III_COMPOSE_STATE_DIR` when the operator relocates it.
+    /// Shared package storage: `~/.iii/compose`, or `$III_COMPOSE_STATE_DIR`.
+    /// Project state lives beside the compose file unless explicitly relocated.
     pub fn root() -> Result<PathBuf> {
         match std::env::var_os("III_COMPOSE_STATE_DIR") {
             Some(root) => Ok(PathBuf::from(root)),
@@ -198,19 +195,22 @@ impl StateStore {
     }
 
     /// Where one project's state lives:
-    /// `~/.iii/compose/<daemon-namespace>/<project-slug>`, or under
-    /// `$III_COMPOSE_STATE_DIR` when the operator relocates it (a read-only
-    /// home, a tmpfs, a test).
+    /// `<compose-dir>/.iii/compose/<daemon-namespace>`, or
+    /// `$III_COMPOSE_STATE_DIR/<project-slug>/<daemon-namespace>` when relocated.
     ///
-    /// The slug comes from the compose file, not from a name anyone chose:
-    /// there is nothing else that identifies a project, and a chosen name is a
-    /// second identity that can be pointed at the wrong file.
+    /// Callers pass the canonical compose path so `--file` and symlinks use
+    /// the same directory. A shared external root needs a slug to keep projects
+    /// apart, while the default is already scoped to the project directory.
     pub fn for_project(daemon_namespace: &str, compose_path: &Path) -> Result<Self> {
-        Ok(Self::at(
-            Self::root()?
-                .join(daemon_namespace)
-                .join(project_slug(compose_path)),
-        ))
+        let project_dir = match std::env::var_os("III_COMPOSE_STATE_DIR") {
+            Some(root) => PathBuf::from(root).join(project_slug(compose_path)),
+            None => compose_path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .join(".iii")
+                .join("compose"),
+        };
+        Ok(Self::at(project_dir.join(daemon_namespace)))
     }
 
     pub fn at(dir: impl Into<PathBuf>) -> Self {

--- a/crates/iii-compose/tests/cli.rs
+++ b/crates/iii-compose/tests/cli.rs
@@ -63,7 +63,7 @@ fn the_namespace_is_how_one_daemon_is_told_from_another() {
 #[test]
 fn a_namespace_that_cannot_also_be_a_directory_is_refused() {
     // It is both the namespace the engine routes on and a directory under
-    // ~/.iii/compose, so a separator or an empty string would be a broken
+    // the project's compose state, so a separator or an empty string would be a broken
     // daemon discovered later, at the first write.
     for bad in ["", "   ", "a/b", "a\\b", ".."] {
         let err = parse(&["iii", "compose", "--namespace", bad])

--- a/crates/iii-compose/tests/crash_recovery.rs
+++ b/crates/iii-compose/tests/crash_recovery.rs
@@ -117,26 +117,24 @@ fn a_corrupt_state_file_is_an_error_not_a_silent_reset() {
 
 #[test]
 fn state_recorded_for_another_compose_file_is_refused() {
-    // Unreachable through the normal path now that the directory is derived
-    // from the compose file — it takes a slug collision, or a state file
-    // someone moved. Kept because what it prevents is one project adopting and
-    // later killing another's children.
+    // Two compose files in the same directory and namespace share a state
+    // path. Refuse the other file's state instead of adopting its children.
     let state = DaemonState::new(Path::new("/srv/a/compose.yaml"), "ns");
 
     state
         .check_binding(Path::new("/srv/a/compose.yaml"))
         .unwrap();
     let err = state
-        .check_binding(Path::new("/srv/b/compose.yaml"))
+        .check_binding(Path::new("/srv/a/other-compose.yaml"))
         .expect_err("state belongs to the file it recorded");
     assert_eq!(err.code(), "INVALID_STATE_FILE");
 }
 
 #[test]
-fn a_project_is_its_file_and_two_files_never_share_a_directory() {
+fn relocated_project_slugs_distinguish_compose_paths() {
     use iii_compose::state::project_slug;
 
-    // Readable, so `~/.iii/compose` can be browsed, and unique, so two
+    // Readable, so `$III_COMPOSE_STATE_DIR` can be browsed, and unique, so two
     // projects whose directories happen to share a name stay apart.
     let a = project_slug(Path::new("/srv/orders/worker-compose.yaml"));
     let b = project_slug(Path::new("/opt/orders/worker-compose.yaml"));

--- a/docs/next/understanding-iii/compose.mdx
+++ b/docs/next/understanding-iii/compose.mdx
@@ -105,34 +105,25 @@ namespace is declared per file, and a project is its file, so a container that r
 else is describing a different project. Declaring it in a second compose file says exactly that, and
 keeps the property that reading one file tells you where everything in it lands.
 
-## Why state is kept in one place per machine
+## Why state belongs to the project
 
-A project's records, its resolved configuration and each container's output all sit under
-`~/.iii/compose`, keyed by the daemon's namespace and by a slug derived from the compose file's
-canonical path. Putting them in a `.iii/` directory beside the compose file would make them easier
-to find, and that is a real cost of the current layout: locating a container's log means asking
-`compose::status` for `state_dir` rather than listing a directory you are already standing in.
+A project's process records, resolved configuration, worker output and VM state are stored in
+`<project-dir>/.iii/compose/<namespace>/`. Its managed engine uses the same directory for its lock,
+generated configuration and log. The project directory comes from the canonical compose file path,
+so running `iii compose --up --file` from another directory keeps state beside that file.
 
-Three things outweigh it.
+The engine lock belongs to the project and namespace together. Two checkouts can each use `default`
+with engines on different ports. A second managed invocation for the same project and namespace is
+refused. Within one engine, each Compose daemon still needs its own namespace.
 
-A checkout is not always writable. A CI runner that mounts the repository read-only, or a container
-image built without a writable working tree, would be unable to start a project at all. State that
-sits outside the checkout keeps starting a project independent of how the checkout was obtained.
+For read-only checkouts, `III_COMPOSE_STATE_DIR` moves project state to
+`$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The slug includes a hash of the canonical
+compose path so different checkouts remain separate under a shared root. `compose::status` reports
+the resolved `state_dir` for either layout. The default layout requires a `.iii/compose/` entry in
+the project's ignore rules to exclude generated state from version control.
 
-State written into a project directory becomes the project's problem to ignore. Every user would
-have to keep a `.iii/` entry in version control ignore rules, and every generated file that lands
-there is one an ordinary `git add` sweeps up. That is a recurring cost paid by everyone who runs
-compose, in exchange for a shorter path.
-
-Installed packages are shared on purpose. `packages/` is keyed by name, version and target so two
-projects asking for the same worker download it once. Moving project state in-tree would split the
-layout across two locations without removing the machine-global one.
-
-The identity concern that motivates in-tree state is already handled. A project is its compose file,
-and the slug is derived from that file's canonical path, so a state directory cannot be pointed at a
-different project and two checkouts of one repository are two projects without anything to
-configure. `$III_COMPOSE_STATE_DIR` relocates the whole tree for anyone whose home directory is the
-wrong place for it.
+Installed packages remain shared at `~/.iii/compose/packages`, or `$III_COMPOSE_STATE_DIR/packages`.
+The cache is keyed by name, version and target, so projects can reuse downloaded workers.
 
 ## Engine observed readiness
 

--- a/docs/next/understanding-iii/compose.mdx.skill.md
+++ b/docs/next/understanding-iii/compose.mdx.skill.md
@@ -101,34 +101,25 @@ namespace is declared per file, and a project is its file, so a container that r
 else is describing a different project. Declaring it in a second compose file says exactly that, and
 keeps the property that reading one file tells you where everything in it lands.
 
-## Why state is kept in one place per machine
+## Why state belongs to the project
 
-A project's records, its resolved configuration and each container's output all sit under
-`~/.iii/compose`, keyed by the daemon's namespace and by a slug derived from the compose file's
-canonical path. Putting them in a `.iii/` directory beside the compose file would make them easier
-to find, and that is a real cost of the current layout: locating a container's log means asking
-`compose::status` for `state_dir` rather than listing a directory you are already standing in.
+A project's process records, resolved configuration, worker output and VM state are stored in
+`<project-dir>/.iii/compose/<namespace>/`. Its managed engine uses the same directory for its lock,
+generated configuration and log. The project directory comes from the canonical compose file path,
+so running `iii compose --up --file` from another directory keeps state beside that file.
 
-Three things outweigh it.
+The engine lock belongs to the project and namespace together. Two checkouts can each use `default`
+with engines on different ports. A second managed invocation for the same project and namespace is
+refused. Within one engine, each Compose daemon still needs its own namespace.
 
-A checkout is not always writable. A CI runner that mounts the repository read-only, or a container
-image built without a writable working tree, would be unable to start a project at all. State that
-sits outside the checkout keeps starting a project independent of how the checkout was obtained.
+For read-only checkouts, `III_COMPOSE_STATE_DIR` moves project state to
+`$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The slug includes a hash of the canonical
+compose path so different checkouts remain separate under a shared root. `compose::status` reports
+the resolved `state_dir` for either layout. The default layout requires a `.iii/compose/` entry in
+the project's ignore rules to exclude generated state from version control.
 
-State written into a project directory becomes the project's problem to ignore. Every user would
-have to keep a `.iii/` entry in version control ignore rules, and every generated file that lands
-there is one an ordinary `git add` sweeps up. That is a recurring cost paid by everyone who runs
-compose, in exchange for a shorter path.
-
-Installed packages are shared on purpose. `packages/` is keyed by name, version and target so two
-projects asking for the same worker download it once. Moving project state in-tree would split the
-layout across two locations without removing the machine-global one.
-
-The identity concern that motivates in-tree state is already handled. A project is its compose file,
-and the slug is derived from that file's canonical path, so a state directory cannot be pointed at a
-different project and two checkouts of one repository are two projects without anything to
-configure. `$III_COMPOSE_STATE_DIR` relocates the whole tree for anyone whose home directory is the
-wrong place for it.
+Installed packages remain shared at `~/.iii/compose/packages`, or `$III_COMPOSE_STATE_DIR/packages`.
+The cache is keyed by name, version and target, so projects can reuse downloaded workers.
 
 ## Engine observed readiness
 

--- a/docs/next/upgrading/workers-to-compose.mdx
+++ b/docs/next/upgrading/workers-to-compose.mdx
@@ -36,7 +36,7 @@ Write worker-compose.yaml:
 
 Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get and raw: true so ${VAR} templates are copied as templates rather than expanded values, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
-Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
+Never edit <project-dir>/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
 Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
@@ -105,7 +105,7 @@ engine:
 ```
 
 `engine.url` defaults to `ws://127.0.0.1:49134`. Compose writes the engine-only representation to
-`~/.iii/compose/<daemon-namespace>/engine-config.yaml` with owner-only permissions and starts the
+`<project-dir>/.iii/compose/<daemon-namespace>/engine-config.yaml` with owner-only permissions and starts the
 engine from it. Do not edit that generated file.
 
 Remove explicit `iii-engine-functions`, `iii-telemetry`, and `iii-observability` entries. The

--- a/docs/next/upgrading/workers-to-compose.mdx
+++ b/docs/next/upgrading/workers-to-compose.mdx
@@ -36,7 +36,7 @@ Write worker-compose.yaml:
 
 Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get and raw: true so ${VAR} templates are copied as templates rather than expanded values, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
-Never edit <project-dir>/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
+Never edit engine-config.yaml in the Compose state directory. Compose generates it at <project-dir>/.iii/compose/<namespace>/engine-config.yaml by default, or $III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/engine-config.yaml when III_COMPOSE_STATE_DIR is set.
 
 Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
@@ -105,8 +105,10 @@ engine:
 ```
 
 `engine.url` defaults to `ws://127.0.0.1:49134`. Compose writes the engine-only representation to
-`<project-dir>/.iii/compose/<daemon-namespace>/engine-config.yaml` with owner-only permissions and starts the
-engine from it. Do not edit that generated file.
+`<project-dir>/.iii/compose/<daemon-namespace>/engine-config.yaml` by default. When `III_COMPOSE_STATE_DIR`
+is set, the path is `$III_COMPOSE_STATE_DIR/<project-slug>/<daemon-namespace>/engine-config.yaml`.
+Compose writes the file with owner-only permissions and starts the engine from it. Do not edit
+that generated file.
 
 Remove explicit `iii-engine-functions`, `iii-telemetry`, and `iii-observability` entries. The
 engine injects them automatically, and declaring one under `engine.workers` fails.

--- a/docs/next/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/next/upgrading/workers-to-compose.mdx.skill.md
@@ -32,7 +32,7 @@ Write worker-compose.yaml:
 
 Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get and raw: true so ${VAR} templates are copied as templates rather than expanded values, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
-Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
+Never edit <project-dir>/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
 Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
@@ -101,7 +101,7 @@ engine:
 ```
 
 `engine.url` defaults to `ws://127.0.0.1:49134`. Compose writes the engine-only representation to
-`~/.iii/compose/<daemon-namespace>/engine-config.yaml` with owner-only permissions and starts the
+`<project-dir>/.iii/compose/<daemon-namespace>/engine-config.yaml` with owner-only permissions and starts the
 engine from it. Do not edit that generated file.
 
 Remove explicit `iii-engine-functions`, `iii-telemetry`, and `iii-observability` entries. The

--- a/docs/next/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/next/upgrading/workers-to-compose.mdx.skill.md
@@ -32,7 +32,7 @@ Write worker-compose.yaml:
 
 Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get and raw: true so ${VAR} templates are copied as templates rather than expanded values, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
-Never edit <project-dir>/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
+Never edit engine-config.yaml in the Compose state directory. Compose generates it at <project-dir>/.iii/compose/<namespace>/engine-config.yaml by default, or $III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/engine-config.yaml when III_COMPOSE_STATE_DIR is set.
 
 Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
@@ -101,8 +101,10 @@ engine:
 ```
 
 `engine.url` defaults to `ws://127.0.0.1:49134`. Compose writes the engine-only representation to
-`<project-dir>/.iii/compose/<daemon-namespace>/engine-config.yaml` with owner-only permissions and starts the
-engine from it. Do not edit that generated file.
+`<project-dir>/.iii/compose/<daemon-namespace>/engine-config.yaml` by default. When `III_COMPOSE_STATE_DIR`
+is set, the path is `$III_COMPOSE_STATE_DIR/<project-slug>/<daemon-namespace>/engine-config.yaml`.
+Compose writes the file with owner-only permissions and starts the engine from it. Do not edit
+that generated file.
 
 Remove explicit `iii-engine-functions`, `iii-telemetry`, and `iii-observability` entries. The
 engine injects them automatically, and declaring one under `engine.workers` fails.

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -70,7 +70,9 @@ systems, process names retain their previous behavior.
 
 ### Compose logs
 
-Compose logs stdout and stderr output from started workers to `$HOME/.iii/compose/namespace/`.
+Compose logs stdout and stderr output from started workers to
+`<project-dir>/.iii/compose/<namespace>/logs/`. The managed engine writes to `engine.log` in the
+same namespace directory.
 
 Logs are rotated every 10 MiB. Compose keeps up to 40 MiB of logs. Compose strips terminal control
 sequences before persisting the engine output.
@@ -667,7 +669,7 @@ iii compose build --file worker-compose.yaml
 iii compose --up --file worker-compose.yaml
 ```
 
-The cache is shared under `~/.iii/compose/packages`, or under `III_COMPOSE_STATE_DIR` when that
+The cache is shared under `~/.iii/compose/packages`, or under `$III_COMPOSE_STATE_DIR/packages` when that
 variable is set. A later `compose::up` reuses a valid cached artifact if it exists.
 
 ## Readiness
@@ -698,24 +700,42 @@ Dependency shutdown is dependent upon when a shutdown happens:
 
 ## Where compose keeps state
 
-Compose state is stored under `~/.iii/compose`, or under `$III_COMPOSE_STATE_DIR` when that is set.
+Compose state is stored in `<project-dir>/.iii/compose/<namespace>/`. `<project-dir>` is the directory
+containing the canonical compose file, including when `--file` points outside the current working
+directory or follows a symbolic link. `<namespace>` is the daemon's namespace.
 
-| Path                        | Contents                                                                                                            |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `<ns>/<project>/state.json` | One project's child records. Owner-only.                                                                            |
-| `<ns>/<project>/config/`    | Resolved configuration files.                                                                                       |
-| `<ns>/<project>/logs/`      | Rotating stdout and stderr for every project worker.                                                                |
-| `<ns>/<project>/vm/`        | VM state for bundle and local-image workers, one directory each, plus the config each one publishes into its guest. |
-| `packages/`                 | Installed `package://` artefacts, shared by projects.                                                               |
+| Path                 | Contents                                                                                      |
+| -------------------- | --------------------------------------------------------------------------------------------- |
+| `engine.lock`        | Lock for the managed engine in this project and namespace.                                     |
+| `engine-config.yaml` | Generated engine configuration, removed after clean shutdown.                                  |
+| `engine.log`         | Rotating stdout and stderr for the managed engine.                                             |
+| `state.json`         | Child process records for the project. Owner-only.                                             |
+| `config/`            | Resolved worker configuration files.                                                          |
+| `logs/`              | Rotating stdout and stderr for project workers.                                                |
+| `vm/`                | VM state for bundle and local-image workers, including rootfs, boot scripts and guest configs. |
 
-`<ns>` is the daemon's namespace. `<project>` is derived from the compose file's canonical path + a
-short hash to prevent project name collisions.
+Two projects can use `default` with separate engines on different ports. Starting the same project
+and namespace twice is refused. Two daemons on the same engine must use different namespaces.
+Two compose files in the same directory must also use different namespaces.
+
+For a read-only project directory, set `III_COMPOSE_STATE_DIR` to a writable directory. Project state
+is then stored at `$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The slug combines the project
+directory name with a hash of the canonical compose file path, keeping projects with the same
+directory name separate.
+
+The package cache stays shared at `~/.iii/compose/packages`, or `$III_COMPOSE_STATE_DIR/packages`.
+Add `.iii/compose/` to the project's `.gitignore` to exclude generated state from version control.
 
 ```bash
 iii trigger compose::status --namespace dev file=./worker-compose.yaml
-# ... "state_dir": "/home/you/.iii/compose/dev/shop-3f2a1b9c"
-ls /home/you/.iii/compose/dev/shop-3f2a1b9c/logs/
+# ... "state_dir": "/home/you/shop/.iii/compose/dev"
+ls /home/you/shop/.iii/compose/dev/logs/
 ```
+
+Before upgrading from the shared namespace layout, stop existing Compose daemons with the old
+version and confirm that their engines and workers have stopped. The new version does not migrate
+old process records or logs. Previous state remains under `~/.iii/compose/<namespace>/` (or the old
+`III_COMPOSE_STATE_DIR` layout); keep any logs or VM data you need before removing it.
 
 ## Error codes
 

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -513,8 +513,8 @@ containers:
 
 Allowed worker keys are `configuration`, `iii-worker-manager`, `iii-http-functions`, `iii-stream`,
 and `iii-sandbox`. Use `#instance` for another instance of an allowed type, for example
-`iii-worker-manager#rbac`. Internal `iii-engine-functions`, `iii-telemetry`, and `iii-observability`
-are injected and must not be declared.
+`iii-worker-manager#rbac`. The engine starts `iii-engine-functions`, `iii-telemetry`, and
+`iii-observability` automatically. Do not declare these workers in the compose file.
 
 <Note>
   These workers are always engine managed and started so this method of operating these workers is

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -70,9 +70,10 @@ systems, process names retain their previous behavior.
 
 ### Compose logs
 
-Compose logs stdout and stderr output from started workers to
-`<project-dir>/.iii/compose/<namespace>/logs/`. The managed engine writes to `engine.log` in the
-same namespace directory.
+Compose logs stdout and stderr output from started workers to `logs/` in the state directory.
+The default state directory is `<project-dir>/.iii/compose/<namespace>/`. When `III_COMPOSE_STATE_DIR`
+is set, it is `$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The managed engine writes to
+`engine.log` in that same state directory.
 
 Logs are rotated every 10 MiB. Compose keeps up to 40 MiB of logs. Compose strips terminal control
 sequences before persisting the engine output.
@@ -716,15 +717,18 @@ directory or follows a symbolic link. `<namespace>` is the daemon's namespace.
 
 Two projects can use `default` with separate engines on different ports. Starting the same project
 and namespace twice is refused. Two daemons on the same engine must use different namespaces.
-Two compose files in the same directory must also use different namespaces.
+With the default state layout, two compose files in the same directory must also use different
+namespaces.
 
 For a read-only project directory, set `III_COMPOSE_STATE_DIR` to a writable directory. Project state
 is then stored at `$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The slug combines the project
 directory name with a hash of the canonical compose file path, keeping projects with the same
-directory name separate.
+directory name separate. With this override, two compose files in the same directory have separate
+state directories and can use the same namespace on separate engines.
 
 The package cache stays shared at `~/.iii/compose/packages`, or `$III_COMPOSE_STATE_DIR/packages`.
-Add `.iii/compose/` to the project's `.gitignore` to exclude generated state from version control.
+Add `**/.iii/compose/` to the repository's `.gitignore` to exclude generated state, including state
+from nested projects, from version control.
 
 ```bash
 iii trigger compose::status --namespace dev file=./worker-compose.yaml

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -64,7 +64,9 @@ systems, process names retain their previous behavior.
 
 ### Compose logs
 
-Compose logs stdout and stderr output from started workers to `$HOME/.iii/compose/namespace/`.
+Compose logs stdout and stderr output from started workers to
+`<project-dir>/.iii/compose/<namespace>/logs/`. The managed engine writes to `engine.log` in the
+same namespace directory.
 
 Logs are rotated every 10 MiB. Compose keeps up to 40 MiB of logs. Compose strips terminal control
 sequences before persisting the engine output.
@@ -661,7 +663,7 @@ iii compose build --file worker-compose.yaml
 iii compose --up --file worker-compose.yaml
 ```
 
-The cache is shared under `~/.iii/compose/packages`, or under `III_COMPOSE_STATE_DIR` when that
+The cache is shared under `~/.iii/compose/packages`, or under `$III_COMPOSE_STATE_DIR/packages` when that
 variable is set. A later `compose::up` reuses a valid cached artifact if it exists.
 
 ## Readiness
@@ -692,24 +694,42 @@ Dependency shutdown is dependent upon when a shutdown happens:
 
 ## Where compose keeps state
 
-Compose state is stored under `~/.iii/compose`, or under `$III_COMPOSE_STATE_DIR` when that is set.
+Compose state is stored in `<project-dir>/.iii/compose/<namespace>/`. `<project-dir>` is the directory
+containing the canonical compose file, including when `--file` points outside the current working
+directory or follows a symbolic link. `<namespace>` is the daemon's namespace.
 
-| Path                        | Contents                                                                                                            |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `<ns>/<project>/state.json` | One project's child records. Owner-only.                                                                            |
-| `<ns>/<project>/config/`    | Resolved configuration files.                                                                                       |
-| `<ns>/<project>/logs/`      | Rotating stdout and stderr for every project worker.                                                                |
-| `<ns>/<project>/vm/`        | VM state for bundle and local-image workers, one directory each, plus the config each one publishes into its guest. |
-| `packages/`                 | Installed `package://` artefacts, shared by projects.                                                               |
+| Path                 | Contents                                                                                      |
+| -------------------- | --------------------------------------------------------------------------------------------- |
+| `engine.lock`        | Lock for the managed engine in this project and namespace.                                     |
+| `engine-config.yaml` | Generated engine configuration, removed after clean shutdown.                                  |
+| `engine.log`         | Rotating stdout and stderr for the managed engine.                                             |
+| `state.json`         | Child process records for the project. Owner-only.                                             |
+| `config/`            | Resolved worker configuration files.                                                          |
+| `logs/`              | Rotating stdout and stderr for project workers.                                                |
+| `vm/`                | VM state for bundle and local-image workers, including rootfs, boot scripts and guest configs. |
 
-`<ns>` is the daemon's namespace. `<project>` is derived from the compose file's canonical path + a
-short hash to prevent project name collisions.
+Two projects can use `default` with separate engines on different ports. Starting the same project
+and namespace twice is refused. Two daemons on the same engine must use different namespaces.
+Two compose files in the same directory must also use different namespaces.
+
+For a read-only project directory, set `III_COMPOSE_STATE_DIR` to a writable directory. Project state
+is then stored at `$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The slug combines the project
+directory name with a hash of the canonical compose file path, keeping projects with the same
+directory name separate.
+
+The package cache stays shared at `~/.iii/compose/packages`, or `$III_COMPOSE_STATE_DIR/packages`.
+Add `.iii/compose/` to the project's `.gitignore` to exclude generated state from version control.
 
 ```bash
 iii trigger compose::status --namespace dev file=./worker-compose.yaml
-# ... "state_dir": "/home/you/.iii/compose/dev/shop-3f2a1b9c"
-ls /home/you/.iii/compose/dev/shop-3f2a1b9c/logs/
+# ... "state_dir": "/home/you/shop/.iii/compose/dev"
+ls /home/you/shop/.iii/compose/dev/logs/
 ```
+
+Before upgrading from the shared namespace layout, stop existing Compose daemons with the old
+version and confirm that their engines and workers have stopped. The new version does not migrate
+old process records or logs. Previous state remains under `~/.iii/compose/<namespace>/` (or the old
+`III_COMPOSE_STATE_DIR` layout); keep any logs or VM data you need before removing it.
 
 ## Error codes
 

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -507,8 +507,8 @@ containers:
 
 Allowed worker keys are `configuration`, `iii-worker-manager`, `iii-http-functions`, `iii-stream`,
 and `iii-sandbox`. Use `#instance` for another instance of an allowed type, for example
-`iii-worker-manager#rbac`. Internal `iii-engine-functions`, `iii-telemetry`, and `iii-observability`
-are injected and must not be declared.
+`iii-worker-manager#rbac`. The engine starts `iii-engine-functions`, `iii-telemetry`, and
+`iii-observability` automatically. Do not declare these workers in the compose file.
 
 <Note>
   These workers are always engine managed and started so this method of operating these workers is

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -64,9 +64,10 @@ systems, process names retain their previous behavior.
 
 ### Compose logs
 
-Compose logs stdout and stderr output from started workers to
-`<project-dir>/.iii/compose/<namespace>/logs/`. The managed engine writes to `engine.log` in the
-same namespace directory.
+Compose logs stdout and stderr output from started workers to `logs/` in the state directory.
+The default state directory is `<project-dir>/.iii/compose/<namespace>/`. When `III_COMPOSE_STATE_DIR`
+is set, it is `$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The managed engine writes to
+`engine.log` in that same state directory.
 
 Logs are rotated every 10 MiB. Compose keeps up to 40 MiB of logs. Compose strips terminal control
 sequences before persisting the engine output.
@@ -710,15 +711,18 @@ directory or follows a symbolic link. `<namespace>` is the daemon's namespace.
 
 Two projects can use `default` with separate engines on different ports. Starting the same project
 and namespace twice is refused. Two daemons on the same engine must use different namespaces.
-Two compose files in the same directory must also use different namespaces.
+With the default state layout, two compose files in the same directory must also use different
+namespaces.
 
 For a read-only project directory, set `III_COMPOSE_STATE_DIR` to a writable directory. Project state
 is then stored at `$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The slug combines the project
 directory name with a hash of the canonical compose file path, keeping projects with the same
-directory name separate.
+directory name separate. With this override, two compose files in the same directory have separate
+state directories and can use the same namespace on separate engines.
 
 The package cache stays shared at `~/.iii/compose/packages`, or `$III_COMPOSE_STATE_DIR/packages`.
-Add `.iii/compose/` to the project's `.gitignore` to exclude generated state from version control.
+Add `**/.iii/compose/` to the repository's `.gitignore` to exclude generated state, including state
+from nested projects, from version control.
 
 ```bash
 iii trigger compose::status --namespace dev file=./worker-compose.yaml

--- a/docs/understanding-iii/compose.mdx
+++ b/docs/understanding-iii/compose.mdx
@@ -105,34 +105,25 @@ namespace is declared per file, and a project is its file, so a container that r
 else is describing a different project. Declaring it in a second compose file says exactly that, and
 keeps the property that reading one file tells you where everything in it lands.
 
-## Why state is kept in one place per machine
+## Why state belongs to the project
 
-A project's records, its resolved configuration and each container's output all sit under
-`~/.iii/compose`, keyed by the daemon's namespace and by a slug derived from the compose file's
-canonical path. Putting them in a `.iii/` directory beside the compose file would make them easier
-to find, and that is a real cost of the current layout: locating a container's log means asking
-`compose::status` for `state_dir` rather than listing a directory you are already standing in.
+A project's process records, resolved configuration, worker output and VM state are stored in
+`<project-dir>/.iii/compose/<namespace>/`. Its managed engine uses the same directory for its lock,
+generated configuration and log. The project directory comes from the canonical compose file path,
+so running `iii compose --up --file` from another directory keeps state beside that file.
 
-Three things outweigh it.
+The engine lock belongs to the project and namespace together. Two checkouts can each use `default`
+with engines on different ports. A second managed invocation for the same project and namespace is
+refused. Within one engine, each Compose daemon still needs its own namespace.
 
-A checkout is not always writable. A CI runner that mounts the repository read-only, or a container
-image built without a writable working tree, would be unable to start a project at all. State that
-sits outside the checkout keeps starting a project independent of how the checkout was obtained.
+For read-only checkouts, `III_COMPOSE_STATE_DIR` moves project state to
+`$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The slug includes a hash of the canonical
+compose path so different checkouts remain separate under a shared root. `compose::status` reports
+the resolved `state_dir` for either layout. The default layout requires a `.iii/compose/` entry in
+the project's ignore rules to exclude generated state from version control.
 
-State written into a project directory becomes the project's problem to ignore. Every user would
-have to keep a `.iii/` entry in version control ignore rules, and every generated file that lands
-there is one an ordinary `git add` sweeps up. That is a recurring cost paid by everyone who runs
-compose, in exchange for a shorter path.
-
-Installed packages are shared on purpose. `packages/` is keyed by name, version and target so two
-projects asking for the same worker download it once. Moving project state in-tree would split the
-layout across two locations without removing the machine-global one.
-
-The identity concern that motivates in-tree state is already handled. A project is its compose file,
-and the slug is derived from that file's canonical path, so a state directory cannot be pointed at a
-different project and two checkouts of one repository are two projects without anything to
-configure. `$III_COMPOSE_STATE_DIR` relocates the whole tree for anyone whose home directory is the
-wrong place for it.
+Installed packages remain shared at `~/.iii/compose/packages`, or `$III_COMPOSE_STATE_DIR/packages`.
+The cache is keyed by name, version and target, so projects can reuse downloaded workers.
 
 ## Engine observed readiness
 

--- a/docs/understanding-iii/compose.mdx.skill.md
+++ b/docs/understanding-iii/compose.mdx.skill.md
@@ -101,34 +101,25 @@ namespace is declared per file, and a project is its file, so a container that r
 else is describing a different project. Declaring it in a second compose file says exactly that, and
 keeps the property that reading one file tells you where everything in it lands.
 
-## Why state is kept in one place per machine
+## Why state belongs to the project
 
-A project's records, its resolved configuration and each container's output all sit under
-`~/.iii/compose`, keyed by the daemon's namespace and by a slug derived from the compose file's
-canonical path. Putting them in a `.iii/` directory beside the compose file would make them easier
-to find, and that is a real cost of the current layout: locating a container's log means asking
-`compose::status` for `state_dir` rather than listing a directory you are already standing in.
+A project's process records, resolved configuration, worker output and VM state are stored in
+`<project-dir>/.iii/compose/<namespace>/`. Its managed engine uses the same directory for its lock,
+generated configuration and log. The project directory comes from the canonical compose file path,
+so running `iii compose --up --file` from another directory keeps state beside that file.
 
-Three things outweigh it.
+The engine lock belongs to the project and namespace together. Two checkouts can each use `default`
+with engines on different ports. A second managed invocation for the same project and namespace is
+refused. Within one engine, each Compose daemon still needs its own namespace.
 
-A checkout is not always writable. A CI runner that mounts the repository read-only, or a container
-image built without a writable working tree, would be unable to start a project at all. State that
-sits outside the checkout keeps starting a project independent of how the checkout was obtained.
+For read-only checkouts, `III_COMPOSE_STATE_DIR` moves project state to
+`$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The slug includes a hash of the canonical
+compose path so different checkouts remain separate under a shared root. `compose::status` reports
+the resolved `state_dir` for either layout. The default layout requires a `.iii/compose/` entry in
+the project's ignore rules to exclude generated state from version control.
 
-State written into a project directory becomes the project's problem to ignore. Every user would
-have to keep a `.iii/` entry in version control ignore rules, and every generated file that lands
-there is one an ordinary `git add` sweeps up. That is a recurring cost paid by everyone who runs
-compose, in exchange for a shorter path.
-
-Installed packages are shared on purpose. `packages/` is keyed by name, version and target so two
-projects asking for the same worker download it once. Moving project state in-tree would split the
-layout across two locations without removing the machine-global one.
-
-The identity concern that motivates in-tree state is already handled. A project is its compose file,
-and the slug is derived from that file's canonical path, so a state directory cannot be pointed at a
-different project and two checkouts of one repository are two projects without anything to
-configure. `$III_COMPOSE_STATE_DIR` relocates the whole tree for anyone whose home directory is the
-wrong place for it.
+Installed packages remain shared at `~/.iii/compose/packages`, or `$III_COMPOSE_STATE_DIR/packages`.
+The cache is keyed by name, version and target, so projects can reuse downloaded workers.
 
 ## Engine observed readiness
 

--- a/docs/upgrading/workers-to-compose.mdx
+++ b/docs/upgrading/workers-to-compose.mdx
@@ -36,7 +36,7 @@ Write worker-compose.yaml:
 
 Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get and raw: true so ${VAR} templates are copied as templates rather than expanded values, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
-Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
+Never edit <project-dir>/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
 Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
@@ -105,7 +105,7 @@ engine:
 ```
 
 `engine.url` defaults to `ws://127.0.0.1:49134`. Compose writes the engine-only representation to
-`~/.iii/compose/<daemon-namespace>/engine-config.yaml` with owner-only permissions and starts the
+`<project-dir>/.iii/compose/<daemon-namespace>/engine-config.yaml` with owner-only permissions and starts the
 engine from it. Do not edit that generated file.
 
 Remove explicit `iii-engine-functions`, `iii-telemetry`, and `iii-observability` entries. The

--- a/docs/upgrading/workers-to-compose.mdx
+++ b/docs/upgrading/workers-to-compose.mdx
@@ -36,7 +36,7 @@ Write worker-compose.yaml:
 
 Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get and raw: true so ${VAR} templates are copied as templates rather than expanded values, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
-Never edit <project-dir>/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
+Never edit engine-config.yaml in the Compose state directory. Compose generates it at <project-dir>/.iii/compose/<namespace>/engine-config.yaml by default, or $III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/engine-config.yaml when III_COMPOSE_STATE_DIR is set.
 
 Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
@@ -105,8 +105,10 @@ engine:
 ```
 
 `engine.url` defaults to `ws://127.0.0.1:49134`. Compose writes the engine-only representation to
-`<project-dir>/.iii/compose/<daemon-namespace>/engine-config.yaml` with owner-only permissions and starts the
-engine from it. Do not edit that generated file.
+`<project-dir>/.iii/compose/<daemon-namespace>/engine-config.yaml` by default. When `III_COMPOSE_STATE_DIR`
+is set, the path is `$III_COMPOSE_STATE_DIR/<project-slug>/<daemon-namespace>/engine-config.yaml`.
+Compose writes the file with owner-only permissions and starts the engine from it. Do not edit
+that generated file.
 
 Remove explicit `iii-engine-functions`, `iii-telemetry`, and `iii-observability` entries. The
 engine injects them automatically, and declaring one under `engine.workers` fails.

--- a/docs/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/upgrading/workers-to-compose.mdx.skill.md
@@ -32,7 +32,7 @@ Write worker-compose.yaml:
 
 Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get and raw: true so ${VAR} templates are copied as templates rather than expanded values, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
-Never edit ~/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
+Never edit <project-dir>/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
 
 Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
@@ -101,7 +101,7 @@ engine:
 ```
 
 `engine.url` defaults to `ws://127.0.0.1:49134`. Compose writes the engine-only representation to
-`~/.iii/compose/<daemon-namespace>/engine-config.yaml` with owner-only permissions and starts the
+`<project-dir>/.iii/compose/<daemon-namespace>/engine-config.yaml` with owner-only permissions and starts the
 engine from it. Do not edit that generated file.
 
 Remove explicit `iii-engine-functions`, `iii-telemetry`, and `iii-observability` entries. The

--- a/docs/upgrading/workers-to-compose.mdx.skill.md
+++ b/docs/upgrading/workers-to-compose.mdx.skill.md
@@ -32,7 +32,7 @@ Write worker-compose.yaml:
 
 Stored configuration: for every worker whose configuration id changed (for example iii-state to state), read the old value with configuration::get and raw: true so ${VAR} templates are copied as templates rather than expanded values, put it under config_override or write it to the new id with configuration::set, and verify the new worker before removing the old entry. Do not rename YAML files as a shortcut.
 
-Never edit <project-dir>/.iii/compose/<namespace>/engine-config.yaml. Compose generates it.
+Never edit engine-config.yaml in the Compose state directory. Compose generates it at <project-dir>/.iii/compose/<namespace>/engine-config.yaml by default, or $III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/engine-config.yaml when III_COMPOSE_STATE_DIR is set.
 
 Start the project. iii compose stays in the foreground, so run it in a second terminal or send it to the background with its output in a log file, then wait until it has started every container:
   iii compose --namespace dev --up --file worker-compose.yaml
@@ -101,8 +101,10 @@ engine:
 ```
 
 `engine.url` defaults to `ws://127.0.0.1:49134`. Compose writes the engine-only representation to
-`<project-dir>/.iii/compose/<daemon-namespace>/engine-config.yaml` with owner-only permissions and starts the
-engine from it. Do not edit that generated file.
+`<project-dir>/.iii/compose/<daemon-namespace>/engine-config.yaml` by default. When `III_COMPOSE_STATE_DIR`
+is set, the path is `$III_COMPOSE_STATE_DIR/<project-slug>/<daemon-namespace>/engine-config.yaml`.
+Compose writes the file with owner-only permissions and starts the engine from it. Do not edit
+that generated file.
 
 Remove explicit `iii-engine-functions`, `iii-telemetry`, and `iii-observability` entries. The
 engine injects them automatically, and declaring one under `engine.workers` fails.

--- a/docs/using-iii/compose.mdx
+++ b/docs/using-iii/compose.mdx
@@ -70,7 +70,9 @@ systems, process names retain their previous behavior.
 
 ### Compose logs
 
-Compose logs stdout and stderr output from started workers to `$HOME/.iii/compose/namespace/`.
+Compose logs stdout and stderr output from started workers to
+`<project-dir>/.iii/compose/<namespace>/logs/`. The managed engine writes to `engine.log` in the
+same namespace directory.
 
 Logs are rotated every 10 MiB. Compose keeps up to 40 MiB of logs. Compose strips terminal control
 sequences before persisting the engine output.
@@ -667,7 +669,7 @@ iii compose build --file worker-compose.yaml
 iii compose --up --file worker-compose.yaml
 ```
 
-The cache is shared under `~/.iii/compose/packages`, or under `III_COMPOSE_STATE_DIR` when that
+The cache is shared under `~/.iii/compose/packages`, or under `$III_COMPOSE_STATE_DIR/packages` when that
 variable is set. A later `compose::up` reuses a valid cached artifact if it exists.
 
 ## Readiness
@@ -698,24 +700,42 @@ Dependency shutdown is dependent upon when a shutdown happens:
 
 ## Where compose keeps state
 
-Compose state is stored under `~/.iii/compose`, or under `$III_COMPOSE_STATE_DIR` when that is set.
+Compose state is stored in `<project-dir>/.iii/compose/<namespace>/`. `<project-dir>` is the directory
+containing the canonical compose file, including when `--file` points outside the current working
+directory or follows a symbolic link. `<namespace>` is the daemon's namespace.
 
-| Path                        | Contents                                                                                                            |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `<ns>/<project>/state.json` | One project's child records. Owner-only.                                                                            |
-| `<ns>/<project>/config/`    | Resolved configuration files.                                                                                       |
-| `<ns>/<project>/logs/`      | Rotating stdout and stderr for every project worker.                                                                |
-| `<ns>/<project>/vm/`        | VM state for bundle and local-image workers, one directory each, plus the config each one publishes into its guest. |
-| `packages/`                 | Installed `package://` artefacts, shared by projects.                                                               |
+| Path                 | Contents                                                                                      |
+| -------------------- | --------------------------------------------------------------------------------------------- |
+| `engine.lock`        | Lock for the managed engine in this project and namespace.                                     |
+| `engine-config.yaml` | Generated engine configuration, removed after clean shutdown.                                  |
+| `engine.log`         | Rotating stdout and stderr for the managed engine.                                             |
+| `state.json`         | Child process records for the project. Owner-only.                                             |
+| `config/`            | Resolved worker configuration files.                                                          |
+| `logs/`              | Rotating stdout and stderr for project workers.                                                |
+| `vm/`                | VM state for bundle and local-image workers, including rootfs, boot scripts and guest configs. |
 
-`<ns>` is the daemon's namespace. `<project>` is derived from the compose file's canonical path + a
-short hash to prevent project name collisions.
+Two projects can use `default` with separate engines on different ports. Starting the same project
+and namespace twice is refused. Two daemons on the same engine must use different namespaces.
+Two compose files in the same directory must also use different namespaces.
+
+For a read-only project directory, set `III_COMPOSE_STATE_DIR` to a writable directory. Project state
+is then stored at `$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The slug combines the project
+directory name with a hash of the canonical compose file path, keeping projects with the same
+directory name separate.
+
+The package cache stays shared at `~/.iii/compose/packages`, or `$III_COMPOSE_STATE_DIR/packages`.
+Add `.iii/compose/` to the project's `.gitignore` to exclude generated state from version control.
 
 ```bash
 iii trigger compose::status --namespace dev file=./worker-compose.yaml
-# ... "state_dir": "/home/you/.iii/compose/dev/shop-3f2a1b9c"
-ls /home/you/.iii/compose/dev/shop-3f2a1b9c/logs/
+# ... "state_dir": "/home/you/shop/.iii/compose/dev"
+ls /home/you/shop/.iii/compose/dev/logs/
 ```
+
+Before upgrading from the shared namespace layout, stop existing Compose daemons with the old
+version and confirm that their engines and workers have stopped. The new version does not migrate
+old process records or logs. Previous state remains under `~/.iii/compose/<namespace>/` (or the old
+`III_COMPOSE_STATE_DIR` layout); keep any logs or VM data you need before removing it.
 
 ## Error codes
 

--- a/docs/using-iii/compose.mdx
+++ b/docs/using-iii/compose.mdx
@@ -513,8 +513,8 @@ containers:
 
 Allowed worker keys are `configuration`, `iii-worker-manager`, `iii-http-functions`, `iii-stream`,
 and `iii-sandbox`. Use `#instance` for another instance of an allowed type, for example
-`iii-worker-manager#rbac`. Internal `iii-engine-functions`, `iii-telemetry`, and `iii-observability`
-are injected and must not be declared.
+`iii-worker-manager#rbac`. The engine starts `iii-engine-functions`, `iii-telemetry`, and
+`iii-observability` automatically. Do not declare these workers in the compose file.
 
 <Note>
   These workers are always engine managed and started so this method of operating these workers is

--- a/docs/using-iii/compose.mdx
+++ b/docs/using-iii/compose.mdx
@@ -70,9 +70,10 @@ systems, process names retain their previous behavior.
 
 ### Compose logs
 
-Compose logs stdout and stderr output from started workers to
-`<project-dir>/.iii/compose/<namespace>/logs/`. The managed engine writes to `engine.log` in the
-same namespace directory.
+Compose logs stdout and stderr output from started workers to `logs/` in the state directory.
+The default state directory is `<project-dir>/.iii/compose/<namespace>/`. When `III_COMPOSE_STATE_DIR`
+is set, it is `$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The managed engine writes to
+`engine.log` in that same state directory.
 
 Logs are rotated every 10 MiB. Compose keeps up to 40 MiB of logs. Compose strips terminal control
 sequences before persisting the engine output.
@@ -716,15 +717,18 @@ directory or follows a symbolic link. `<namespace>` is the daemon's namespace.
 
 Two projects can use `default` with separate engines on different ports. Starting the same project
 and namespace twice is refused. Two daemons on the same engine must use different namespaces.
-Two compose files in the same directory must also use different namespaces.
+With the default state layout, two compose files in the same directory must also use different
+namespaces.
 
 For a read-only project directory, set `III_COMPOSE_STATE_DIR` to a writable directory. Project state
 is then stored at `$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The slug combines the project
 directory name with a hash of the canonical compose file path, keeping projects with the same
-directory name separate.
+directory name separate. With this override, two compose files in the same directory have separate
+state directories and can use the same namespace on separate engines.
 
 The package cache stays shared at `~/.iii/compose/packages`, or `$III_COMPOSE_STATE_DIR/packages`.
-Add `.iii/compose/` to the project's `.gitignore` to exclude generated state from version control.
+Add `**/.iii/compose/` to the repository's `.gitignore` to exclude generated state, including state
+from nested projects, from version control.
 
 ```bash
 iii trigger compose::status --namespace dev file=./worker-compose.yaml

--- a/docs/using-iii/compose.mdx.skill.md
+++ b/docs/using-iii/compose.mdx.skill.md
@@ -64,7 +64,9 @@ systems, process names retain their previous behavior.
 
 ### Compose logs
 
-Compose logs stdout and stderr output from started workers to `$HOME/.iii/compose/namespace/`.
+Compose logs stdout and stderr output from started workers to
+`<project-dir>/.iii/compose/<namespace>/logs/`. The managed engine writes to `engine.log` in the
+same namespace directory.
 
 Logs are rotated every 10 MiB. Compose keeps up to 40 MiB of logs. Compose strips terminal control
 sequences before persisting the engine output.
@@ -661,7 +663,7 @@ iii compose build --file worker-compose.yaml
 iii compose --up --file worker-compose.yaml
 ```
 
-The cache is shared under `~/.iii/compose/packages`, or under `III_COMPOSE_STATE_DIR` when that
+The cache is shared under `~/.iii/compose/packages`, or under `$III_COMPOSE_STATE_DIR/packages` when that
 variable is set. A later `compose::up` reuses a valid cached artifact if it exists.
 
 ## Readiness
@@ -692,24 +694,42 @@ Dependency shutdown is dependent upon when a shutdown happens:
 
 ## Where compose keeps state
 
-Compose state is stored under `~/.iii/compose`, or under `$III_COMPOSE_STATE_DIR` when that is set.
+Compose state is stored in `<project-dir>/.iii/compose/<namespace>/`. `<project-dir>` is the directory
+containing the canonical compose file, including when `--file` points outside the current working
+directory or follows a symbolic link. `<namespace>` is the daemon's namespace.
 
-| Path                        | Contents                                                                                                            |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `<ns>/<project>/state.json` | One project's child records. Owner-only.                                                                            |
-| `<ns>/<project>/config/`    | Resolved configuration files.                                                                                       |
-| `<ns>/<project>/logs/`      | Rotating stdout and stderr for every project worker.                                                                |
-| `<ns>/<project>/vm/`        | VM state for bundle and local-image workers, one directory each, plus the config each one publishes into its guest. |
-| `packages/`                 | Installed `package://` artefacts, shared by projects.                                                               |
+| Path                 | Contents                                                                                      |
+| -------------------- | --------------------------------------------------------------------------------------------- |
+| `engine.lock`        | Lock for the managed engine in this project and namespace.                                     |
+| `engine-config.yaml` | Generated engine configuration, removed after clean shutdown.                                  |
+| `engine.log`         | Rotating stdout and stderr for the managed engine.                                             |
+| `state.json`         | Child process records for the project. Owner-only.                                             |
+| `config/`            | Resolved worker configuration files.                                                          |
+| `logs/`              | Rotating stdout and stderr for project workers.                                                |
+| `vm/`                | VM state for bundle and local-image workers, including rootfs, boot scripts and guest configs. |
 
-`<ns>` is the daemon's namespace. `<project>` is derived from the compose file's canonical path + a
-short hash to prevent project name collisions.
+Two projects can use `default` with separate engines on different ports. Starting the same project
+and namespace twice is refused. Two daemons on the same engine must use different namespaces.
+Two compose files in the same directory must also use different namespaces.
+
+For a read-only project directory, set `III_COMPOSE_STATE_DIR` to a writable directory. Project state
+is then stored at `$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The slug combines the project
+directory name with a hash of the canonical compose file path, keeping projects with the same
+directory name separate.
+
+The package cache stays shared at `~/.iii/compose/packages`, or `$III_COMPOSE_STATE_DIR/packages`.
+Add `.iii/compose/` to the project's `.gitignore` to exclude generated state from version control.
 
 ```bash
 iii trigger compose::status --namespace dev file=./worker-compose.yaml
-# ... "state_dir": "/home/you/.iii/compose/dev/shop-3f2a1b9c"
-ls /home/you/.iii/compose/dev/shop-3f2a1b9c/logs/
+# ... "state_dir": "/home/you/shop/.iii/compose/dev"
+ls /home/you/shop/.iii/compose/dev/logs/
 ```
+
+Before upgrading from the shared namespace layout, stop existing Compose daemons with the old
+version and confirm that their engines and workers have stopped. The new version does not migrate
+old process records or logs. Previous state remains under `~/.iii/compose/<namespace>/` (or the old
+`III_COMPOSE_STATE_DIR` layout); keep any logs or VM data you need before removing it.
 
 ## Error codes
 

--- a/docs/using-iii/compose.mdx.skill.md
+++ b/docs/using-iii/compose.mdx.skill.md
@@ -507,8 +507,8 @@ containers:
 
 Allowed worker keys are `configuration`, `iii-worker-manager`, `iii-http-functions`, `iii-stream`,
 and `iii-sandbox`. Use `#instance` for another instance of an allowed type, for example
-`iii-worker-manager#rbac`. Internal `iii-engine-functions`, `iii-telemetry`, and `iii-observability`
-are injected and must not be declared.
+`iii-worker-manager#rbac`. The engine starts `iii-engine-functions`, `iii-telemetry`, and
+`iii-observability` automatically. Do not declare these workers in the compose file.
 
 <Note>
   These workers are always engine managed and started so this method of operating these workers is

--- a/docs/using-iii/compose.mdx.skill.md
+++ b/docs/using-iii/compose.mdx.skill.md
@@ -64,9 +64,10 @@ systems, process names retain their previous behavior.
 
 ### Compose logs
 
-Compose logs stdout and stderr output from started workers to
-`<project-dir>/.iii/compose/<namespace>/logs/`. The managed engine writes to `engine.log` in the
-same namespace directory.
+Compose logs stdout and stderr output from started workers to `logs/` in the state directory.
+The default state directory is `<project-dir>/.iii/compose/<namespace>/`. When `III_COMPOSE_STATE_DIR`
+is set, it is `$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The managed engine writes to
+`engine.log` in that same state directory.
 
 Logs are rotated every 10 MiB. Compose keeps up to 40 MiB of logs. Compose strips terminal control
 sequences before persisting the engine output.
@@ -710,15 +711,18 @@ directory or follows a symbolic link. `<namespace>` is the daemon's namespace.
 
 Two projects can use `default` with separate engines on different ports. Starting the same project
 and namespace twice is refused. Two daemons on the same engine must use different namespaces.
-Two compose files in the same directory must also use different namespaces.
+With the default state layout, two compose files in the same directory must also use different
+namespaces.
 
 For a read-only project directory, set `III_COMPOSE_STATE_DIR` to a writable directory. Project state
 is then stored at `$III_COMPOSE_STATE_DIR/<project-slug>/<namespace>/`. The slug combines the project
 directory name with a hash of the canonical compose file path, keeping projects with the same
-directory name separate.
+directory name separate. With this override, two compose files in the same directory have separate
+state directories and can use the same namespace on separate engines.
 
 The package cache stays shared at `~/.iii/compose/packages`, or `$III_COMPOSE_STATE_DIR/packages`.
-Add `.iii/compose/` to the project's `.gitignore` to exclude generated state from version control.
+Add `**/.iii/compose/` to the repository's `.gitignore` to exclude generated state, including state
+from nested projects, from version control.
 
 ```bash
 iii trigger compose::status --namespace dev file=./worker-compose.yaml

--- a/engine/tests/compose_managed_engine_e2e.rs
+++ b/engine/tests/compose_managed_engine_e2e.rs
@@ -159,7 +159,13 @@ fn compose_up_starts_logs_and_stops_the_engine_it_owns() {
         "owner file not announced:\n{terminal}"
     );
 
-    let generated_config = state.path().join("managed-e2e/engine-config.yaml");
+    let project_state = state
+        .path()
+        .join(iii_compose::state::project_slug(
+            &compose.canonicalize().unwrap(),
+        ))
+        .join("managed-e2e");
+    let generated_config = project_state.join("engine-config.yaml");
     assert!(
         terminal.contains(generated_config.to_str().unwrap()),
         "generated config not announced:\n{terminal}"
@@ -169,7 +175,7 @@ fn compose_up_starts_logs_and_stops_the_engine_it_owns() {
         "clean error teardown must remove generated config"
     );
 
-    let engine_log = state.path().join("managed-e2e/engine.log");
+    let engine_log = project_state.join("engine.log");
     assert!(
         engine_log.exists(),
         "no engine log at {}",
@@ -394,7 +400,16 @@ fn signal_during_managed_engine_startup_stops_the_engine() {
     )
     .unwrap();
 
-    let generated_config = state.path().join("managed-early-signal/engine-config.yaml");
+    let generated_config = state
+        .path()
+        .join(iii_compose::state::project_slug(
+            &project
+                .path()
+                .join("worker-compose.yaml")
+                .canonicalize()
+                .unwrap(),
+        ))
+        .join("managed-early-signal/engine-config.yaml");
     let mut child = iii_bin()
         .current_dir(project.path())
         .env("III_COMPOSE_STATE_DIR", state.path())
@@ -468,6 +483,13 @@ fn signal_during_dependent_startup_rolls_back_every_started_process() {
 
     let generated_config = state
         .path()
+        .join(iii_compose::state::project_slug(
+            &project
+                .path()
+                .join("worker-compose.yaml")
+                .canonicalize()
+                .unwrap(),
+        ))
         .join("managed-dependent-signal/engine-config.yaml");
     let mut child = iii_bin()
         .current_dir(project.path())

--- a/engine/tests/compose_process_title_e2e.rs
+++ b/engine/tests/compose_process_title_e2e.rs
@@ -220,7 +220,14 @@ fn managed_engine_has_its_own_role_and_stops_with_the_named_compose() {
             "iii:e:orders".to_string(),
             "--config".to_string(),
             dir.path()
-                .join("state/orders/engine-config.yaml")
+                .join("state")
+                .join(iii_compose::state::project_slug(
+                    &dir.path()
+                        .join("worker-compose.yaml")
+                        .canonicalize()
+                        .unwrap(),
+                ))
+                .join("orders/engine-config.yaml")
                 .display()
                 .to_string(),
         ]

--- a/engine/tests/compose_project_state_e2e.rs
+++ b/engine/tests/compose_project_state_e2e.rs
@@ -1,0 +1,234 @@
+//! Project-local Compose state exercised through the real CLI.
+
+#![cfg(unix)]
+
+use std::{
+    fs,
+    net::{TcpListener, TcpStream},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    time::{Duration, Instant},
+};
+
+use nix::{sys::signal::Signal, unistd::Pid};
+
+fn compose_command(cwd: &Path, file: &Path, state_root: Option<&Path>) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_iii"));
+    command
+        .current_dir(cwd)
+        .args(["compose", "--up", "--file"])
+        .arg(file)
+        .env_remove("III_COMPOSE_STATE_DIR")
+        .env_remove("III_URL")
+        .env("III_TELEMETRY_ENABLED", "false")
+        .env("TOKIO_WORKER_THREADS", "2")
+        .env("NO_COLOR", "1")
+        .stdin(Stdio::null());
+    if let Some(root) = state_root {
+        command.env("III_COMPOSE_STATE_DIR", root);
+    }
+    command
+}
+
+struct ComposeProcess {
+    child: Child,
+    output: PathBuf,
+}
+
+impl ComposeProcess {
+    fn start(mut command: Command, output: PathBuf, state_dir: &Path) -> Self {
+        let log = fs::File::create(&output).unwrap();
+        let child = command
+            .stdout(log.try_clone().unwrap())
+            .stderr(log)
+            .spawn()
+            .unwrap();
+        let mut process = Self { child, output };
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !state_dir.join("state.json").exists() {
+            assert!(
+                process.child.try_wait().unwrap().is_none() && Instant::now() < deadline,
+                "compose did not start:\n{}",
+                fs::read_to_string(&process.output).unwrap_or_default()
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        process
+    }
+
+    fn stop(&mut self) {
+        nix::sys::signal::kill(Pid::from_raw(self.child.id() as i32), Signal::SIGTERM).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(20);
+        loop {
+            if let Some(status) = self.child.try_wait().unwrap() {
+                assert!(
+                    status.success(),
+                    "compose failed:\n{}",
+                    fs::read_to_string(&self.output).unwrap_or_default()
+                );
+                return;
+            }
+            assert!(Instant::now() < deadline, "compose did not stop");
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+impl Drop for ComposeProcess {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = nix::sys::signal::kill(Pid::from_raw(self.child.id() as i32), Signal::SIGTERM);
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while Instant::now() < deadline {
+                if self.child.try_wait().ok().flatten().is_some() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+fn write_compose(file: &Path, port: u16) {
+    fs::create_dir_all(file.parent().unwrap()).unwrap();
+    fs::write(
+        file,
+        format!("engine:\n  url: ws://127.0.0.1:{port}\n  workers: {{}}\ncontainers: {{}}\n"),
+    )
+    .unwrap();
+}
+
+#[test]
+fn default_namespace_is_isolated_beside_each_compose_file() {
+    let root = tempfile::tempdir().unwrap();
+    let a = root.path().join("one/shop/worker-compose.yaml");
+    let b = root.path().join("two/shop/worker-compose.yaml");
+    let listener_a = TcpListener::bind("127.0.0.1:0").unwrap();
+    let listener_b = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port_a = listener_a.local_addr().unwrap().port();
+    let port_b = listener_b.local_addr().unwrap().port();
+    write_compose(&a, port_a);
+    write_compose(&b, port_b);
+    let state_a = a.parent().unwrap().join(".iii/compose/default");
+    let state_b = b.parent().unwrap().join(".iii/compose/default");
+    drop((listener_a, listener_b));
+
+    // Both invocations start outside their projects, using relative --file paths.
+    let mut first = ComposeProcess::start(
+        compose_command(root.path(), a.strip_prefix(root.path()).unwrap(), None),
+        root.path().join("first.log"),
+        &state_a,
+    );
+    let mut second = ComposeProcess::start(
+        compose_command(root.path(), b.strip_prefix(root.path()).unwrap(), None),
+        root.path().join("second.log"),
+        &state_b,
+    );
+
+    for (file, state_dir, port) in [(&a, &state_a, port_a), (&b, &state_b, port_b)] {
+        let state: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(state_dir.join("state.json")).unwrap())
+                .unwrap();
+        assert_eq!(state["namespace"], "default");
+        assert_eq!(
+            state["compose_path"],
+            file.canonicalize().unwrap().to_str().unwrap()
+        );
+        for artifact in ["engine.lock", "engine-config.yaml", "engine.log", "logs"] {
+            assert!(state_dir.join(artifact).exists(), "missing {artifact}");
+        }
+        let config = fs::read_to_string(state_dir.join("engine-config.yaml")).unwrap();
+        assert!(config.contains(&format!("port: {port}")), "{config}");
+    }
+    assert!(!root.path().join(".iii/compose").exists());
+
+    first.stop();
+    assert!(!state_a.join("engine-config.yaml").exists());
+    assert!(!state_a.join("state.json").exists());
+    assert!(second.child.try_wait().unwrap().is_none());
+    assert!(state_b.join("engine-config.yaml").exists());
+    TcpStream::connect(("127.0.0.1", port_b)).expect("second project's engine still serves");
+    second.stop();
+    assert!(!state_b.join("state.json").exists());
+}
+
+#[test]
+fn relocated_state_groups_namespaces_under_each_project() {
+    let root = tempfile::tempdir().unwrap();
+    let state_root = root.path().join("shared-state");
+    let mut processes = Vec::new();
+    for (project, namespace) in [
+        ("one/shop", "default"),
+        ("two/shop", "default"),
+        ("one/shop", "dev"),
+    ] {
+        let file = root.path().join(project).join("worker-compose.yaml");
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        write_compose(&file, port);
+        let slug = iii_compose::state::project_slug(&file.canonicalize().unwrap());
+        let state_dir = state_root.join(&slug).join(namespace);
+        let mut command = compose_command(root.path(), &file, Some(&state_root));
+        command.args(["--namespace", namespace]);
+        drop(listener);
+        let process = ComposeProcess::start(
+            command,
+            root.path().join(format!("{slug}-{namespace}.log")),
+            &state_dir,
+        );
+        assert!(state_dir.join("engine-config.yaml").exists());
+        assert!(state_dir.join("engine.log").exists());
+        assert!(!file.parent().unwrap().join(".iii/compose").exists());
+        processes.push(process);
+    }
+    assert!(!state_root.join("default").exists());
+    for process in &mut processes {
+        process.stop();
+    }
+}
+
+#[test]
+fn the_same_project_namespace_is_refused_even_with_another_engine_port() {
+    let root = tempfile::tempdir().unwrap();
+    let file = root.path().join("worker-compose.yaml");
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    write_compose(&file, port);
+    let state_dir = root.path().join(".iii/compose/default");
+    drop(listener);
+    let mut first = ComposeProcess::start(
+        compose_command(root.path(), &file, None),
+        root.path().join("first.log"),
+        &state_dir,
+    );
+    let original_config = fs::read(state_dir.join("engine-config.yaml")).unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    write_compose(&file, listener.local_addr().unwrap().port());
+    drop(listener);
+    fs::create_dir(root.path().join("links")).unwrap();
+    std::os::unix::fs::symlink(&file, root.path().join("links/worker-compose.yaml")).unwrap();
+    let output = compose_command(root.path(), Path::new("links/worker-compose.yaml"), None)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("DAEMON_NAMESPACE_TAKEN"), "{stderr}");
+    assert_eq!(
+        fs::read(state_dir.join("engine-config.yaml")).unwrap(),
+        original_config
+    );
+    assert!(first.child.try_wait().unwrap().is_none());
+    TcpStream::connect(("127.0.0.1", port)).expect("original engine still serves");
+
+    write_compose(&file, port);
+    first.stop();
+    let mut restarted = ComposeProcess::start(
+        compose_command(root.path(), &file, None),
+        root.path().join("restarted.log"),
+        &state_dir,
+    );
+    restarted.stop();
+}

--- a/skills/iii-engine-config/SKILL.md
+++ b/skills/iii-engine-config/SKILL.md
@@ -51,7 +51,8 @@ iii compose --namespace orders-daemon --up --file worker-compose.yaml
 `engine.url` defaults to `ws://127.0.0.1:49134` and uses Compose's `${VAR:-default}` expansion.
 `engine.workers` stays opaque until the engine reads the generated YAML, so its values use
 `${VAR:default}` and retain numeric types. Compose materializes an owner-only config under
-`~/.iii/compose/<daemon-namespace>/` and removes it after clean shutdown. Changing `engine:`
+`<project-dir>/.iii/compose/<daemon-namespace>/` and removes it after clean shutdown. With
+`III_COMPOSE_STATE_DIR`, it uses `<state-root>/<project-slug>/<daemon-namespace>/`. Changing `engine:`
 requires restarting Compose. Do not combine a managed file with explicit `--engine`.
 
 Allowed engine worker base names are:


### PR DESCRIPTION
## What

Store managed engine locks, generated configs, logs, and worker state in `<project-dir>/.iii/compose/<namespace>/`, relative to the canonical compose file. Engine and worker storage now use the same path resolver.

When `III_COMPOSE_STATE_DIR` is set, use `<state-root>/<project-slug>/<namespace>/`. Keep downloaded packages shared in the existing package cache.

## Why

Two projects using `default` previously competed for `~/.iii/compose/default/engine.lock`, causing `DAEMON_NAMESPACE_TAKEN` even when their engines used different ports. Each project now has its own engine lock and runtime files.

Fixes [MOT-4730](https://linear.app/motia/issue/MOT-4730/store-compose-items-relative-to-worker-composeyaml).

## Notes

- Starting the same project and namespace twice is still refused, including through a symlink or after changing its engine port. Daemons on the same engine still need distinct namespaces.
- Stop old Compose daemons and their children before upgrading. Existing process records, logs, and VM data are not migrated automatically. The docs describe both layouts and the transition.
- Validation: 346 Compose tests and 30 engine integration tests passed, including project isolation, external state, relative `--file`, symlinks, duplicate rejection, restart, shutdown, and external engines. Formatting, Compose Clippy with warnings denied, documentation structure/Vale checks, and rendered-artifact checks passed.

<!-- cli-demos:start -->
## CLI demos

### Two projects using `default`

Both projects start with separate engines and keep their runtime files beside their compose files.

```sh
iii compose --up --file orders/worker-compose.yaml
iii compose --up --file billing/worker-compose.yaml
```

![Two projects use default without sharing an engine lock](https://vhs.charm.sh/vhs-6ixBZAYi99jDJrVtGELwDr.gif)

### Relocated project state

```sh
export III_COMPOSE_STATE_DIR=/demo/runtime
iii compose --up --file orders/worker-compose.yaml
```

![An external state root groups namespaces under each project slug](https://vhs.charm.sh/vhs-3oTi852yGV8YQORJX8og6w.gif)

### Duplicate project rejection

Starting the same project and namespace again is refused, even after changing its engine port.

```sh
iii compose --up --file orders/worker-compose.yaml
```

![The existing project lock rejects a second managed invocation](https://vhs.charm.sh/vhs-tieaDYLX3Zec2oiOE15o4.gif)
<!-- cli-demos:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compose state, logs, engine configuration, and locks are now stored per project under `.iii/compose/<namespace>/`.
  * Added support for relocating project state with `III_COMPOSE_STATE_DIR`.
  * Compose namespaces are isolated across different compose files and projects.

* **Documentation**
  * Updated usage, migration, and engine configuration guidance for the new state layout.
  * Documented ignore rules, package cache locations, and state migration considerations.

* **Tests**
  * Added end-to-end coverage for project-local state, relocation, namespace isolation, and collision handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->