### PR TITLE
feat(compose): warn on worker aliases and reuse canonical dependencies

### DIFF
--- a/crates/iii-compose/src/build.rs
+++ b/crates/iii-compose/src/build.rs
@@ -3,7 +3,7 @@
 
 //! Prepare every registry package in a compose file without starting anything.
 
-use std::{future::Future, path::Path, time::Instant};
+use std::{collections::BTreeSet, future::Future, path::Path, time::Instant};
 
 use futures::StreamExt;
 
@@ -91,7 +91,7 @@ where
             let began = Instant::now();
             report::starting(&container, &format!("preparing {reference}@{version}"));
             let result = installer(request, cache).await;
-            (index, container, began.elapsed(), result)
+            (index, container, reference, began.elapsed(), result)
         }
     }))
     .buffer_unordered(crate::parallelism::max_parallel_workers());
@@ -99,7 +99,14 @@ where
     let mut downloaded = 0;
     let mut cached = 0;
     let mut failures = Vec::new();
-    while let Some((index, container, elapsed, result)) = work.next().await {
+    let mut warned = BTreeSet::new();
+    while let Some((index, container, reference, elapsed, result)) = work.next().await {
+        if let Ok(package) = &result
+            && let Some(alias_of) = &package.alias_of
+            && warned.insert((registry::split_reference(&reference), alias_of.clone()))
+        {
+            registry::warn_alias(&container, &reference, Some(alias_of), None).await;
+        }
         match result {
             Ok(package) => match package.status {
                 InstallStatus::Downloaded => {
@@ -149,6 +156,7 @@ mod tests {
     fn package(status: InstallStatus) -> InstalledPackage {
         InstalledPackage {
             name: "worker".to_string(),
+            alias_of: None,
             version: "1.0.0".to_string(),
             payload: Payload::Binary("/tmp/worker".into()),
             default_config: None,

--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -454,9 +454,9 @@ impl Daemon {
         // add declaring one of this graph's dependencies as `path://`, say)
         // is planned again, and past the limit the add fails for a retry.
         let mut replans = 0;
-        let (_mutation, text, wanted) = loop {
-            let (snapshot, wanted) = self
-                .plan_add(path, &asked, &declarations, &asked_keys, &operation_id)
+        let (_mutation, text, plan) = loop {
+            let (snapshot, plan) = self
+                .plan_add(path, &declarations, &asked_keys, &operation_id)
                 .await?;
             let mutation = self.lock_mutation(path).await;
             if operation
@@ -470,7 +470,7 @@ impl Daemon {
                 source,
             })?;
             if text == snapshot {
-                break (mutation, text, wanted);
+                break (mutation, text, plan);
             }
             if replans == ADD_REPLAN_LIMIT {
                 return Err(ComposeError::AddPlanStale {
@@ -488,6 +488,16 @@ impl Daemon {
             );
         };
         self.validate_engine_policy_text(path, &text)?;
+        for alias in plan.aliases {
+            crate::registry::warn_alias(
+                &alias.container,
+                &alias.reference,
+                Some(&alias.canonical),
+                operation.as_deref(),
+            )
+            .await;
+        }
+        let wanted = plan.containers;
         let mut edited = text.clone();
         let mut added: Vec<String> = Vec::new();
         let mut replaced: Vec<String> = Vec::new();
@@ -583,72 +593,18 @@ impl Daemon {
     async fn plan_add(
         &self,
         path: &Path,
-        asked: &[crate::edit::NewContainer],
         declarations: &[crate::edit::NewContainer],
         asked_keys: &BTreeSet<String>,
         operation_id: &str,
-    ) -> Result<(String, Vec<crate::edit::NewContainer>)> {
+    ) -> Result<(String, crate::dependencies::Plan)> {
         let snapshot = std::fs::read_to_string(path).map_err(|source| ComposeError::Io {
             path: path.to_path_buf(),
             source,
         })?;
         let declared = ComposeFile::parse(&snapshot, path.to_path_buf())?;
-        let mut path_workers: BTreeSet<String> = declared
-            .containers
-            .iter()
-            .filter(|(_, container)| {
-                matches!(&container.worker, crate::config::WorkerSource::Path { .. })
-            })
-            .map(|(key, _)| key.clone())
-            .collect();
-        path_workers.extend(
-            declarations
-                .iter()
-                .filter(|worker| matches!(worker.source, crate::edit::Source::Path { .. }))
-                .map(|worker| worker.key.clone()),
-        );
-        // A worker is not useful alone: its manifest names what it calls, and
-        // the registry answers with that whole graph already pinned to versions
-        // that satisfy each other. They are declared rather than started
-        // behind the file, so what runs is still what the file says.
-        //
-        // Dependencies first and the worker last: with no `start_after`, start
-        // order is declaration order, so this is what makes a worker start
-        // after the things it calls.
-        let path_workers = &path_workers;
-        let mut expanded = futures::stream::iter(asked.iter().cloned().enumerate().map(
-            |(index, mut worker)| async move {
-                // Coalesce registry graphs before applying explicit settings.
-                // A requested worker can also be another worker's dependency.
-                worker.fields.clear();
-                worker.start_after.clear();
-                let graph = self.expand(&worker, path_workers).await;
-                (index, graph)
-            },
-        ))
-        .buffer_unordered(4)
-        .collect::<Vec<_>>()
-        .await;
-        expanded.sort_by_key(|(index, _)| *index);
-        let mut wanted = Vec::new();
-        for (_, graph) in expanded {
-            wanted.extend(graph?);
-        }
-        let wanted = coalesce_containers(wanted)?;
-        // Against the snapshot read above, which is also the text the caller
-        // edits, so the registry artifacts acquired below are only the ones
-        // this add actually declares.
-        let mut wanted = keep_declared_dependencies(wanted, asked_keys, &declared);
-        for worker in &mut wanted {
-            if let Some(declaration) = declarations.iter().find(|item| item.key == worker.key) {
-                worker.fields = declaration.fields.clone();
-                worker
-                    .start_after
-                    .extend(declaration.start_after.iter().cloned());
-                worker.start_after.sort();
-                worker.start_after.dedup();
-            }
-        }
+        let mut plan = crate::dependencies::plan(&declared, declarations).await?;
+        plan.containers = keep_declared_dependencies(plan.containers, asked_keys, &declared);
+        let wanted = &plan.containers;
 
         // Acquire registry artifacts before taking either the file mutation lock
         // or the project's runtime lock. `lifecycle::start_one` calls install
@@ -670,7 +626,7 @@ impl Daemon {
                 let package_cache = package_cache.clone();
                 let operation = operation.clone();
                 async move {
-                    if let Some(operation) = operation {
+                    if let Some(operation) = &operation {
                         operation
                             .emit(
                                 Some(&key),
@@ -679,9 +635,17 @@ impl Daemon {
                             )
                             .await;
                     }
-                    crate::registry::install(&key, &reference, &version, &package_cache)
-                        .await
-                        .map(|_| ())
+                    let installed =
+                        crate::registry::install(&key, &reference, &version, &package_cache)
+                            .await?;
+                    crate::registry::warn_alias(
+                        &key,
+                        &reference,
+                        installed.alias_of.as_deref(),
+                        operation.as_deref(),
+                    )
+                    .await;
+                    Ok(())
                 }
             }))
             .buffer_unordered(4)
@@ -699,36 +663,7 @@ impl Daemon {
                 operation_id: operation_id.to_string(),
             });
         }
-        Ok((snapshot, wanted))
-    }
-
-    /// The worker asked for, plus everything it needs, in start order.
-    ///
-    /// A `path://` worker is taken alone: its dependencies are declared in a
-    /// manifest on disk, and resolving those means asking the registry per name
-    /// rather than reading one answer. That is worth doing, and is not done
-    /// here yet.
-    ///
-    /// A registry dependency already declared as `path://` is also taken as an
-    /// operator-owned boundary. The package keeps its edge to that container,
-    /// but neither the local worker nor the package dependencies below it are
-    /// added from the registry graph.
-    ///
-    /// `engine` workers are skipped. They are compiled into the engine and are
-    /// already serving before compose starts anything; declaring one would
-    /// produce a container with no artefact to install.
-    async fn expand(
-        &self,
-        asked: &crate::edit::NewContainer,
-        path_workers: &BTreeSet<String>,
-    ) -> Result<Vec<crate::edit::NewContainer>> {
-        let crate::edit::Source::Package { reference, version } = &asked.source else {
-            return Ok(vec![asked.clone()]);
-        };
-
-        let range = version.clone().unwrap_or_else(|| "*".to_string());
-        let graph = crate::registry::resolve_graph(&asked.key, reference, &range).await?;
-        expand_graph(asked, reference, graph, path_workers)
+        Ok((snapshot, plan))
     }
 
     /// Moves declared containers to other versions of the same packages.
@@ -1403,7 +1338,7 @@ fn keep_declared_dependencies(
 /// root is different: silently omitting the exact worker the caller requested
 /// would make `compose::add` report success without changing the project, so
 /// reject it with migration guidance instead.
-fn expand_graph(
+pub(crate) fn expand_graph(
     asked: &crate::edit::NewContainer,
     reference: &str,
     graph: crate::registry::Graph,
@@ -1671,6 +1606,7 @@ containers:
                 name: "configuration".to_string(),
                 version: "0.23.0".to_string(),
                 kind: "engine".to_string(),
+                ..Default::default()
             }],
             edges: Vec::new(),
         };
@@ -1698,6 +1634,7 @@ containers:
                 name: "iii-engine-functions".to_string(),
                 version: "0.23.0".to_string(),
                 kind: "engine".to_string(),
+                ..Default::default()
             }],
             edges: Vec::new(),
         };
@@ -1722,16 +1659,19 @@ containers:
                     name: "api".to_string(),
                     version: "1.0.0".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
                 crate::registry::Node {
                     name: "configuration".to_string(),
                     version: "0.23.0".to_string(),
                     kind: "engine".to_string(),
+                    ..Default::default()
                 },
                 crate::registry::Node {
                     name: "state".to_string(),
                     version: "2.0.0".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
             ],
             edges: vec![
@@ -1755,16 +1695,19 @@ containers:
                     name: "state".to_string(),
                     version: "2.0.0".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
                 crate::registry::Node {
                     name: "db".to_string(),
                     version: "3.0.0".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
                 crate::registry::Node {
                     name: "api".to_string(),
                     version: "1.0.0".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
             ],
             edges: vec![
@@ -1787,11 +1730,13 @@ containers:
                     name: "api".to_string(),
                     version: "1.0.0".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
                 crate::registry::Node {
                     name: "state".to_string(),
                     version: "2.0.0".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
             ],
             edges: vec![
@@ -1813,11 +1758,13 @@ containers:
                     name: "tailscale".to_string(),
                     version: "1.0.0".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
                 crate::registry::Node {
                     name: "console".to_string(),
                     version: "1.9.11".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
             ],
             edges: vec![("tailscale".to_string(), "console".to_string())],
@@ -1849,16 +1796,19 @@ containers:
                     name: "tailscale".to_string(),
                     version: "1.0.0".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
                 crate::registry::Node {
                     name: "console".to_string(),
                     version: "1.9.11".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
                 crate::registry::Node {
                     name: "state".to_string(),
                     version: "2.0.0".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
             ],
             edges: vec![
@@ -1893,16 +1843,19 @@ containers:
                     name: "tailscale".to_string(),
                     version: "1.0.0".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
                 crate::registry::Node {
                     name: "console".to_string(),
                     version: "1.9.11".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
                 crate::registry::Node {
                     name: "state".to_string(),
                     version: "2.0.0".to_string(),
                     kind: "binary".to_string(),
+                    ..Default::default()
                 },
             ],
             edges: vec![
@@ -1927,6 +1880,7 @@ containers:
                 name: "console".to_string(),
                 version: "1.9.11".to_string(),
                 kind: "binary".to_string(),
+                ..Default::default()
             }],
             edges: Vec::new(),
         };

--- a/crates/iii-compose/src/dependencies.rs
+++ b/crates/iii-compose/src/dependencies.rs
@@ -1,0 +1,752 @@
+// Copyright Motia LLC and/or licensed to Motia LLC under one or more
+// contributor license agreements. Licensed under the Elastic License 2.0.
+
+//! Select instances for generated dependencies without renaming declarations.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use futures::StreamExt;
+
+use crate::{
+    ComposeFile, WorkerSource,
+    edit::{NewContainer, Source},
+    error::{ComposeError, Result},
+    registry::{self, Node},
+};
+
+type Identity = (String, String);
+
+#[derive(Clone)]
+struct Package {
+    registry: String,
+    node: Node,
+    /// A fresh resolution of a range cannot identify an already running version.
+    exact_version: bool,
+}
+
+impl Package {
+    fn identity(&self) -> Identity {
+        (
+            self.registry.clone(),
+            self.node.canonical_name().to_string(),
+        )
+    }
+}
+
+struct Candidate {
+    declaration: NewContainer,
+    package: Option<Package>,
+}
+
+#[derive(Debug)]
+pub(crate) struct Alias {
+    pub container: String,
+    pub reference: String,
+    pub canonical: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct Plan {
+    pub containers: Vec<NewContainer>,
+    pub aliases: Vec<Alias>,
+}
+
+/// Resolve before editing or downloading. Existing package declarations must be
+/// inspected too: an old alias may be present only in the compose file.
+pub(crate) async fn plan(file: &ComposeFile, asked: &[NewContainer]) -> Result<Plan> {
+    let paths: BTreeSet<String> = file
+        .containers
+        .iter()
+        .filter(|(_, container)| matches!(container.worker, WorkerSource::Path { .. }))
+        .map(|(key, _)| key.clone())
+        .chain(
+            asked
+                .iter()
+                .filter(|worker| matches!(worker.source, Source::Path { .. }))
+                .map(|worker| worker.key.clone()),
+        )
+        .collect();
+    let expansions = futures::stream::iter(asked.iter().cloned().map(|worker| {
+        let paths = paths.clone();
+        async move {
+            let Source::Package { reference, version } = &worker.source else {
+                return Ok(vec![Candidate {
+                    declaration: worker.clone(),
+                    package: None,
+                }]);
+            };
+            let graph =
+                registry::resolve_graph(&worker.key, reference, version.as_deref().unwrap_or("*"))
+                    .await?;
+            let nodes: BTreeMap<_, _> = graph
+                .nodes
+                .iter()
+                .map(|node| (node.name.clone(), node.clone()))
+                .collect();
+            let mut root = worker.clone();
+            root.fields.clear();
+            root.start_after.clear();
+            let expanded = crate::daemon::expand_graph(&root, reference, graph, &paths)?;
+            let (registry, _) = registry::split_reference(reference);
+            expanded
+                .into_iter()
+                .map(|declaration| {
+                    let node = nodes.get(&declaration.key).cloned().ok_or_else(|| {
+                        conflict(
+                            &declaration.key,
+                            "the registry graph does not contain the requested worker",
+                        )
+                    })?;
+                    Ok(Candidate {
+                        declaration,
+                        package: Some(Package {
+                            registry: registry.clone(),
+                            node,
+                            exact_version: true,
+                        }),
+                    })
+                })
+                .collect::<Result<Vec<_>>>()
+        }
+    }))
+    .buffered(4)
+    .collect::<Vec<Result<Vec<Candidate>>>>()
+    .await;
+    let expanded = expansions
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let registries: BTreeSet<String> = expanded
+        .iter()
+        .filter_map(|candidate| candidate.package.as_ref())
+        .map(|package| package.registry.clone())
+        .collect();
+    let requested: BTreeSet<&str> = asked.iter().map(|worker| worker.key.as_str()).collect();
+    let existing_requests: Vec<_> = file
+        .containers
+        .iter()
+        .filter_map(|(key, container)| {
+            if requested.contains(key.as_str()) {
+                return None;
+            }
+            let WorkerSource::Package { reference } = &container.worker else {
+                return None;
+            };
+            let (registry, _) = registry::split_reference(reference);
+            if !registries.contains(registry.as_str()) {
+                return None;
+            }
+            Some((
+                key.clone(),
+                reference.clone(),
+                container.version.clone().unwrap_or_else(|| "*".into()),
+                registry,
+            ))
+        })
+        .collect();
+    let existing = futures::stream::iter(existing_requests.into_iter().map(
+        |(key, reference, range, registry)| async move {
+            let node = registry::resolve_package(&key, &reference, &range).await?;
+            let exact_version = range == node.version;
+            Ok((
+                key,
+                Package {
+                    registry,
+                    node,
+                    exact_version,
+                },
+            ))
+        },
+    ))
+    .buffered(4)
+    .collect::<Vec<Result<_>>>()
+    .await
+    .into_iter()
+    .collect::<Result<BTreeMap<_, _>>>()?;
+    plan_resolved(
+        asked,
+        expanded,
+        &existing,
+        &file.containers.keys().cloned().collect(),
+    )
+}
+
+fn conflict(name: &str, reason: &str) -> ComposeError {
+    ComposeError::InvalidWorkerSpec {
+        spec: name.to_string(),
+        reason: reason.to_string(),
+    }
+}
+
+fn plan_resolved(
+    asked: &[NewContainer],
+    expanded: Vec<Candidate>,
+    existing: &BTreeMap<String, Package>,
+    existing_keys: &BTreeSet<String>,
+) -> Result<Plan> {
+    let requested: BTreeMap<&str, &NewContainer> = asked
+        .iter()
+        .map(|worker| (worker.key.as_str(), worker))
+        .collect();
+    let mut owners: BTreeMap<Identity, BTreeMap<&str, &Package>> = BTreeMap::new();
+    for (key, package) in existing {
+        owners
+            .entry(package.identity())
+            .or_default()
+            .insert(key, package);
+    }
+    let mut automatic: BTreeMap<Identity, Vec<&Package>> = BTreeMap::new();
+    for candidate in &expanded {
+        let Some(package) = &candidate.package else {
+            continue;
+        };
+        if requested.contains_key(candidate.declaration.key.as_str()) {
+            let previous = owners
+                .entry(package.identity())
+                .or_default()
+                .insert(&candidate.declaration.key, package);
+            if let Some(previous) = previous
+                && !previous.node.same_release(&package.node)
+            {
+                return Err(conflict(
+                    &candidate.declaration.key,
+                    "the requested container resolves to different versions, artifacts, or default configurations in the dependency graphs",
+                ));
+            }
+        } else {
+            automatic
+                .entry(package.identity())
+                .or_default()
+                .push(package);
+        }
+    }
+
+    let mut selected = BTreeMap::new();
+    for (identity, packages) in &automatic {
+        let release = &packages[0].node;
+        if packages
+            .iter()
+            .any(|package| !release.same_release(&package.node))
+        {
+            return Err(conflict(
+                &identity.1,
+                &format!(
+                    "aliases of '{}' resolve to different versions, artifacts, or default configurations. \
+                 Align the dependency versions before adding these workers",
+                    identity.1,
+                ),
+            ));
+        }
+        let choices = owners.get(identity);
+        // Preserve the existing add policy for an unchanged package name.
+        // Alias convergence needs a release match; an ordinary declared
+        // dependency keeps its pin until compose::update changes it.
+        let aliases_used = packages
+            .iter()
+            .any(|package| package.node.alias_of.is_some())
+            || choices.is_some_and(|choices| {
+                choices
+                    .values()
+                    .any(|package| package.node.alias_of.is_some())
+            });
+        if !aliases_used
+            && let Some(declared) = existing.get(&release.name)
+            && declared.identity() == *identity
+        {
+            selected.insert(identity.clone(), release.name.clone());
+            continue;
+        }
+        let compatible: Vec<&str> = choices
+            .into_iter()
+            .flat_map(|choices| choices.iter())
+            .filter(|(_, package)| package.exact_version && release.same_release(&package.node))
+            .map(|(key, _)| *key)
+            .collect();
+        let key = match compatible.as_slice() {
+            [key] => (*key).to_string(),
+            [] if choices.is_some_and(|choices| !choices.is_empty()) => {
+                return Err(conflict(
+                    &identity.1,
+                    &format!(
+                        "dependency '{}' at version '{}' conflicts with the declared instances. \
+                 Pin matching exact versions and artifacts before adding this worker",
+                        identity.1, release.version,
+                    ),
+                ));
+            }
+            [] => {
+                let key = identity.1.clone();
+                if existing_keys.contains(&key) || requested.contains_key(key.as_str()) {
+                    return Err(conflict(
+                        &key,
+                        "the canonical dependency name is already used by another container. Keep that declaration and choose an unambiguous dependency",
+                    ));
+                }
+                key
+            }
+            _ => {
+                return Err(conflict(
+                    &identity.1,
+                    &format!(
+                        "dependency '{}' matches multiple declared containers: {}. \
+                 Keep their settings and select a single dependency instance before adding this worker",
+                        identity.1,
+                        compatible.join(", "),
+                    ),
+                ));
+            }
+        };
+        selected.insert(identity.clone(), key);
+    }
+
+    // Edges use registry names, while start_after uses container keys. The
+    // registry is part of this lookup so a custom registry cannot borrow a
+    // declaration from another registry with the same worker name.
+    let mut targets = BTreeMap::new();
+    for candidate in &expanded {
+        let Some(package) = &candidate.package else {
+            continue;
+        };
+        let key = if requested.contains_key(candidate.declaration.key.as_str()) {
+            candidate.declaration.key.clone()
+        } else {
+            selected[&package.identity()].clone()
+        };
+        targets.insert(
+            (package.registry.clone(), candidate.declaration.key.clone()),
+            key,
+        );
+    }
+
+    let mut containers: BTreeMap<String, NewContainer> = BTreeMap::new();
+    let mut order = Vec::new();
+    let mut aliases = Vec::new();
+    for candidate in expanded {
+        let mut declaration = candidate.declaration;
+        let explicit = requested.get(declaration.key.as_str()).copied();
+        if let Some(package) = candidate.package {
+            let original_key = declaration.key.clone();
+            let key = targets[&(package.registry.clone(), original_key.clone())].clone();
+            if let Some(canonical) = &package.node.alias_of {
+                aliases.push(Alias {
+                    container: key.clone(),
+                    reference: format!(
+                        "{}/{}",
+                        package.registry.trim_start_matches("https://"),
+                        package.node.name
+                    ),
+                    canonical: canonical.clone(),
+                });
+            }
+            if explicit.is_none()
+                && (existing.contains_key(&key) || requested.contains_key(key.as_str()))
+            {
+                // Reuse an owner without changing its configuration, source,
+                // version, or startup dependencies.
+                continue;
+            }
+            declaration.key = key;
+            if explicit.is_none() {
+                declaration.source = Source::Package {
+                    reference: format!(
+                        "{}/{}",
+                        package.registry.trim_start_matches("https://"),
+                        package.node.canonical_name()
+                    ),
+                    version: Some(package.node.version.clone()),
+                };
+            }
+            for dependency in &mut declaration.start_after {
+                if let Some(target) = targets.get(&(package.registry.clone(), dependency.clone())) {
+                    *dependency = target.clone();
+                }
+                if dependency == &declaration.key {
+                    return Err(ComposeError::DependencyCycle {
+                        path: format!("{original_key} -> {}", declaration.key),
+                    });
+                }
+            }
+        }
+        if let Some(explicit) = explicit {
+            declaration.fields = explicit.fields.clone();
+            declaration
+                .start_after
+                .extend(explicit.start_after.iter().cloned());
+        }
+        declaration.start_after.sort();
+        declaration.start_after.dedup();
+        if let Some(previous) = containers.get_mut(&declaration.key) {
+            if previous.source != declaration.source || previous.fields != declaration.fields {
+                return Err(conflict(
+                    &declaration.key,
+                    "the dependency resolves to conflicting sources, versions, or settings",
+                ));
+            }
+            previous.start_after.extend(declaration.start_after);
+            previous.start_after.sort();
+            previous.start_after.dedup();
+        } else {
+            order.push(declaration.key.clone());
+            containers.insert(declaration.key.clone(), declaration);
+        }
+    }
+
+    // A reused declaration owns its dependency tree. Do not install nodes that
+    // were reachable only through the registry's version of that declaration.
+    let mut reachable = BTreeSet::new();
+    let mut visit: Vec<String> = asked.iter().map(|worker| worker.key.clone()).collect();
+    while let Some(key) = visit.pop() {
+        if reachable.insert(key.clone())
+            && let Some(container) = containers.get(&key)
+        {
+            visit.extend(container.start_after.iter().cloned());
+        }
+    }
+    order.retain(|key| reachable.contains(key));
+    containers.retain(|key, _| reachable.contains(key));
+    aliases.retain(|alias| reachable.contains(&alias.container));
+    let mut sorted = Vec::new();
+    while !order.is_empty() {
+        let Some(index) = order.iter().position(|key| {
+            containers[key]
+                .start_after
+                .iter()
+                .all(|dep| !containers.contains_key(dep))
+        }) else {
+            return Err(ComposeError::DependencyCycle {
+                path: order.join(" -> "),
+            });
+        };
+        let key = order.remove(index);
+        if let Some(container) = containers.remove(&key) {
+            sorted.push(container);
+        }
+    }
+    Ok(Plan {
+        containers: sorted,
+        aliases,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(name: &str, alias_of: Option<&str>, dependencies: &[&str]) -> Candidate {
+        Candidate {
+            declaration: NewContainer {
+                key: name.into(),
+                source: Source::Package {
+                    reference: format!("api.workers.iii.dev/{name}"),
+                    version: Some("1.0.0".into()),
+                },
+                start_after: dependencies.iter().map(|name| (*name).into()).collect(),
+                fields: Default::default(),
+            },
+            package: Some(Package {
+                registry: registry::DEFAULT_REGISTRY.into(),
+                exact_version: true,
+                node: Node {
+                    name: name.into(),
+                    alias_of: alias_of.map(str::to_string),
+                    version: "1.0.0".into(),
+                    kind: "binary".into(),
+                    artifact_digest: Some("a".repeat(64)),
+                    ..Default::default()
+                },
+            }),
+        }
+    }
+
+    fn request(candidate: &Candidate) -> NewContainer {
+        let mut declaration = candidate.declaration.clone();
+        declaration.start_after.clear();
+        declaration
+    }
+
+    #[test]
+    fn alias_and_canonical_dependencies_share_one_container() {
+        let a = candidate("api", None, &["console"]);
+        let b = candidate("jobs", None, &["shell"]);
+        let asked = vec![request(&a), request(&b)];
+        let plan = plan_resolved(
+            &asked,
+            vec![
+                candidate("console", Some("shell"), &[]),
+                a,
+                candidate("shell", None, &[]),
+                b,
+            ],
+            &BTreeMap::new(),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            plan.containers
+                .iter()
+                .map(|c| (c.key.as_str(), c.start_after.clone()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("shell", vec![]),
+                ("api", vec!["shell".into()]),
+                ("jobs", vec!["shell".into()]),
+            ]
+        );
+        assert_eq!(plan.aliases[0].container, "shell");
+    }
+
+    #[test]
+    fn existing_instance_is_reused_without_editing_its_settings_or_dependencies() {
+        let a = candidate("api", None, &["console"]);
+        let asked = vec![request(&a)];
+        let existing = BTreeMap::from([(
+            "my-shell".into(),
+            candidate("shell", None, &[]).package.unwrap(),
+        )]);
+        let plan = plan_resolved(
+            &asked,
+            vec![
+                candidate("helper", None, &[]),
+                candidate("console", Some("shell"), &["helper"]),
+                a,
+            ],
+            &existing,
+            &existing.keys().cloned().collect(),
+        )
+        .unwrap();
+        assert_eq!(plan.containers.len(), 1);
+        assert_eq!(plan.containers[0].start_after, vec!["my-shell"]);
+    }
+
+    #[test]
+    fn existing_alias_keeps_its_container_key() {
+        let a = candidate("api", None, &["shell"]);
+        let asked = vec![request(&a)];
+        let existing = BTreeMap::from([(
+            "console".into(),
+            candidate("console", Some("shell"), &[]).package.unwrap(),
+        )]);
+        let plan = plan_resolved(
+            &asked,
+            vec![candidate("shell", None, &[]), a],
+            &existing,
+            &existing.keys().cloned().collect(),
+        )
+        .unwrap();
+        assert_eq!(plan.containers[0].start_after, vec!["console"]);
+    }
+
+    #[test]
+    fn explicitly_requested_instances_keep_distinct_configurations() {
+        let mut a = candidate("console", Some("shell"), &[]);
+        a.declaration
+            .fields
+            .insert("config_name".into(), "console-config".into());
+        let mut b = candidate("shell", None, &[]);
+        b.declaration
+            .fields
+            .insert("config_name".into(), "shell-config".into());
+        let asked = vec![request(&a), request(&b)];
+        let plan = plan_resolved(&asked, vec![a, b], &BTreeMap::new(), &BTreeSet::new()).unwrap();
+        assert_eq!(plan.containers, asked);
+    }
+
+    #[test]
+    fn generated_alias_uses_an_explicit_canonical_request() {
+        let a = candidate("api", None, &["console"]);
+        let shell = candidate("shell", None, &[]);
+        let asked = vec![request(&a), request(&shell)];
+        let plan = plan_resolved(
+            &asked,
+            vec![candidate("console", Some("shell"), &[]), a, shell],
+            &BTreeMap::new(),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            plan.containers
+                .iter()
+                .map(|c| c.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["shell", "api"]
+        );
+    }
+
+    #[test]
+    fn ambiguous_existing_instances_are_not_merged() {
+        let a = candidate("api", None, &["console"]);
+        let asked = vec![request(&a)];
+        let package = candidate("shell", None, &[]).package.unwrap();
+        let existing = BTreeMap::from([
+            ("shell-one".into(), package.clone()),
+            ("shell-two".into(), package),
+        ]);
+        let error = plan_resolved(
+            &asked,
+            vec![candidate("console", Some("shell"), &[]), a],
+            &existing,
+            &existing.keys().cloned().collect(),
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("multiple declared containers: shell-one, shell-two")
+        );
+    }
+
+    #[test]
+    fn different_alias_versions_are_refused() {
+        let a = candidate("api", None, &["console", "shell"]);
+        let asked = vec![request(&a)];
+        let mut shell = candidate("shell", None, &[]);
+        shell.package.as_mut().unwrap().node.version = "2.0.0".into();
+        let error = plan_resolved(
+            &asked,
+            vec![candidate("console", Some("shell"), &[]), shell, a],
+            &BTreeMap::new(),
+            &BTreeSet::new(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("different versions, artifacts"));
+    }
+
+    #[test]
+    fn a_matching_version_with_a_different_artifact_is_refused() {
+        let a = candidate("api", None, &["console"]);
+        let asked = vec![request(&a)];
+        let mut package = candidate("shell", None, &[]).package.unwrap();
+        package.node.artifact_digest = Some("b".repeat(64));
+        let existing = BTreeMap::from([("shell".into(), package)]);
+        let error = plan_resolved(
+            &asked,
+            vec![candidate("console", Some("shell"), &[]), a],
+            &existing,
+            &existing.keys().cloned().collect(),
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("conflicts with the declared instances")
+        );
+    }
+
+    #[test]
+    fn an_existing_version_range_is_not_treated_as_a_known_running_version() {
+        let a = candidate("api", None, &["console"]);
+        let asked = vec![request(&a)];
+        let mut package = candidate("shell", None, &[]).package.unwrap();
+        package.exact_version = false;
+        let existing = BTreeMap::from([("shell".into(), package)]);
+        let error = plan_resolved(
+            &asked,
+            vec![candidate("console", Some("shell"), &[]), a],
+            &existing,
+            &existing.keys().cloned().collect(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("Pin matching exact versions"));
+    }
+
+    #[test]
+    fn an_ordinary_declared_dependency_keeps_its_pin_on_add() {
+        let a = candidate("api", None, &["shell"]);
+        let asked = vec![request(&a)];
+        let mut package = candidate("shell", None, &[]).package.unwrap();
+        package.node.version = "0.9.0".into();
+        let existing = BTreeMap::from([("shell".into(), package)]);
+        let plan = plan_resolved(
+            &asked,
+            vec![candidate("shell", None, &[]), a],
+            &existing,
+            &existing.keys().cloned().collect(),
+        )
+        .unwrap();
+        assert_eq!(plan.containers.len(), 1);
+        assert_eq!(plan.containers[0].start_after, vec!["shell"]);
+    }
+
+    #[test]
+    fn a_requested_root_cannot_hide_conflicting_dependency_artifacts() {
+        let a = candidate("api", None, &["shell"]);
+        let shell = candidate("shell", None, &[]);
+        let asked = vec![request(&a), request(&shell)];
+        let mut dependency = candidate("shell", None, &[]);
+        dependency.package.as_mut().unwrap().node.artifact_digest = Some("b".repeat(64));
+        let error = plan_resolved(
+            &asked,
+            vec![dependency, a, shell],
+            &BTreeMap::new(),
+            &BTreeSet::new(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("different versions, artifacts"));
+    }
+
+    #[test]
+    fn containers_from_another_registry_do_not_satisfy_a_dependency() {
+        let a = candidate("api", None, &["console"]);
+        let asked = vec![request(&a)];
+        let mut package = candidate("shell", None, &[]).package.unwrap();
+        package.registry = "https://custom.example".into();
+        let existing = BTreeMap::from([("custom-shell".into(), package)]);
+        let plan = plan_resolved(
+            &asked,
+            vec![candidate("console", Some("shell"), &[]), a],
+            &existing,
+            &existing.keys().cloned().collect(),
+        )
+        .unwrap();
+        assert_eq!(plan.containers[0].key, "shell");
+        assert_eq!(plan.containers[1].start_after, vec!["shell"]);
+    }
+
+    #[test]
+    fn a_generated_canonical_name_cannot_replace_a_local_container() {
+        let a = candidate("api", None, &["console"]);
+        let asked = vec![request(&a)];
+        let error = plan_resolved(
+            &asked,
+            vec![candidate("console", Some("shell"), &[]), a],
+            &BTreeMap::new(),
+            &BTreeSet::from(["shell".into()]),
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("already used by another container")
+        );
+    }
+
+    #[test]
+    fn local_dependencies_keep_their_original_edges() {
+        let a = candidate("api", None, &["console"]);
+        let asked = vec![request(&a)];
+        let plan = plan_resolved(
+            &asked,
+            vec![a],
+            &BTreeMap::new(),
+            &BTreeSet::from(["console".into()]),
+        )
+        .unwrap();
+        assert_eq!(plan.containers[0].start_after, vec!["console"]);
+    }
+
+    #[test]
+    fn a_cycle_created_by_alias_resolution_is_refused() {
+        let a = candidate("api", None, &["console"]);
+        let asked = vec![request(&a)];
+        let error = plan_resolved(
+            &asked,
+            vec![candidate("console", Some("api"), &[]), a],
+            &BTreeMap::new(),
+            &BTreeSet::new(),
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "DEPENDENCY_CYCLE");
+    }
+}

--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -24,6 +24,7 @@ pub mod config;
 pub mod configuration;
 pub mod daemon;
 pub mod dag;
+mod dependencies;
 pub mod edit;
 pub mod engine;
 pub mod error;

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -681,6 +681,14 @@ async fn start_one_until_shutdown(
                 range,
                 ctx.package_cache,
             ))?;
+            let operation = operation_id.and_then(crate::operation::active);
+            crate::registry::warn_alias(
+                key,
+                reference,
+                installed.alias_of.as_deref(),
+                operation.as_deref(),
+            )
+            .await;
             report::starting(
                 key,
                 &format!("starting {} {}", installed.name, installed.version),

--- a/crates/iii-compose/src/operation.rs
+++ b/crates/iii-compose/src/operation.rs
@@ -9,7 +9,7 @@
 //! only; normal progress delivery never polls.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     sync::{Arc, Mutex, OnceLock, Weak},
     time::Instant,
 };
@@ -196,6 +196,7 @@ struct State {
     completed: usize,
     sequence: u64,
     last_event: Option<ProgressEvent>,
+    warnings: BTreeSet<String>,
 }
 
 pub struct Operation {
@@ -220,6 +221,7 @@ impl Operation {
                 completed: 0,
                 sequence: 0,
                 last_event: None,
+                warnings: BTreeSet::new(),
             }),
             cancel,
             emitter,
@@ -282,6 +284,14 @@ impl Operation {
     pub async fn emit(&self, container: Option<&str>, phase: &str, detail: impl Into<String>) {
         self.emit_progress(container, phase, detail, None, None, false)
             .await;
+    }
+
+    pub(crate) async fn warn_once(&self, key: String, container: &str, detail: String) {
+        if !self.state.write().await.warnings.insert(key) {
+            return;
+        }
+        crate::report::daemon_line(&format!("warning: {detail}"), true);
+        self.emit(Some(container), "warning", detail).await;
     }
     pub async fn plan(&self, total: usize) {
         self.state.write().await.total = total;
@@ -401,6 +411,34 @@ impl OperationManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn alias_warnings_are_emitted_once_per_operation_even_with_concurrent_installs() {
+        let emitter = ProgressEmitter {
+            client: IIIClient::new("ws://127.0.0.1:1/ws"),
+            bindings: Arc::new(Mutex::new(BTreeMap::new())),
+        };
+        let operation = Operation::new("compose:alias-warning".into(), 1, emitter.clone());
+        tokio::join!(
+            crate::registry::warn_alias("shell", "console", Some("shell"), Some(&operation)),
+            crate::registry::warn_alias(
+                "shell",
+                "api.workers.iii.dev/console",
+                Some("shell"),
+                Some(&operation)
+            ),
+        );
+        let snapshot = operation.snapshot().await;
+        assert_eq!(snapshot.last_sequence, 1);
+        let event = snapshot.last_event.unwrap();
+        assert_eq!(event.phase, "warning");
+        assert_eq!(event.container.as_deref(), Some("shell"));
+        assert!(event.detail.contains("'console' is an alias of 'shell'"));
+        assert!(!event.terminal);
+        let next = Operation::new("compose:next-alias-warning".into(), 1, emitter);
+        crate::registry::warn_alias("shell", "console", Some("shell"), Some(&next)).await;
+        assert_eq!(next.snapshot().await.last_sequence, 1);
+    }
 
     #[test]
     fn lifecycle_suffixes_resolve_to_the_root_operation() {

--- a/crates/iii-compose/src/registry.rs
+++ b/crates/iii-compose/src/registry.rs
@@ -68,6 +68,8 @@ struct ResolvedEdge {
 #[derive(Debug, Deserialize)]
 struct ResolvedWorker {
     name: String,
+    #[serde(default)]
+    alias_of: Option<String>,
     version: String,
     #[serde(rename = "type")]
     kind: String,
@@ -113,12 +115,37 @@ pub enum InstallStatus {
 #[derive(Debug, Clone)]
 pub struct InstalledPackage {
     pub name: String,
+    pub alias_of: Option<String>,
     pub version: String,
     pub payload: Payload,
     /// Configuration the worker ships with, to be merged under anything the
     /// compose file overrides.
     pub default_config: Option<serde_yaml::Value>,
     pub status: InstallStatus,
+}
+
+/// Alias warnings belong to an operation, not the daemon's lifetime: add may
+/// acquire a package and then install it again during reconciliation.
+pub(crate) async fn warn_alias(
+    container: &str,
+    reference: &str,
+    alias_of: Option<&str>,
+    operation: Option<&crate::operation::Operation>,
+) {
+    let Some(canonical) = alias_of else { return };
+    let (registry, name) = split_reference(reference);
+    let detail = format!(
+        "worker '{name}' is an alias of '{canonical}'. Using container '{container}'. \
+         Use 'package://{}/{canonical}' for new references.",
+        registry.trim_start_matches("https://"),
+    );
+    if let Some(operation) = operation {
+        operation
+            .warn_once(format!("{registry}/{name}/{canonical}"), container, detail)
+            .await;
+    } else {
+        crate::report::daemon_line(&format!("warning: {detail}"), true);
+    }
 }
 
 /// The rust target triple this daemon is running on, which is the one its
@@ -151,7 +178,7 @@ pub fn host_target() -> &'static str {
 
 /// Splits `workers.iii.dev/state` into its registry base and worker name. A
 /// reference with no host uses [`DEFAULT_REGISTRY`].
-fn split_reference(reference: &str) -> (String, String) {
+pub(crate) fn split_reference(reference: &str) -> (String, String) {
     match reference.split_once('/') {
         Some((host, name)) => (format!("https://{host}"), name.to_string()),
         None => (DEFAULT_REGISTRY.to_string(), reference.to_string()),
@@ -160,8 +187,7 @@ fn split_reference(reference: &str) -> (String, String) {
 
 /// Resolves a package reference and makes sure its binary is on disk.
 ///
-/// `cache_root` holds installs keyed by artefact identity; an already-installed
-/// version is reused without touching the network.
+/// Resolution is always refreshed; cached artifacts do not need another download.
 pub async fn install(
     container: &str,
     reference: &str,
@@ -182,11 +208,17 @@ async fn install_from_registry(
     let target = host_target();
 
     let resolved = resolve(container, registry, name, version_range, target).await?;
+    // Registry identity is separate from the operator's container key.
+    let cache_root = if registry == DEFAULT_REGISTRY {
+        cache_root.to_path_buf()
+    } else {
+        cache_root.join(hex::encode(Sha256::digest(registry.as_bytes())))
+    };
 
     let (payload, status) = match resolved.kind.as_str() {
         "binary" => {
             let (program, status) =
-                install_binary(container, &resolved, target, cache_root).await?;
+                install_binary(container, &resolved, target, &cache_root).await?;
             (Payload::Binary(program), status)
         }
         // Refused before the download on a platform that could not start it:
@@ -201,7 +233,7 @@ async fn install_from_registry(
         }
         #[cfg(unix)]
         "bundle" => {
-            let (install_dir, status) = install_bundle(container, &resolved, cache_root).await?;
+            let (install_dir, status) = install_bundle(container, &resolved, &cache_root).await?;
             (Payload::Bundle(install_dir), status)
         }
         // `engine` workers are compiled into the engine itself: there is no
@@ -223,6 +255,7 @@ async fn install_from_registry(
 
     Ok(InstalledPackage {
         name: resolved.name,
+        alias_of: resolved.alias_of,
         version: resolved.version,
         payload,
         default_config,
@@ -239,13 +272,59 @@ pub async fn latest_version(container: &str, reference: &str) -> Result<String> 
 }
 
 /// One worker in a resolved graph.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Node {
     pub name: String,
+    pub alias_of: Option<String>,
     pub version: String,
     /// `binary`, `bundle`, `engine`, `image` — what it is, and therefore
     /// whether compose can run it at all.
     pub kind: String,
+    /// Digest for this host, or the bundle archive. Used to compare resolutions.
+    pub artifact_digest: Option<String>,
+    pub default_config: Option<serde_json::Value>,
+}
+
+impl Node {
+    pub fn canonical_name(&self) -> &str {
+        self.alias_of.as_deref().unwrap_or(&self.name)
+    }
+
+    pub(crate) fn same_release(&self, other: &Self) -> bool {
+        self.version == other.version
+            && self.kind == other.kind
+            && self.artifact_digest == other.artifact_digest
+            && self.default_config == other.default_config
+    }
+}
+
+impl From<ResolvedWorker> for Node {
+    fn from(worker: ResolvedWorker) -> Self {
+        let artifact_digest = if worker.kind == "bundle" {
+            worker.sha256.as_deref()
+        } else {
+            worker
+                .binaries
+                .get(host_target())
+                .map(|artifact| artifact.sha256.as_str())
+        }
+        .map(str::to_ascii_lowercase);
+        Self {
+            name: worker.name,
+            alias_of: worker.alias_of,
+            version: worker.version,
+            kind: worker.kind,
+            artifact_digest,
+            default_config: worker.config.filter(|config| !config.is_null()),
+        }
+    }
+}
+
+pub(crate) async fn resolve_package(container: &str, reference: &str, range: &str) -> Result<Node> {
+    let (registry, name) = split_reference(reference);
+    resolve(container, &registry, &name, range, host_target())
+        .await
+        .map(Node::from)
 }
 
 /// A resolved graph: what to declare, and what each one needs.
@@ -267,15 +346,7 @@ pub async fn resolve_graph(container: &str, reference: &str, version_range: &str
     let target = host_target();
     let response = resolve_response(container, &registry, &name, version_range, target).await?;
     Ok(Graph {
-        nodes: response
-            .graph
-            .into_iter()
-            .map(|worker| Node {
-                name: worker.name,
-                version: worker.version,
-                kind: worker.kind,
-            })
-            .collect(),
+        nodes: response.graph.into_iter().map(Node::from).collect(),
         edges: response
             .edges
             .into_iter()
@@ -310,8 +381,11 @@ async fn install_binary(
     let digest = validated_cache_digest(container, resolved, &artifact.sha256)?;
     let install_dir = cache_root.join(format!(
         "{}-{}-{}-{digest}",
-        resolved.name, resolved.version, target
+        resolved.alias_of.as_deref().unwrap_or(&resolved.name),
+        resolved.version,
+        target
     ));
+    let _lock = lock_artifact(&install_dir).await?;
     if let Some(existing) = installed_binary(&install_dir) {
         return Ok((existing, InstallStatus::Cached));
     }
@@ -359,8 +433,10 @@ async fn install_bundle(
     let digest = validated_cache_digest(container, resolved, sha256)?;
     let install_dir = cache_root.join(format!(
         "{}-{}-bundle-{digest}",
-        resolved.name, resolved.version
+        resolved.alias_of.as_deref().unwrap_or(&resolved.name),
+        resolved.version
     ));
+    let _lock = lock_artifact(&install_dir).await?;
     // The manifest is the bundle's entry point, so its presence is what makes
     // an install dir a cache hit — not the first executable, which a bundle
     // need not have at all.
@@ -383,6 +459,33 @@ async fn install_bundle(
         });
     }
     Ok((install_dir, InstallStatus::Downloaded))
+}
+
+/// The kernel releases this lock on cancellation or process exit. Keep the lock
+/// file in place so every process continues to lock the same inode.
+async fn lock_artifact(install_dir: &Path) -> Result<fslock::LockFile> {
+    let mut path = install_dir.as_os_str().to_os_string();
+    path.push(".lock");
+    let path = PathBuf::from(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| ComposeError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let mut lock = fslock::LockFile::open(&path).map_err(|source| ComposeError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    loop {
+        if lock.try_lock().map_err(|source| ComposeError::Io {
+            path: path.clone(),
+            source,
+        })? {
+            return Ok(lock);
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 }
 
 /// Returns the normalized digest used as the immutable part of a cache key.
@@ -530,6 +633,11 @@ fn check_names(container: &str, registry: &str, resolved: &ResolveResponse) -> R
         }
         if !is_path_safe(&worker.version) {
             return Err(refuse("version", &worker.version));
+        }
+        if let Some(alias_of) = &worker.alias_of
+            && !is_path_safe(alias_of)
+        {
+            return Err(refuse("alias_of", alias_of));
         }
     }
     Ok(())
@@ -806,6 +914,133 @@ mod tests {
         let (registry, name) = split_reference("state");
         assert_eq!(registry, DEFAULT_REGISTRY);
         assert_eq!(name, "state");
+    }
+
+    async fn alias_registry(kind: &str, archive: Vec<u8>, downloads: u64) -> MockServer {
+        let server = MockServer::start().await;
+        let digest = hex::encode(Sha256::digest(&archive));
+        let url = format!("{}/artifact", server.uri());
+        let kind = kind.to_string();
+        Mock::given(matchers::method("POST"))
+            .and(matchers::path("/resolve"))
+            .respond_with(move |request: &wiremock::Request| {
+                let request: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                let name = request["worker"].as_str().unwrap();
+                let mut worker = serde_json::json!({
+                    "name": name, "version": "1.0.0", "type": kind,
+                    "binaries": { (host_target()): { "sha256": digest, "url": url } },
+                    "archive_url": url, "sha256": digest,
+                });
+                if name == "console" {
+                    worker["alias_of"] = "shell".into();
+                }
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"graph": [worker]}))
+            })
+            .mount(&server)
+            .await;
+        Mock::given(matchers::method("GET"))
+            .and(matchers::path("/artifact"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(archive)
+                    .set_delay(Duration::from_millis(100)),
+            )
+            .expect(downloads)
+            .mount(&server)
+            .await;
+        server
+    }
+
+    #[tokio::test]
+    async fn concurrent_alias_and_canonical_installs_download_one_binary() {
+        let server = alias_registry("binary", executable_archive(b"#!/bin/sh\nexit 0\n"), 1).await;
+        let cache = tempfile::tempdir().unwrap();
+        let registry = server.uri();
+        let (alias, canonical) = tokio::join!(
+            install_from_registry("console", &registry, "console", "1.0.0", cache.path()),
+            install_from_registry("shell", &registry, "shell", "1.0.0", cache.path()),
+        );
+        let alias = alias.unwrap();
+        let canonical = canonical.unwrap();
+        assert_eq!(alias.payload, canonical.payload);
+        assert_ne!(alias.status, canonical.status);
+        assert_eq!(alias.alias_of.as_deref(), Some("shell"));
+        assert_eq!(canonical.alias_of, None);
+        let cached_alias =
+            install_from_registry("console", &registry, "console", "1.0.0", cache.path())
+                .await
+                .unwrap();
+        assert_eq!(cached_alias.status, InstallStatus::Cached);
+        assert_eq!(cached_alias.alias_of.as_deref(), Some("shell"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn concurrent_alias_and_canonical_installs_share_a_bundle() {
+        let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut archive = tar::Builder::new(encoder);
+        let body = b"name: shell\n";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        archive
+            .append_data(&mut header, BUNDLE_MANIFEST, &body[..])
+            .unwrap();
+        let server =
+            alias_registry("bundle", archive.into_inner().unwrap().finish().unwrap(), 1).await;
+        let registry = server.uri();
+        let cache = tempfile::tempdir().unwrap();
+        let (alias, canonical) = tokio::join!(
+            install_from_registry("console", &registry, "console", "1.0.0", cache.path()),
+            install_from_registry("shell", &registry, "shell", "1.0.0", cache.path()),
+        );
+        let alias = alias.unwrap();
+        let canonical = canonical.unwrap();
+        assert_eq!(alias.payload, canonical.payload);
+        assert_ne!(alias.status, canonical.status);
+        assert!(matches!(alias.payload, Payload::Bundle(_)));
+    }
+
+    #[tokio::test]
+    async fn registries_with_the_same_package_name_keep_separate_cache_entries() {
+        let archive = executable_archive(b"#!/bin/sh\nexit 0\n");
+        let first = alias_registry("binary", archive.clone(), 1).await;
+        let second = alias_registry("binary", archive, 1).await;
+        let cache = tempfile::tempdir().unwrap();
+        let one = install_from_registry("shell", &first.uri(), "shell", "1.0.0", cache.path())
+            .await
+            .unwrap();
+        let two = install_from_registry("shell", &second.uri(), "shell", "1.0.0", cache.path())
+            .await
+            .unwrap();
+        assert_ne!(one.payload, two.payload);
+        assert_eq!(two.status, InstallStatus::Downloaded);
+    }
+
+    #[test]
+    fn aliases_are_preserved_for_root_and_dependency_graph_nodes() {
+        let response: ResolveResponse = serde_json::from_value(serde_json::json!({
+            "graph": [
+                {"name": "console", "alias_of": "shell", "version": "1.0.0", "type": "binary"},
+                {"name": "api", "version": "1.0.0", "type": "binary"}
+            ]
+        }))
+        .unwrap();
+        let nodes: Vec<Node> = response.graph.into_iter().map(Node::from).collect();
+        assert_eq!(nodes[0].name, "console");
+        assert_eq!(nodes[0].canonical_name(), "shell");
+        assert_eq!(nodes[1].alias_of, None);
+    }
+
+    #[test]
+    fn an_unsafe_canonical_name_is_refused_before_installation() {
+        let response: ResolveResponse = serde_json::from_value(serde_json::json!({
+            "graph": [{"name": "console", "alias_of": "../shell", "version": "1.0.0", "type": "binary"}]
+        })).unwrap();
+        let error = check_names("console", DEFAULT_REGISTRY, &response).unwrap_err();
+        assert_eq!(error.code(), "REGISTRY_NAME_REFUSED");
+        assert!(error.to_string().contains("alias_of"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Warn when Compose installs a worker through a registry alias, including cache hits. Alias and canonical references share one verified artifact cache entry, with a lock to prevent concurrent downloads.

When `compose::add` expands dependencies, map aliases to one canonical dependency or reuse a compatible declared instance. For example, if `api` depends on `console` and `jobs` depends on `shell`, and `console` aliases `shell`, both use the same `shell` container.

## Why

Registry alias support in https://github.com/iii-hq/registry/pull/96 keeps old worker names usable after a rename. Without canonical identity in Compose, these names can cause duplicate downloads and duplicate dependency processes.

## Notes

- Preserve explicitly declared container keys, settings, and separate instances.
- Reject ambiguous alias matches or conflicting versions, artifacts, and default configurations before editing the compose file.
- Keep the existing add policy for ordinary dependencies: declared version pins remain unchanged.
- Scope custom registry caches separately. Emit each alias warning once per operation.
- Planning resolves existing package declarations in the relevant registries to discover legacy aliases absent from the new graph. If their identity cannot be resolved, the add stops before editing the file. A narrower lookup requires a complete alias index or stored canonical identity.

Validation: `cargo fmt --all -- --check`, `cargo clippy -p iii-compose --all-targets --all-features --locked -- -D warnings`, `cargo test -p iii-compose --all-features --locked` (367 passed, 1 ignored), and `cargo build -p iii --bin iii --locked`.

<!-- cli-demos:start -->
## CLI demos

Recorded with a local TLS registry fixture and isolated Compose state. The demo build enables native certificate roots to trust the local fixture CA.

### Build through an alias

Alias and canonical references share one artifact download.

```sh
iii compose build
```

![Build through an alias](https://vhs.charm.sh/vhs-3JqfqVG5xNIIskcALUGWAc.gif)

### Warn on a cache hit

A cached alias still emits a warning.

```sh
iii compose build
```

![Warn on a cache hit](https://vhs.charm.sh/vhs-3baqauWbkCBOn1iErthSVU.gif)

### Start an alias worker

The alias warning appears before the worker becomes ready.

```sh
iii compose --up
```

![Start an alias worker](https://vhs.charm.sh/vhs-4J6221EUE9aUX7e3tVEeik.gif)

### Share an automatic dependency

The local registry resolves api → console (alias of shell) and jobs → shell. Both use one shell container.

```sh
iii trigger compose::add --port 54434 worker=localhost:54433/api worker=localhost:54433/jobs
```

![Share an automatic dependency](https://vhs.charm.sh/vhs-1X9nAMppjtwsxVm0MlZh5A.gif)

### Reuse a declared instance

The dependency uses the existing my-shell container and preserves its declaration.

```sh
iii trigger compose::add --port 54434 worker=localhost:54433/api
```

![Reuse a declared instance](https://vhs.charm.sh/vhs-4G0V7Jn5hJ6B82667fex9K.gif)

### Reject an incompatible version

An existing shell at 2.0.0 conflicts with the dependency at 1.0.0. The operation fails and the compose file stays unchanged.

```sh
iii trigger compose::add --port 54434 worker=localhost:54433/api
```

![Reject an incompatible version](https://vhs.charm.sh/vhs-1ojzJTxkHEIQp9dbBADdKP.gif)
<!-- cli-demos:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved dependency resolution for Compose applications, including automatic reuse of compatible packages and support for package aliases.
  * Added clearer handling of dependency conflicts, ambiguous versions, and circular dependencies.
  * Registry caches are now separated by registry, improving reliability across multiple package sources.
  * Added clearer warnings when packages resolve through aliases.
* **Bug Fixes**
  * Prevented duplicate alias warnings during a single operation.
  * Improved coordination of concurrent package installations to avoid conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->