### PR TITLE
fix(compose): retry a spawn that fails with ETXTBSY

### DIFF
--- a/crates/iii-compose/src/process/unix.rs
+++ b/crates/iii-compose/src/process/unix.rs
@@ -89,7 +89,7 @@ fn spawn_supervised_inner(
             .stderr(std::process::Stdio::piped());
     }
 
-    let mut child = command.spawn()?;
+    let mut child = spawn_retrying_text_file_busy(&mut command)?;
     let output = ChildOutput {
         stdout: child.stdout.take(),
         stderr: child.stderr.take(),
@@ -115,6 +115,30 @@ fn spawn_supervised_inner(
         },
         output,
     ))
+}
+
+/// `exec` refuses a binary that some process still holds open for writing
+/// (`ETXTBSY`): a worker build that just finished, `iii update` swapping the
+/// engine, or, in tests, a stub written moments ago whose descriptor a
+/// concurrent fork inherited for a few microseconds before its own exec. The
+/// window is short, so retry with a growing pause (about half a second in
+/// total) before reporting the failure.
+fn spawn_retrying_text_file_busy(
+    command: &mut tokio::process::Command,
+) -> std::io::Result<tokio::process::Child> {
+    const ATTEMPTS: u64 = 10;
+    let mut attempt = 0;
+    loop {
+        match command.spawn() {
+            Err(err)
+                if err.kind() == std::io::ErrorKind::ExecutableFileBusy && attempt < ATTEMPTS =>
+            {
+                attempt += 1;
+                std::thread::sleep(std::time::Duration::from_millis(10 * attempt));
+            }
+            other => return other,
+        }
+    }
 }
 
 impl Supervised {
@@ -277,4 +301,48 @@ pub fn is_same_process(pid: u32, recorded: &BirthIdentity) -> bool {
 fn exited_unknown() -> ExitStatus {
     use std::os::unix::process::ExitStatusExt;
     ExitStatus::from_raw(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::Write as _,
+        os::unix::fs::OpenOptionsExt,
+        time::{Duration, Instant},
+    };
+
+    use super::spawn_supervised;
+
+    #[tokio::test]
+    async fn spawn_retries_while_the_executable_is_still_open_for_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("busy.sh");
+        let mut writer = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o700)
+            .open(&script)
+            .unwrap();
+        writer.write_all(b"#!/bin/sh\nexit 0\n").unwrap();
+        writer.flush().unwrap();
+
+        // Hold the write handle across the first attempts: exec answers
+        // ETXTBSY until it is dropped.
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(80));
+            drop(writer);
+        });
+
+        let started = Instant::now();
+        let child = spawn_supervised(tokio::process::Command::new(&script))
+            .expect("spawn should wait out ETXTBSY");
+        release.join().unwrap();
+
+        assert!(child.pid > 0);
+        assert!(
+            started.elapsed() >= Duration::from_millis(60),
+            "spawn should have retried instead of succeeding before the writer closed"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`Compose Tests` flakes with `EngineSpawnFailed { message: "could not start /tmp/.../noisy-iii: Text file busy (os error 26)" }` in `managed_engine::tests` (this time `engine_log_rotates_before_it_can_grow_without_bound` on #2161; earlier `engine_receives_config_and_captures_both_output_streams` on #2154, and the same in the workers repo). The tests write a stub engine and spawn it while sibling tests fork their own children; a forked child inherits the stub's write descriptor for the microseconds before its own `exec`, and the kernel refuses to exec a file that is open for writing.

The same race exists in real use: a worker build or `iii update` that has just replaced the binary compose is about to start.

## Fix

`spawn_supervised_inner` (unix) retries `ErrorKind::ExecutableFileBusy` with a growing pause, 10 attempts and about half a second in total, before surfacing the error. Any other error is returned on the first attempt as before. Windows is untouched.

## Test

`process::unix::tests::spawn_retries_while_the_executable_is_still_open_for_writing` keeps the stub's write handle open for 80 ms from another thread and asserts the spawn succeeds and took at least 60 ms. With the retry removed it fails immediately:

```
spawn should wait out ETXTBSY: Os { code: 26, kind: ExecutableFileBusy, message: "Text file busy" }
```

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Process startup now automatically retries temporary `ETXTBSY` failures, improving reliability when an executable is briefly unavailable.
  * Added coverage for successful startup after the executable becomes available during the retry window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->