### PR TITLE
fix: route Vercel security checks through the docs origin

### DIFF
--- a/infra/terraform/website/cloudfront.tf
+++ b/infra/terraform/website/cloudfront.tf
@@ -218,6 +218,20 @@ resource "aws_cloudfront_distribution" "site" {
     origin_request_policy_id = local.origin_request_all_viewer_id
   }
 
+  # Checkpoint assets and verification POSTs must reach the docs origin.
+  # CloudFront requires the full method set to allow POST.
+  ordered_cache_behavior {
+    path_pattern           = "/.well-known/vercel/*"
+    target_origin_id       = "docs-nlb"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    cache_policy_id          = local.cache_policy_disabled_id
+    origin_request_policy_id = local.origin_request_all_viewer_id
+  }
+
   viewer_certificate {
     acm_certificate_arn      = aws_acm_certificate_validation.site.certificate_arn
     ssl_support_method       = "sni-only"

--- a/infra/terraform/website/cloudfront.tf
+++ b/infra/terraform/website/cloudfront.tf
@@ -230,6 +230,12 @@ resource "aws_cloudfront_distribution" "site" {
 
     cache_policy_id          = local.cache_policy_disabled_id
     origin_request_policy_id = local.origin_request_all_viewer_id
+
+    # The function preserves /.well-known/ requests and canonicalizes www.
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.redirects.arn
+    }
   }
 
   viewer_certificate {


### PR DESCRIPTION
## What

Route `/.well-known/vercel/*` through the existing `docs-nlb` origin, with caching disabled and all viewer headers, cookies, and query strings forwarded. Allow the full CloudFront HTTP method set so the browser can submit the verification POST. Reuse the existing viewer-request function, which preserves `/.well-known/` requests while retaining the canonical redirect from `www.iii.dev`. Do not apply the website response-header policy to checkpoint responses.

## Why

Visitors intermittently get stuck at the Vercel Security Checkpoint on `https://iii.dev/docs`. Docs requests reach Mintlify, but the checkpoint's root-level paths currently fall through to the S3 website origin.

Both `/.well-known/vercel/security/static/challenge.v2.min.js` and `challenge.v2.wasm` return S3 `404 NoSuchKey` on `iii.dev`. Both return `200` with the correct content types through `docs.iii.dev`. Probing that origin while preserving `Host: iii.dev` and TLS SNI also returned `200` and `no-store` for both files.

This restores the route required by [Mintlify's reverse-proxy configuration](https://www.mintlify.com/docs/deploy/reverse-proxy). It does not disable Vercel protection or determine which upstream rule initially triggers a challenge.

## Notes

- Terraform 1.9.8: recursive `fmt -check`, `validate`, and a read-only production `plan` passed. All 70 existing redirect-function tests and `git diff --check` passed. A focused handler check also confirmed that the checkpoint POST, headers, cookies, and query remain intact and the `www` canonical redirect is preserved.
- The CloudFront plan adds only the new behavior, updating distribution `E3N35RPQE4YVFQ` in place. Dependent IAM/S3 policy documents are deferred until apply, producing two additional planned policy updates.
- The full plan is **1 add, 3 change, 0 destroy**. The SNS email subscription creation is pre-existing drift: an independent plan of unchanged `main` is **1 add, 0 change, 0 destroy**, for that same subscription. Review this before production apply; this PR does not change SNS configuration.
- No Terraform apply was run. After deployment, verify the public JavaScript/WASM URLs and the complete browser challenge, including its verification POST and subsequent docs access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added routing for `/.well-known/vercel/*` requests through the documentation service.
  * Supports all standard HTTP methods, including read, write, and request-option methods.
  * Enables compressed responses while disabling edge caching for these requests.
  * Preserves `/.well-known/` request paths and applies canonical URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->