### PR TITLE
(MOT-4712) fix(worker): accept the Registry's `license` key in iii.worker.yaml when `base_image` is set

### DIFF
--- a/crates/iii-worker/src/cli/project.rs
+++ b/crates/iii-worker/src/cli/project.rs
@@ -253,7 +253,8 @@ pub fn validate_manifest_keys(
         "unknown key(s) in {}: [{}]. Supported fields are: name, description, \
          runtime.base_image, scripts.(setup|install|start), env, dependencies, \
          resources.(cpus|memory), plus the registry publish metadata keys \
-         (iii, deploy, manifest, tags) which the engine accepts and ignores.",
+         (iii, deploy, manifest, tags, license) which the engine accepts and \
+         ignores.",
         manifest_path.display(),
         unknown.join(", "),
     ))

--- a/crates/iii-worker/src/cli/worker_manifest.rs
+++ b/crates/iii-worker/src/cli/worker_manifest.rs
@@ -120,6 +120,11 @@ pub struct WorkerManifest {
     pub tags: Option<Vec<String>>,
 
     #[schemars(
+        description = "Registry publish metadata: SPDX license id the Registry publishes the worker under (e.g. `Apache-2.0`), required by the workers-repo release CI. Accepted and ignored by the engine."
+    )]
+    pub license: Option<String>,
+
+    #[schemars(
         with = "Option<JsonValue>",
         description = "DEPRECATED — set per-worker config directly in your project's config.yaml entry instead. Copied verbatim into config.yaml at add time."
     )]
@@ -265,6 +270,7 @@ fn shape_problems(doc: &YamlValue) -> Vec<String> {
         "iii",
         "deploy",
         "manifest",
+        "license",
     ] {
         if let Some(v) = present(doc.get(field))
             && v.as_str().is_none()
@@ -733,6 +739,17 @@ mod tests {
     }
 
     #[test]
+    fn report_accepts_the_registry_license() {
+        // The workers-repo release CI requires `license` for Registry
+        // publication, so a worker that publishes AND runs from a local path
+        // needs the engine to accept the key.
+        let r = report("name: onboarding\nlicense: Apache-2.0\nscripts:\n  start: run\n");
+        assert!(r.valid, "registry license must not invalidate: {r:?}");
+        let r = report("name: onboarding\nlicense: [Apache-2.0]\nscripts:\n  start: run\n");
+        assert!(!r.valid, "license must be a string: {r:?}");
+    }
+
+    #[test]
     fn report_accepts_registry_tags() {
         let r = report("name: database\ntags:\n  - sql\n  - postgres\nscripts:\n  start: run\n");
 
@@ -980,7 +997,7 @@ mod tests {
         assert!(runtime_kind_desc.contains("DEPRECATED"));
         // Publish metadata is in the schema (so authored manifests validate)
         // and described as engine-ignored (so LLMs don't cargo-cult it).
-        for field in ["iii", "deploy", "manifest", "tags"] {
+        for field in ["iii", "deploy", "manifest", "tags", "license"] {
             let desc = s["properties"][field]["description"].as_str().unwrap_or("");
             assert!(
                 desc.contains("ignored by the engine"),


### PR DESCRIPTION
## Summary

A worker cannot both publish to the Registry and run from a local path with `runtime.base_image` today.

- `workers`' release CI (`.github/scripts/deployment_compiler.py`) refuses a worker whose `iii.worker.yaml` has no `license`: `license is required for Registry publication`. Every worker in that repo carries the key.
- The engine's local-worker start path validates the manifest keys strictly and refuses it:

```
error: manifest validation failed at start: unknown key(s) in
.../iii.worker.yaml: [license]. Supported fields are: name, description,
runtime.base_image, scripts.(setup|install|start), env, dependencies,
resources.(cpus|memory), plus the registry publish metadata keys
(iii, deploy, manifest, tags) which the engine accepts and ignores.
```

`license` belongs in exactly that last group. This change puts it there: in `WorkerManifest`, accepted, described as engine-ignored so an authoring LLM does not treat it as engine behavior, and shape-checked as a string.

Found while giving the new `onboarding` worker (iii-hq/workers#1128) a `base_image`, where the two validators collided.

## Test plan

- [x] `cargo test -p iii-worker --lib worker_manifest` — 37 pass, including the new `report_accepts_the_registry_license` (a string license validates; a list does not)
- [x] `cargo test -p iii-worker --lib cli::project` — 52 pass
- [x] `cargo fmt -p iii-worker`, `cargo clippy -p iii-worker --lib` clean
- [x] `make install-iii-worker`, then a real local worker with `license` + `runtime.base_image` started and served its functions, where the same manifest was refused before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worker manifests now accept an optional `license` field for registry publishing metadata.
  - License values must be provided as text.
  - The engine accepts and ignores this metadata during processing.

- **Bug Fixes**
  - Validation messages now include `license` among the supported registry publishing metadata fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->