### PR TITLE
fix(cli): read the compose file's engine url in iii trigger

### DIFF
--- a/crates/iii-compose/src/config.rs
+++ b/crates/iii-compose/src/config.rs
@@ -296,8 +296,10 @@ fn validate_engine(raw: RawEngineSpec) -> Result<EngineSpec> {
 /// Mutation preflight and teardown paths use this to reject ownership changes
 /// without requiring the container graph to be valid first. A cached project
 /// must still be stoppable or repairable when an unrelated container edit is
-/// temporarily invalid.
-pub(crate) fn parse_engine_section(text: &str, path: &Path) -> Result<Option<EngineSpec>> {
+/// temporarily invalid. `iii trigger` reads the engine address through it for
+/// the same reason: the address a caller needs does not depend on whether the
+/// containers parse.
+pub fn parse_engine_section(text: &str, path: &Path) -> Result<Option<EngineSpec>> {
     let document: serde_yaml::Value =
         serde_yaml::from_str(text).map_err(|err| ComposeError::Yaml {
             path: path.to_path_buf(),
@@ -783,6 +785,9 @@ containers:
   api:
     worker: path://./api
     start_after: [missing]
+    # A field this binary does not know, as a file written for a newer
+    # release would carry.
+    unknown_field: true
     environment:
       BROKEN: ${III_COMPOSE_ENGINE_ONLY_MISSING}
 "#;

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -151,8 +151,8 @@ iii trigger [OPTIONS] [FUNCTION_PATH] [KV]...
 | Option | Description |
 | ------ | ----------- |
 | `--json <JSON>` | JSON payload (`--json '{"a":1}'`). When combined with kv pairs the json must be an object; kv pairs override its keys (shallow merge) |
-| `--address <ADDRESS>` | Engine host address. Taken from the working directory's compose file or `III_URL` when omitted, else `localhost` |
-| `--port <PORT>` | Engine WebSocket port. Taken from the working directory's compose file or `III_URL` when omitted, else 49134 |
+| `--address <ADDRESS>` | Engine host address. Taken from `III_URL` or the working directory's compose file when omitted, else `localhost` |
+| `--port <PORT>` | Engine WebSocket port. Taken from `III_URL` or the working directory's compose file when omitted, else 49134 |
 | `--timeout-ms <TIMEOUT_MS>` | Max time to wait for the invocation result (milliseconds) [default: 30000] |
 | `-n, --namespace <NS>` | Namespace to resolve FUNCTION_PATH in. Omit to resolve in the engine's `default` namespace; routing is strict, so a function registered in another namespace is only reachable with this flag |
 

--- a/docs/next/cli-reference/index.mdx
+++ b/docs/next/cli-reference/index.mdx
@@ -151,8 +151,8 @@ iii trigger [OPTIONS] [FUNCTION_PATH] [KV]...
 | Option | Description |
 | ------ | ----------- |
 | `--json <JSON>` | JSON payload (`--json '{"a":1}'`). When combined with kv pairs the json must be an object; kv pairs override its keys (shallow merge) |
-| `--address <ADDRESS>` | Engine host address. Taken from `III_URL` when omitted, else `localhost` |
-| `--port <PORT>` | Engine WebSocket port. Taken from `III_URL` when omitted, else 49134 |
+| `--address <ADDRESS>` | Engine host address. Taken from the working directory's compose file or `III_URL` when omitted, else `localhost` |
+| `--port <PORT>` | Engine WebSocket port. Taken from the working directory's compose file or `III_URL` when omitted, else 49134 |
 | `--timeout-ms <TIMEOUT_MS>` | Max time to wait for the invocation result (milliseconds) [default: 30000] |
 | `-n, --namespace <NS>` | Namespace to resolve FUNCTION_PATH in. Omit to resolve in the engine's `default` namespace; routing is strict, so a function registered in another namespace is only reachable with this flag |
 

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -149,8 +149,8 @@ iii trigger [OPTIONS] [FUNCTION_PATH] [KV]...
 | Option | Description |
 | ------ | ----------- |
 | `--json <JSON>` | JSON payload (`--json '{"a":1}'`). When combined with kv pairs the json must be an object; kv pairs override its keys (shallow merge) |
-| `--address <ADDRESS>` | Engine host address. Taken from `III_URL` when omitted, else `localhost` |
-| `--port <PORT>` | Engine WebSocket port. Taken from `III_URL` when omitted, else 49134 |
+| `--address <ADDRESS>` | Engine host address. Taken from the working directory's compose file or `III_URL` when omitted, else `localhost` |
+| `--port <PORT>` | Engine WebSocket port. Taken from the working directory's compose file or `III_URL` when omitted, else 49134 |
 | `--timeout-ms <TIMEOUT_MS>` | Max time to wait for the invocation result (milliseconds) [default: 30000] |
 | `-n, --namespace <NS>` | Namespace to resolve FUNCTION_PATH in. Omit to resolve in the engine's `default` namespace; routing is strict, so a function registered in another namespace is only reachable with this flag |
 

--- a/docs/next/cli-reference/index.mdx.skill.md
+++ b/docs/next/cli-reference/index.mdx.skill.md
@@ -149,8 +149,8 @@ iii trigger [OPTIONS] [FUNCTION_PATH] [KV]...
 | Option | Description |
 | ------ | ----------- |
 | `--json <JSON>` | JSON payload (`--json '{"a":1}'`). When combined with kv pairs the json must be an object; kv pairs override its keys (shallow merge) |
-| `--address <ADDRESS>` | Engine host address. Taken from the working directory's compose file or `III_URL` when omitted, else `localhost` |
-| `--port <PORT>` | Engine WebSocket port. Taken from the working directory's compose file or `III_URL` when omitted, else 49134 |
+| `--address <ADDRESS>` | Engine host address. Taken from `III_URL` or the working directory's compose file when omitted, else `localhost` |
+| `--port <PORT>` | Engine WebSocket port. Taken from `III_URL` or the working directory's compose file when omitted, else 49134 |
 | `--timeout-ms <TIMEOUT_MS>` | Max time to wait for the invocation result (milliseconds) [default: 30000] |
 | `-n, --namespace <NS>` | Namespace to resolve FUNCTION_PATH in. Omit to resolve in the engine's `default` namespace; routing is strict, so a function registered in another namespace is only reachable with this flag |
 

--- a/engine/src/cli_trigger/mod.rs
+++ b/engine/src/cli_trigger/mod.rs
@@ -41,13 +41,13 @@ pub struct TriggerArgs {
     #[arg(long)]
     pub json: Option<String>,
 
-    /// Engine host address. Taken from the working directory's compose file
-    /// or `III_URL` when omitted, else `localhost`.
+    /// Engine host address. Taken from `III_URL` or the working directory's
+    /// compose file when omitted, else `localhost`.
     #[arg(long)]
     pub address: Option<String>,
 
-    /// Engine WebSocket port. Taken from the working directory's compose file
-    /// or `III_URL` when omitted, else 49134.
+    /// Engine WebSocket port. Taken from `III_URL` or the working directory's
+    /// compose file when omitted, else 49134.
     #[arg(long)]
     pub port: Option<u16>,
 
@@ -106,13 +106,12 @@ fn compose_file_engine_url() -> Option<String> {
 /// Resolves the engine endpoint from the flags, the compose file, and
 /// `III_URL`.
 ///
-/// Order, matching `iii compose`: the flag, then the compose file in the
-/// working directory, then `III_URL`, then `localhost:49134`. `iii compose`
-/// resolves `--engine`, then the file, then `III_URL` (see
-/// `iii_compose::resolve_engine_mode`), so the file is ahead of the
-/// environment here for the same reason: a project directory states which
-/// engine it owns, and a leftover variable in the operator's shell should not
-/// beat it.
+/// Order: the flag, then `III_URL`, then the compose file in the working
+/// directory, then `localhost:49134`. The environment is ahead of the file
+/// because an explicitly exported variable is the caller's live intent, while
+/// the file is only what the directory happens to hold: a worker or a shell
+/// that compose itself pointed at another engine must reach that engine, not
+/// the one the checked-in file names.
 ///
 /// `--address` and `--port` win over whichever source supplied the URL, each
 /// over its own half, so a flag can retarget one component and inherit the
@@ -126,7 +125,7 @@ fn resolve_endpoint(
     compose_url: Option<&str>,
     engine_url: Option<&str>,
 ) -> (String, u16) {
-    let from_source = [compose_url, engine_url]
+    let from_source = [engine_url, compose_url]
         .into_iter()
         .flatten()
         .map(str::trim)
@@ -209,9 +208,9 @@ mod tests {
     }
 
     #[test]
-    fn compose_file_wins_over_engine_url() {
-        // `iii compose` resolves the file ahead of `III_URL`; a leftover
-        // variable in the operator's shell must not beat the project.
+    fn engine_url_wins_over_the_compose_file() {
+        // An exported `III_URL` is the caller's live intent; the file is only
+        // what the directory happens to hold.
         assert_eq!(
             resolve_endpoint(
                 None,
@@ -219,7 +218,7 @@ mod tests {
                 Some("ws://127.0.0.1:49934"),
                 Some("ws://127.0.0.1:49134")
             ),
-            ("127.0.0.1".to_string(), 49934)
+            ("127.0.0.1".to_string(), 49134)
         );
     }
 
@@ -245,12 +244,12 @@ mod tests {
     }
 
     #[test]
-    fn unusable_compose_url_falls_through_to_engine_url() {
-        for compose in ["", "   ", "not a url", "http://127.0.0.1:49934"] {
+    fn unusable_engine_url_falls_through_to_the_compose_file() {
+        for engine_url in ["", "   ", "not a url", "http://127.0.0.1:49134"] {
             assert_eq!(
-                resolve_endpoint(None, None, Some(compose), Some("ws://127.0.0.1:49134")),
-                ("127.0.0.1".to_string(), 49134),
-                "unexpected endpoint for compose url {compose:?}"
+                resolve_endpoint(None, None, Some("ws://127.0.0.1:49934"), Some(engine_url)),
+                ("127.0.0.1".to_string(), 49934),
+                "unexpected endpoint for III_URL {engine_url:?}"
             );
         }
     }

--- a/engine/src/cli_trigger/mod.rs
+++ b/engine/src/cli_trigger/mod.rs
@@ -41,12 +41,13 @@ pub struct TriggerArgs {
     #[arg(long)]
     pub json: Option<String>,
 
-    /// Engine host address. Taken from `III_URL` when omitted, else
-    /// `localhost`.
+    /// Engine host address. Taken from the working directory's compose file
+    /// or `III_URL` when omitted, else `localhost`.
     #[arg(long)]
     pub address: Option<String>,
 
-    /// Engine WebSocket port. Taken from `III_URL` when omitted, else 49134.
+    /// Engine WebSocket port. Taken from the working directory's compose file
+    /// or `III_URL` when omitted, else 49134.
     #[arg(long)]
     pub port: Option<u16>,
 
@@ -87,28 +88,51 @@ fn engine_url_endpoint(raw: &str) -> Option<(String, u16)> {
     Some((host, url.port().unwrap_or(DEFAULT_PORT)))
 }
 
-/// Resolves the engine endpoint from the flags and `III_URL`.
+/// Reads `engine.url` from the compose file in the working directory.
 ///
-/// `III_URL` is how every managed context already names its engine: compose
-/// exports it to each worker it spawns, and `iii compose --engine` reads it.
-/// This CLI used to ignore it, so on a project that does not own port 49134
-/// every call silently reached whatever engine did.
+/// Returns `None` whenever the file is absent, unreadable, invalid, or
+/// declares no engine. This is only a resolution step: `iii trigger` has to
+/// keep working outside any project, so a broken compose file must never fail
+/// a command that did not ask about it.
+fn compose_file_engine_url() -> Option<String> {
+    let path = std::path::Path::new(iii_compose::cli::DEFAULT_COMPOSE_FILE);
+    let text = std::fs::read_to_string(path).ok()?;
+    // Only the engine section, so a container the running binary cannot parse
+    // does not cost the caller the address the file plainly states.
+    let engine = iii_compose::config::parse_engine_section(&text, path).ok()??;
+    (!engine.url.trim().is_empty()).then_some(engine.url)
+}
+
+/// Resolves the engine endpoint from the flags, the compose file, and
+/// `III_URL`.
 ///
-/// `--address` and `--port` still win, each over its own half of the URL, so a
-/// flag can retarget one component and inherit the other.
+/// Order, matching `iii compose`: the flag, then the compose file in the
+/// working directory, then `III_URL`, then `localhost:49134`. `iii compose`
+/// resolves `--engine`, then the file, then `III_URL` (see
+/// `iii_compose::resolve_engine_mode`), so the file is ahead of the
+/// environment here for the same reason: a project directory states which
+/// engine it owns, and a leftover variable in the operator's shell should not
+/// beat it.
 ///
-/// Takes the environment value as an argument rather than reading it, so the
-/// precedence is testable without mutating process state.
+/// `--address` and `--port` win over whichever source supplied the URL, each
+/// over its own half, so a flag can retarget one component and inherit the
+/// other.
+///
+/// Takes both outside values as arguments rather than reading them, so the
+/// precedence is testable without touching the filesystem or process state.
 fn resolve_endpoint(
     address: Option<&str>,
     port: Option<u16>,
+    compose_url: Option<&str>,
     engine_url: Option<&str>,
 ) -> (String, u16) {
-    let from_env = engine_url
+    let from_source = [compose_url, engine_url]
+        .into_iter()
+        .flatten()
         .map(str::trim)
         .filter(|url| !url.is_empty())
-        .and_then(engine_url_endpoint);
-    let (env_host, env_port) = match from_env {
+        .find_map(engine_url_endpoint);
+    let (source_host, source_port) = match from_source {
         Some((host, port)) => (Some(host), Some(port)),
         None => (None, None),
     };
@@ -116,17 +140,23 @@ fn resolve_endpoint(
     (
         address
             .map(str::to_string)
-            .or(env_host)
+            .or(source_host)
             .unwrap_or_else(|| DEFAULT_ADDRESS.to_string()),
-        port.or(env_port).unwrap_or(DEFAULT_PORT),
+        port.or(source_port).unwrap_or(DEFAULT_PORT),
     )
 }
 
 impl TriggerArgs {
     /// The engine this invocation talks to.
     fn endpoint(&self) -> (String, u16) {
+        let compose_url = compose_file_engine_url();
         let engine_url = std::env::var("III_URL").ok();
-        resolve_endpoint(self.address.as_deref(), self.port, engine_url.as_deref())
+        resolve_endpoint(
+            self.address.as_deref(),
+            self.port,
+            compose_url.as_deref(),
+            engine_url.as_deref(),
+        )
     }
 }
 
@@ -171,9 +201,72 @@ mod tests {
     use super::*;
 
     #[test]
+    fn compose_file_is_used_when_no_other_source_names_an_engine() {
+        assert_eq!(
+            resolve_endpoint(None, None, Some("ws://127.0.0.1:49934"), None),
+            ("127.0.0.1".to_string(), 49934)
+        );
+    }
+
+    #[test]
+    fn compose_file_wins_over_engine_url() {
+        // `iii compose` resolves the file ahead of `III_URL`; a leftover
+        // variable in the operator's shell must not beat the project.
+        assert_eq!(
+            resolve_endpoint(
+                None,
+                None,
+                Some("ws://127.0.0.1:49934"),
+                Some("ws://127.0.0.1:49134")
+            ),
+            ("127.0.0.1".to_string(), 49934)
+        );
+    }
+
+    #[test]
+    fn flags_win_over_the_compose_file() {
+        assert_eq!(
+            resolve_endpoint(
+                Some("example.test"),
+                Some(1234),
+                Some("ws://127.0.0.1:49934"),
+                None
+            ),
+            ("example.test".to_string(), 1234)
+        );
+    }
+
+    #[test]
+    fn each_flag_wins_over_its_own_half_of_the_compose_file() {
+        assert_eq!(
+            resolve_endpoint(None, Some(1234), Some("ws://127.0.0.1:49934"), None),
+            ("127.0.0.1".to_string(), 1234)
+        );
+    }
+
+    #[test]
+    fn unusable_compose_url_falls_through_to_engine_url() {
+        for compose in ["", "   ", "not a url", "http://127.0.0.1:49934"] {
+            assert_eq!(
+                resolve_endpoint(None, None, Some(compose), Some("ws://127.0.0.1:49134")),
+                ("127.0.0.1".to_string(), 49134),
+                "unexpected endpoint for compose url {compose:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unusable_compose_url_and_no_engine_url_falls_back_to_defaults() {
+        assert_eq!(
+            resolve_endpoint(None, None, Some("not a url"), None),
+            ("localhost".to_string(), DEFAULT_PORT)
+        );
+    }
+
+    #[test]
     fn endpoint_defaults_when_nothing_is_set() {
         assert_eq!(
-            resolve_endpoint(None, None, None),
+            resolve_endpoint(None, None, None, None),
             ("localhost".to_string(), DEFAULT_PORT)
         );
     }
@@ -181,7 +274,7 @@ mod tests {
     #[test]
     fn endpoint_reads_engine_url() {
         assert_eq!(
-            resolve_endpoint(None, None, Some("ws://127.0.0.1:49734")),
+            resolve_endpoint(None, None, None, Some("ws://127.0.0.1:49734")),
             ("127.0.0.1".to_string(), 49734)
         );
     }
@@ -192,6 +285,7 @@ mod tests {
             resolve_endpoint(
                 Some("example.test"),
                 Some(1234),
+                None,
                 Some("ws://127.0.0.1:49734")
             ),
             ("example.test".to_string(), 1234)
@@ -201,11 +295,16 @@ mod tests {
     #[test]
     fn each_flag_wins_over_its_own_half() {
         assert_eq!(
-            resolve_endpoint(None, Some(1234), Some("ws://127.0.0.1:49734")),
+            resolve_endpoint(None, Some(1234), None, Some("ws://127.0.0.1:49734")),
             ("127.0.0.1".to_string(), 1234)
         );
         assert_eq!(
-            resolve_endpoint(Some("example.test"), None, Some("ws://127.0.0.1:49734")),
+            resolve_endpoint(
+                Some("example.test"),
+                None,
+                None,
+                Some("ws://127.0.0.1:49734")
+            ),
             ("example.test".to_string(), 49734)
         );
     }
@@ -214,7 +313,7 @@ mod tests {
     fn unusable_engine_url_falls_back_to_defaults() {
         for url in ["", "   ", "not a url", "http://127.0.0.1:49734", "ws://"] {
             assert_eq!(
-                resolve_endpoint(None, None, Some(url)),
+                resolve_endpoint(None, None, None, Some(url)),
                 ("localhost".to_string(), DEFAULT_PORT),
                 "unexpected endpoint for III_URL {url:?}"
             );
@@ -224,7 +323,7 @@ mod tests {
     #[test]
     fn engine_url_without_a_port_keeps_the_engine_default() {
         assert_eq!(
-            resolve_endpoint(None, None, Some("ws://engine.test")),
+            resolve_endpoint(None, None, None, Some("ws://engine.test")),
             ("engine.test".to_string(), DEFAULT_PORT)
         );
     }
@@ -232,7 +331,7 @@ mod tests {
     #[test]
     fn engine_url_keeps_ipv6_brackets() {
         assert_eq!(
-            resolve_endpoint(None, None, Some("ws://[::1]:49734")),
+            resolve_endpoint(None, None, None, Some("ws://[::1]:49734")),
             ("[::1]".to_string(), 49734)
         );
     }

--- a/engine/src/cli_trigger/mod.rs
+++ b/engine/src/cli_trigger/mod.rs
@@ -569,7 +569,7 @@ mod tests {
             ("ws://user@127.0.0.1:4400", "must not carry credentials"),
             ("ws:127.0.0.1:4400", "must start with ws://"),
         ] {
-            let err = resolve_endpoint(None, None, Some(url), None)
+            let err = resolve_endpoint(None, None, Some(url), None, None)
                 .unwrap_err()
                 .to_string();
             assert!(err.contains(detail), "unexpected error for {url:?}: {err}");
@@ -582,7 +582,7 @@ mod tests {
         // crate normalises both paths to "/".
         for url in ["ws://engine.test:4400", "ws://engine.test:4400/"] {
             assert_eq!(
-                resolve_endpoint(None, None, Some(url), None).unwrap(),
+                resolve_endpoint(None, None, Some(url), None, None).unwrap(),
                 ("engine.test".to_string(), 4400),
                 "unexpected endpoint for {url:?}"
             );
@@ -596,7 +596,7 @@ mod tests {
             "wss://engine.test/ws",
             "WSS://engine.test",
         ] {
-            let err = resolve_endpoint(None, None, Some(url), None)
+            let err = resolve_endpoint(None, None, Some(url), None, None)
                 .unwrap_err()
                 .to_string();
             assert_eq!(err, WSS_UNSUPPORTED, "unexpected error for {url:?}");
@@ -606,9 +606,15 @@ mod tests {
     #[test]
     fn a_url_with_credentials_is_refused_without_echoing_the_password() {
         // An error line reaches terminals, CI logs and bug reports.
-        let err = resolve_endpoint(None, None, Some("ws://user:secret@127.0.0.1:4400"), None)
-            .unwrap_err()
-            .to_string();
+        let err = resolve_endpoint(
+            None,
+            None,
+            Some("ws://user:secret@127.0.0.1:4400"),
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
         assert!(err.contains("must not carry credentials"), "{err}");
         assert!(
             !err.contains("secret"),


### PR DESCRIPTION
Stacked on #2167. Review that one first; this PR's diff is only the compose-file step.

Closes MOT-4747.

## Problem

After #2167, `iii trigger` resolves its endpoint from `--engine`, `III_URL`, or the local default. A project directory whose `worker-compose.yaml` names its own engine still has to repeat that address on every call, or export `III_URL` by hand.

## Change

The compose file in the working directory becomes the last URL source:

| Precedence | Source |
| --- | --- |
| 1 | `--address` / `--port` (each over its own half of the URL) |
| 2 | `--engine <URL>` |
| 3 | `III_URL` |
| 4 | `engine.url` in `./worker-compose.yaml` |
| 5 | `ws://localhost:49134` |

The environment sits ahead of the file. An exported `III_URL` is the caller's live intent; the file is only what the working directory happens to hold. A worker that compose itself started, or a shell an operator pointed at a second engine, must reach that engine and not the one the checked-in file names.

Note that `iii compose` had the opposite order, with the file ahead of `III_URL`. #2173 aligns it, so that the environment always wins over what is on disk.

Only the engine section is read, through `config::parse_engine_section` (now `pub` for this). Its doc comment already gave the reason for the mutation paths: a project must stay usable when an unrelated container edit is temporarily invalid. The address a caller needs does not depend on whether the containers parse.

Finding the file is a resolution step, not a validation one. A file that is absent, unreadable, or declares no engine resolves to nothing, because `iii trigger` has to keep working outside any project. A file that does state an address is held to the same rule as every other source in #2167: `wss://` and malformed values fail the call, and the error names the file.

```
Error: worker-compose.yaml engine.url "not a url" must be a ws:// URL with a host, e.g. ws://localhost:49134
Error: Encrypted websocket connections are not currently supported.
```

## Verification

`cargo test -p iii --bins cli_trigger`: 47 passed, including the file as the only source, `III_URL` and `--engine` each beating it, a deprecated flag overriding its half of it, and a `wss`, malformed, or blank value in it.

Live, against a compose file that declares `ws://127.0.0.1:4300`:

| Case | Result |
| --- | --- |
| Compose file only, no `III_URL` | reached 4300 |
| `III_URL` at a dead 4999, compose file at 4300 | timed out — the environment won |
| `--port 4300` with the dead `III_URL` | reached 4300 |
| No compose file, `III_URL` at 4300 | reached 4300 |
| Nothing set, outside a project | fell back to 49134 |

`cargo fmt --check -p iii` is clean, and the CLI reference plus its `.skill.md` were regenerated with `scripts/generate-cli-docs.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `iii trigger` can now use the engine endpoint from the working directory’s compose file.
  - Engine endpoint precedence is now: `--engine`, `III_URL`, compose file, then the default local endpoint.
  - Invalid, unreadable, or missing compose files are handled gracefully.

- **Documentation**
  - Updated `iii trigger` option descriptions to reflect compose-file endpoint configuration and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->