### PR TITLE
fix(compose): prevent duplicated startup progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,6 +2800,7 @@ dependencies = [
  "async-trait",
  "clap",
  "colored",
+ "console 0.15.11",
  "dirs 6.0.0",
  "flate2",
  "fslock",
@@ -2816,6 +2823,7 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
+ "vt100",
  "windows-sys 0.60.2",
  "wiremock",
 ]
@@ -6912,6 +6920,27 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vt100"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
+dependencies = [
+ "itoa",
+ "unicode-width 0.2.2",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/iii-compose/Cargo.toml
+++ b/crates/iii-compose/Cargo.toml
@@ -20,6 +20,7 @@ dirs = { workspace = true }
 # Colour is disabled automatically when the output is not a terminal, so piped
 # output stays parseable.
 colored = { workspace = true }
+console = { workspace = true }
 # The daemon is an ordinary worker: it talks to the engine through the SDK.
 iii-sdk = { workspace = true }
 # Registry resolution and artefact download.
@@ -71,3 +72,4 @@ windows-sys = { version = "0.60", features = [
 tempfile = { workspace = true }
 jsonschema = { version = "0.30", default-features = false }
 wiremock = { workspace = true }
+vt100 = "0.16"

--- a/crates/iii-compose/src/report.rs
+++ b/crates/iii-compose/src/report.rs
@@ -59,6 +59,7 @@ const CLEAR_LINE: &str = "\r\x1b[2K";
 /// waves now, so what an operator wants is not "which one is compose on" but
 /// "where is all of it" — which is a block that is redrawn, not a line that is
 /// replaced.
+#[derive(Default)]
 struct Console {
     startup: Option<StartupRows>,
     rows: Vec<Row>,
@@ -66,8 +67,13 @@ struct Console {
     /// far up to go. Zero when nothing is drawn.
     drawn: usize,
     frame: usize,
+    size: Option<(u16, u16)>,
+    /// Once cursor coordinates become unreliable, keep this operation static.
+    static_output: bool,
+    rendered: Vec<Row>,
 }
 
+#[derive(Clone, PartialEq)]
 struct Row {
     key: String,
     /// How far in it sits: a container is drawn under the one that waits for
@@ -76,7 +82,7 @@ struct Row {
     state: RowState,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 enum RowState {
     /// Declared, and waiting on something earlier in the graph.
     Waiting,
@@ -102,7 +108,7 @@ enum RowState {
     Skipped(String),
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 enum RetryPhase {
     Waiting(Duration),
     Starting(String),
@@ -122,13 +128,11 @@ pub(crate) struct StartupProgress {
 impl StartupProgress {
     pub(crate) fn start(managed: bool) -> Self {
         let mut state = console().lock().unwrap_or_else(|p| p.into_inner());
+        *state = Console::default();
         state.startup = Some(StartupRows::new(managed));
+        redraw(&mut state);
         if animated() {
-            redraw(&mut state);
             ensure_ticker();
-        } else if let Some(startup) = &state.startup {
-            eprintln!("{}", render_row(&startup.engine, 0, false));
-            eprintln!("{}", render_row(&startup.containers, 0, false));
         }
         Self { finished: false }
     }
@@ -157,11 +161,7 @@ impl StartupProgress {
         } else {
             *what = message.to_string();
         }
-        if animated() {
-            redraw(&mut state);
-        } else {
-            eprintln!("{}", render_row(&startup.engine, 0, false));
-        }
+        redraw(&mut state);
     }
 
     pub(crate) fn containers_starting(&self) {
@@ -173,11 +173,7 @@ impl StartupProgress {
             what: "Starting".to_string(),
             began: Instant::now(),
         };
-        if animated() {
-            redraw(&mut state);
-        } else {
-            eprintln!("{}", render_row(&startup.containers, 0, false));
-        }
+        redraw(&mut state);
     }
 
     pub(crate) fn finish(&mut self, success: bool, message: &str) {
@@ -195,21 +191,14 @@ impl StartupProgress {
         for row in &mut state.rows {
             match row.state {
                 RowState::Waiting => row.state = RowState::Skipped("Not started".to_string()),
-                RowState::Starting { .. } => row.state = RowState::Skipped("Cancelled".to_string()),
+                RowState::Starting { .. } | RowState::Retrying { .. } => {
+                    row.state = RowState::Skipped("Cancelled".to_string());
+                }
                 _ => {}
             }
         }
-        if animated() {
-            redraw(&mut state);
-        } else if let Some(startup) = &state.startup {
-            if !matches!(startup.engine.state, RowState::Ready { .. }) {
-                eprintln!("{}", render_row(&startup.engine, 0, false));
-            }
-            eprintln!("{}", render_row(&startup.containers, 0, false));
-        }
-        state.startup = None;
-        state.rows.clear();
-        state.drawn = 0;
+        redraw(&mut state);
+        *state = Console::default();
     }
 }
 
@@ -274,35 +263,22 @@ impl StartupRows {
 
 fn console() -> &'static Mutex<Console> {
     static CONSOLE: OnceLock<Mutex<Console>> = OnceLock::new();
-    CONSOLE.get_or_init(|| {
-        Mutex::new(Console {
-            startup: None,
-            rows: Vec::new(),
-            drawn: 0,
-            frame: 0,
-        })
-    })
+    CONSOLE.get_or_init(|| Mutex::new(Console::default()))
 }
 
 /// Announces what this operation will touch, in the shape it will touch it.
 ///
-/// `rows` is `(container, depth)` in the order to draw. Nothing is drawn on a
-/// terminal that cannot animate: there, each container reports itself as it
-/// settles, which is what a log wants anyway.
+/// `rows` is `(container, depth)` in the order to draw. A terminal that cannot
+/// animate gets state transitions instead of repeated spinner frames.
 pub fn plan(rows: &[(String, usize)]) {
-    if !animated() {
-        console()
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .rows
-            .clear();
-        return;
-    }
     {
         let console = console();
         let mut state = console
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.startup.is_none() {
+            *state = Console::default();
+        }
         state.rows = rows
             .iter()
             .map(|(key, depth)| Row {
@@ -311,14 +287,12 @@ pub fn plan(rows: &[(String, usize)]) {
                 state: RowState::Waiting,
             })
             .collect();
-        // The engine panel already owns the block above these new child rows.
-        if state.startup.is_none() {
-            state.drawn = 0;
-        }
         state.frame = 0;
         redraw(&mut state);
     }
-    ensure_ticker();
+    if animated() {
+        ensure_ticker();
+    }
 }
 
 /// Releases the block so later output does not overwrite it.
@@ -328,8 +302,7 @@ pub fn plan_done() {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     if state.startup.is_none() {
-        state.rows.clear();
-        state.drawn = 0;
+        *state = Console::default();
     }
 }
 
@@ -356,31 +329,119 @@ fn set(key: &str, to: RowState) -> bool {
     {
         *what = format!("Starting ({ready}/{total})");
     }
-    if animated() {
-        redraw(&mut state);
-    }
+    redraw(&mut state);
     true
 }
 
-/// Redraws the block in place: up over what was drawn, then every row again.
-fn redraw(state: &mut Console) {
-    let mut out = String::new();
-    if state.drawn > 0 {
-        out.push_str(&format!("\x1b[{}A", state.drawn));
+impl Console {
+    fn observe_size(&mut self, size: Option<(u16, u16)>) {
+        if self.drawn > 0 && self.size != size {
+            // Resize can reflow the old block into scrollback. Preserve it and
+            // emit only subsequent changes; its old cursor offset is unsafe.
+            self.static_output = true;
+            self.drawn = 0;
+        }
+        self.size = size;
     }
-    let headers = state
-        .startup
-        .iter()
-        .flat_map(|startup| [&startup.engine, &startup.containers])
-        .map(|row| (row, ""));
-    let indent = if state.startup.is_some() { "  " } else { "" };
-    for (row, prefix) in headers.chain(state.rows.iter().map(|row| (row, indent))) {
-        out.push_str(CLEAR_LINE);
-        out.push_str(prefix);
-        out.push_str(&render_row(row, state.frame, true));
+
+    fn clear_block(&mut self, out: &mut String) {
+        if self.drawn == 0 {
+            return;
+        }
+        out.push_str(&format!("\x1b[{}A", self.drawn));
+        for _ in 0..self.drawn {
+            out.push_str(CLEAR_LINE);
+            out.push('\n');
+        }
+        out.push_str(&format!("\x1b[{}A", self.drawn));
+        self.drawn = 0;
+        self.rendered.clear();
+    }
+
+    fn render(&mut self, size: Option<(u16, u16)>) -> String {
+        self.observe_size(size);
+        let mut rows = Vec::new();
+        if let Some(startup) = &self.startup {
+            rows.extend([startup.engine.clone(), startup.containers.clone()]);
+        }
+        rows.extend(self.rows.iter().cloned().map(|mut row| {
+            row.depth += usize::from(self.startup.is_some());
+            row
+        }));
+        let lines: Vec<String> = rows
+            .iter()
+            .map(|row| render_row(row, self.frame, true))
+            .collect();
+        let height = size.and_then(|(height, width)| {
+            let needed = panel_height(&lines, width)?;
+            // The last newline leaves the cursor on a row below the panel.
+            (needed < usize::from(height)).then_some(needed)
+        });
+        let mut out = String::new();
+        if self.static_output || height.is_none() {
+            if self.drawn > 0 {
+                // This is a larger new frame, not a resize. The previous
+                // frame still fits, so replace it with a static snapshot.
+                self.clear_block(&mut out);
+            }
+            self.static_output = true;
+            for row in &rows {
+                if !self.rendered.contains(row) {
+                    out.push_str(&render_row(row, 0, false));
+                    out.push('\n');
+                }
+            }
+        } else {
+            self.clear_block(&mut out);
+            for line in &lines {
+                out.push_str(CLEAR_LINE);
+                out.push_str(line);
+                out.push('\n');
+            }
+            self.drawn = height.unwrap_or_default();
+        }
+        self.rendered = rows;
+        out
+    }
+
+    fn line(&mut self, text: &str, size: Option<(u16, u16)>) -> String {
+        self.observe_size(size);
+        let mut out = String::new();
+        self.clear_block(&mut out);
+        out.push_str(text);
         out.push('\n');
+        out.push_str(&self.render(size));
+        out
     }
-    state.drawn = state.rows.len() + if state.startup.is_some() { 2 } else { 0 };
+}
+
+/// Animate only complete, unwrapped rows. Wide characters can wrap before the
+/// last column, so dividing a string's display width by the terminal width is
+/// not a reliable cursor offset.
+fn panel_height(lines: &[String], width: u16) -> Option<usize> {
+    if width < 2 {
+        return None;
+    }
+    lines
+        .iter()
+        .all(|line| {
+            !console::strip_ansi_codes(line)
+                .chars()
+                .any(char::is_control)
+                && console::measure_text_width(line) < usize::from(width)
+        })
+        .then_some(lines.len())
+}
+
+fn terminal_size() -> Option<(u16, u16)> {
+    animated()
+        .then(|| console::Term::stderr().size_checked())
+        .flatten()
+}
+
+/// Redraws only while the entire block and its cursor fit in the terminal.
+fn redraw(state: &mut Console) {
+    let out = state.render(terminal_size());
     let mut stderr = std::io::stderr().lock();
     let _ = write!(stderr, "{out}");
     let _ = stderr.flush();
@@ -452,7 +513,9 @@ fn render_row(row: &Row, frame: usize, animate: bool) -> String {
 /// Whether progress can animate. A pipe or a file gets static lines.
 fn animated() -> bool {
     static ANIMATED: OnceLock<bool> = OnceLock::new();
-    *ANIMATED.get_or_init(|| std::io::stderr().is_terminal())
+    *ANIMATED.get_or_init(|| {
+        std::io::stderr().is_terminal() && !std::env::var("TERM").is_ok_and(|term| term == "dumb")
+    })
 }
 
 /// Writes one line, stepping around the spinner if one is turning.
@@ -478,24 +541,10 @@ pub fn line(text: &str) {
     let mut state = console
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let out = state.line(text, terminal_size());
     let mut stderr = std::io::stderr().lock();
-
-    // The block owns the bottom of the screen, so a line goes above it: rewind
-    // over it, print, and draw it again underneath.
-    if state.drawn > 0 {
-        let _ = write!(stderr, "\x1b[{}A", state.drawn);
-        for _ in 0..state.drawn {
-            let _ = writeln!(stderr, "{CLEAR_LINE}");
-        }
-        let _ = write!(stderr, "\x1b[{}A", state.drawn);
-    }
-    let _ = writeln!(stderr, "{text}");
-    if state.drawn > 0 {
-        state.drawn = 0;
-        redraw(&mut state);
-    } else {
-        let _ = stderr.flush();
-    }
+    let _ = write!(stderr, "{out}");
+    let _ = stderr.flush();
 }
 
 /// Turns the frame for the whole block. One task, not one per container: the
@@ -511,13 +560,14 @@ fn ensure_ticker() {
                 let mut state = console
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
-                let turning = state.startup.is_some()
-                    || state.rows.iter().any(|row| {
-                        matches!(
-                            row.state,
-                            RowState::Starting { .. } | RowState::Retrying { .. }
-                        )
-                    });
+                let turning = !state.static_output
+                    && (state.startup.is_some()
+                        || state.rows.iter().any(|row| {
+                            matches!(
+                                row.state,
+                                RowState::Starting { .. } | RowState::Retrying { .. }
+                            )
+                        }));
                 if turning {
                     state.frame = state.frame.wrapping_add(1);
                     redraw(&mut state);
@@ -623,31 +673,22 @@ fn show_retry(key: &str, attempt: u32, total: u32, phase: RetryPhase) {
 }
 
 fn show_retry_row(row: Row) {
-    let animate = animated();
     // During `up`, keep this row inside the dependency tree and preserve its
     // depth. A run-time retry has no active plan, so it falls through and owns
     // a one-row block as before.
-    if animate && set(&row.key, row.state.clone()) {
+    if set(&row.key, row.state.clone()) {
         return;
     }
 
-    let static_line = {
+    {
         let mut state = console()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         state.rows = vec![row];
         state.frame = 0;
-        if animate {
-            redraw(&mut state);
-            None
-        } else {
-            state.rows.first().map(|row| render_row(row, 0, false))
-        }
-    };
-
-    if let Some(static_line) = static_line {
-        line(&static_line);
-    } else {
+        redraw(&mut state);
+    }
+    if animated() {
         ensure_ticker();
     }
 }
@@ -766,11 +807,7 @@ pub fn not_required_failed(containers: &[String]) {
 
 /// Closing line of an operation.
 pub fn summary_ok(action: &str, changed: usize, total: usize, elapsed: Duration) {
-    let body = if changed == 0 {
-        format!("{action}: nothing to do ({total} already in place)")
-    } else {
-        format!("{action}: {changed} of {total} changed")
-    };
+    let body = format!("{action}: {changed} of {total} changed");
     line(&format!(
         "{} {}",
         body.green(),
@@ -868,6 +905,10 @@ fn pick_color(taken: &[Color], last: Option<Color>) -> Color {
         .copied()
         .unwrap_or(CONTAINER_COLORS[0])
 }
+
+#[cfg(test)]
+#[path = "report/terminal_tests.rs"]
+mod terminal_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/iii-compose/src/report/terminal_tests.rs
+++ b/crates/iii-compose/src/report/terminal_tests.rs
@@ -1,0 +1,282 @@
+use super::*;
+
+fn progress(workers: usize) -> Console {
+    let mut startup = StartupRows::new(true);
+    startup.engine.state = RowState::Ready {
+        what: "Ready".to_string(),
+        elapsed: Duration::from_secs(2),
+    };
+    startup.containers.state = RowState::Starting {
+        what: "Starting".to_string(),
+        began: Instant::now(),
+    };
+    Console {
+        startup: Some(startup),
+        rows: (0..workers)
+            .map(|index| Row {
+                key: format!("worker-{index:02}"),
+                depth: index % 3,
+                state: RowState::Starting {
+                    what: "waiting for engine registration".to_string(),
+                    began: Instant::now(),
+                },
+            })
+            .collect(),
+        ..Console::default()
+    }
+}
+
+fn write_terminal(terminal: &mut vt100::Parser, output: &str) {
+    // Match the newline conversion performed by a normal PTY (ONLCR).
+    terminal.process(output.replace('\n', "\r\n").as_bytes());
+}
+
+fn screen_and_history(terminal: &mut vt100::Parser) -> String {
+    let screen = terminal.screen_mut();
+    let (_, width) = screen.size();
+    screen.set_scrollback(usize::MAX);
+    let history = screen.scrollback();
+    let mut text = String::new();
+    for offset in (1..=history).rev() {
+        screen.set_scrollback(offset);
+        text.push_str(&screen.rows(0, width).next().unwrap());
+        text.push('\n');
+    }
+    screen.set_scrollback(0);
+    text.push_str(&screen.contents());
+    text
+}
+
+#[test]
+fn startup_preserves_one_ready_line_per_worker_and_engine_at_small_terminal_sizes() {
+    for (height, width) in [
+        (24, 120),
+        (16, 120),
+        (15, 120),
+        (14, 120),
+        (40, 40),
+        (24, 40),
+    ] {
+        let mut state = progress(13);
+        let mut terminal = vt100::Parser::new(height, width, 1000);
+        for frame in 0..20 {
+            state.frame = frame;
+            write_terminal(&mut terminal, &state.render(Some((height, width))));
+        }
+        for index in 0..state.rows.len() {
+            state.rows[index].state = RowState::Ready {
+                what: "ready".to_string(),
+                elapsed: Duration::from_millis(612),
+            };
+            write_terminal(&mut terminal, &state.render(Some((height, width))));
+        }
+        state.startup.as_mut().unwrap().finish(true, "Ready");
+        write_terminal(&mut terminal, &state.render(Some((height, width))));
+
+        let text = screen_and_history(&mut terminal);
+        for name in std::iter::once("Engine Ready".to_string())
+            .chain((0..13).map(|index| format!("worker-{index:02} ready")))
+        {
+            assert_eq!(text.matches(&name).count(), 1, "{width}x{height}: {text}");
+        }
+    }
+}
+
+#[test]
+fn adding_workers_beyond_the_screen_keeps_the_confirmed_engine_line_once() {
+    let mut state = progress(0);
+    let mut terminal = vt100::Parser::new(15, 80, 1000);
+    write_terminal(&mut terminal, &state.render(Some((15, 80))));
+    state.rows = progress(13).rows;
+    for frame in 0..20 {
+        state.frame = frame;
+        write_terminal(&mut terminal, &state.render(Some((15, 80))));
+    }
+
+    let text = screen_and_history(&mut terminal);
+    assert_eq!(text.matches("Engine Ready").count(), 1, "{text}");
+}
+
+#[test]
+fn a_wrapping_status_switches_to_static_output_without_overwriting_prior_lines() {
+    let mut state = progress(1);
+    let mut terminal = vt100::Parser::new(20, 80, 1000);
+    write_terminal(&mut terminal, "keep this log\n");
+    write_terminal(&mut terminal, &state.render(Some((20, 80))));
+    state.rows[0].state = RowState::Starting {
+        what: "waiting for a worker in a very long directory ".repeat(3),
+        began: Instant::now(),
+    };
+    for frame in 0..10 {
+        state.frame = frame;
+        write_terminal(&mut terminal, &state.render(Some((20, 80))));
+    }
+    state.rows[0].state = RowState::Ready {
+        what: "ready".to_string(),
+        elapsed: Duration::from_secs(1),
+    };
+    write_terminal(&mut terminal, &state.render(Some((20, 80))));
+
+    let text = screen_and_history(&mut terminal);
+    assert!(text.starts_with("keep this log\n"), "{text}");
+    assert_eq!(text.matches("Engine Ready").count(), 1, "{text}");
+    assert_eq!(text.matches("worker-00 ready").count(), 1, "{text}");
+}
+
+#[test]
+fn smaller_panels_erase_removed_rows() {
+    let mut state = progress(3);
+    let mut terminal = vt100::Parser::new(24, 80, 1000);
+    write_terminal(&mut terminal, &state.render(Some((24, 80))));
+    state.rows.truncate(1);
+    write_terminal(&mut terminal, &state.render(Some((24, 80))));
+
+    let text = screen_and_history(&mut terminal);
+    assert!(text.contains("worker-00"), "{text}");
+    assert!(
+        !text.contains("worker-01") && !text.contains("worker-02"),
+        "{text}"
+    );
+}
+
+#[test]
+fn logs_remain_above_the_panel_even_when_they_wrap_or_span_lines() {
+    let mut state = progress(2);
+    let mut terminal = vt100::Parser::new(10, 80, 1000);
+    write_terminal(&mut terminal, &state.render(Some((10, 80))));
+    let message = format!("error: {}\nsecond diagnostic", "long path/".repeat(15));
+    write_terminal(&mut terminal, &state.line(&message, Some((10, 80))));
+    write_terminal(&mut terminal, &state.render(Some((10, 80))));
+
+    let text = screen_and_history(&mut terminal);
+    assert_eq!(text.matches("error:").count(), 1, "{text}");
+    assert_eq!(text.matches("second diagnostic").count(), 1, "{text}");
+    assert_eq!(text.matches("Engine Ready").count(), 1, "{text}");
+}
+
+#[test]
+fn logging_during_static_fallback_restores_rows_erased_with_the_previous_panel() {
+    let mut state = progress(1);
+    let mut terminal = vt100::Parser::new(20, 80, 1000);
+    write_terminal(&mut terminal, &state.render(Some((20, 80))));
+    state.rows[0].state = RowState::Starting {
+        what: "a status that now wraps onto multiple terminal lines ".repeat(3),
+        began: Instant::now(),
+    };
+    write_terminal(&mut terminal, &state.line("new diagnostic", Some((20, 80))));
+
+    let text = screen_and_history(&mut terminal);
+    assert_eq!(text.matches("Engine Ready").count(), 1, "{text}");
+}
+
+#[test]
+fn resizing_stops_cursor_updates_even_when_a_log_arrives_before_the_next_frame() {
+    for size in [(3, 80), (24, 25), (40, 120)] {
+        let mut state = progress(2);
+        let mut terminal = vt100::Parser::new(24, 80, 1000);
+        write_terminal(&mut terminal, &state.render(Some((24, 80))));
+        terminal.screen_mut().set_size(size.0, size.1);
+
+        let output = state.line("new diagnostic", Some(size));
+        assert_eq!(output, "new diagnostic\n");
+        write_terminal(&mut terminal, &output);
+        assert!(state.render(Some(size)).is_empty());
+        // Growing the terminal again must not repaint already committed rows.
+        assert!(state.render(Some((40, 120))).is_empty());
+    }
+}
+
+#[test]
+fn missing_dimensions_use_static_state_changes_without_spinner_ticks() {
+    let mut state = progress(1);
+    let first = state.render(None);
+    assert!(first.contains("Engine Ready"), "{first}");
+    assert!(!FRAMES.iter().any(|frame| first.contains(frame)), "{first}");
+    state.frame += 1;
+    assert!(state.render(None).is_empty());
+    state.rows[0].state = RowState::Ready {
+        what: "ready".to_string(),
+        elapsed: Duration::from_millis(25),
+    };
+    let output = state.render(None);
+    assert!(output.contains("worker-00 ready"), "{output}");
+    assert!(!output.contains("Engine"), "{output}");
+}
+
+#[test]
+fn colored_unicode_rows_fit_by_display_width_and_not_ansi_byte_length() {
+    let mut state = Console {
+        rows: vec![Row {
+            key: "\x1b[32m日本語\x1b[0m".to_string(),
+            depth: 0,
+            state: RowState::Waiting,
+        }],
+        ..Console::default()
+    };
+    let mut terminal = vt100::Parser::new(4, 20, 1000);
+    write_terminal(&mut terminal, "saved log\n");
+    for frame in 0..10 {
+        state.frame = frame;
+        write_terminal(&mut terminal, &state.render(Some((4, 20))));
+    }
+    let text = screen_and_history(&mut terminal);
+    assert_eq!(text, "saved log\n· 日本語 Pending");
+}
+
+#[test]
+fn wide_characters_that_would_wrap_do_not_move_the_cursor_into_earlier_logs() {
+    let mut state = Console {
+        rows: vec![Row {
+            key: "a日本語日本語".to_string(),
+            depth: 0,
+            state: RowState::Waiting,
+        }],
+        ..Console::default()
+    };
+    let first = state.render(Some((10, 10)));
+    assert!(!first.contains('\x1b'), "{first:?}");
+    assert!(state.render(Some((10, 10))).is_empty());
+}
+
+fn cancelled_retry_output() -> String {
+    let output = std::process::Command::new(std::env::current_exe().unwrap())
+        .args([
+            "--ignored",
+            "--exact",
+            "report::terminal_tests::cancelled_retry_fixture",
+            "--nocapture",
+        ])
+        .env_remove("CLICOLOR_FORCE")
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    String::from_utf8(output.stderr).unwrap()
+}
+
+#[test]
+fn cancelled_retries_report_the_final_state() {
+    let text = cancelled_retry_output();
+    let cancelled = text.find("Containers Cancelled").unwrap();
+    assert!(text[cancelled..].contains("api Cancelled"), "{text}");
+    assert!(!text[cancelled..].contains("Retrying"), "{text}");
+}
+
+#[test]
+fn zero_change_summaries_do_not_claim_workers_are_already_running() {
+    let text = cancelled_retry_output();
+    assert!(text.contains("up: 0 of 2 changed"), "{text}");
+    assert!(!text.contains("already in place"), "{text}");
+}
+
+#[tokio::test]
+#[ignore = "subprocess fixture for cancellation and zero-change summaries"]
+async fn cancelled_retry_fixture() {
+    let mut progress = StartupProgress::start(true);
+    progress.engine_ready();
+    progress.containers_starting();
+    plan(&[("api".to_string(), 0)]);
+    retry_waiting("api", 1, 3, Duration::from_secs(10));
+    progress.finish(false, "Cancelled");
+    summary_ok("up", 0, 2, Duration::from_millis(100));
+}


### PR DESCRIPTION
## What

Prevent duplicate `Engine Ready` lines and stale worker rows when compose startup progress exceeds the terminal size or the window is resized. Animate only while the full panel fits, then emit state changes without cursor movement for the rest of the operation.

Cancelled retries now end as `Cancelled`. Zero-change summaries show `0 of N changed` instead of claiming that failed workers are already running.

## Why

The renderer moved the cursor by the number of logical rows, even when lines wrapped or part of the panel had entered scrollback. Each redraw could leave another copy of the startup headers behind. A cancelled retry also retained its active status, and the old zero-change summary confused failed workers with workers already in place.

## Notes

- Added terminal emulator regression coverage for small and narrow terminals, resize, Unicode/color width, shorter panels, interleaved diagnostics, and static state transitions.
- Validation: `cargo fmt --all`; `cargo clippy -p iii-compose --all-targets --all-features --locked -- -D warnings`; `cargo test -p iii-compose --locked` (433 passed); `cargo test -p iii --test compose_managed_engine_e2e --locked` (7 passed); `cargo build -p iii --bin iii --locked`.
- Repeated the 13-worker startup in tmux at 120x24, 120x15, and 40x40, plus resize cases. Each run retained one `Engine Ready` line in the screen and history. Also verified retry cancellation and optional worker failures with the CLI.


<!-- cli-demos:start -->
## CLI demos

### Small terminal and scrollback

Start 13 workers in a short terminal, then scroll through the history. State changes remain readable, with one `Engine Ready` line.

![Small terminal and scrollback](https://vhs.charm.sh/vhs-6Vhvcz9XDQKzCmuinAr2Ob.gif)

### Resize during startup

Reduce the terminal to 40 columns and 15 rows during startup. The renderer switches to static updates and all 13 workers reach ready.

![Resize during startup](https://vhs.charm.sh/vhs-1JP916TV68tA9GHjQCidBz.gif)

### Cancel a retry

Press Ctrl+C while a worker is retrying. Both the worker and the container group finish as `Cancelled`.

![Cancel a retry](https://vhs.charm.sh/vhs-7ynOXuK3KeIYODFmqwaWiA.gif)

### Optional worker failures

Let both optional workers fail before registration. The summary reports `up: 0 of 2 changed` and shows the failed workers.

![Optional worker failures](https://vhs.charm.sh/vhs-4CWXGMIFi3OD9LvTqyUPgH.gif)

<!-- cli-demos:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved compose progress display across different terminal sizes.
  - Added more reliable handling for wrapped output, colored and Unicode text, resizing, and log messages.
  - Progress output now falls back to a readable static format when animation is unavailable or unsupported.

- **Bug Fixes**
  - Prevented stale progress rows and cursor movement from overwriting earlier logs.
  - Cancelled retry states are now cleared when operations finish.
  - Simplified completion summaries when no changes are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->