### PR TITLE
feat(compose): show worker restart time in terminal feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2792,6 +2792,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "clap",
  "colored",
  "dirs 6.0.0",

--- a/crates/iii-compose/Cargo.toml
+++ b/crates/iii-compose/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = "0.1"
+chrono = "0.4"
 clap = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/iii-compose/src/lifecycle.rs
+++ b/crates/iii-compose/src/lifecycle.rs
@@ -475,6 +475,7 @@ async fn restart_one_inner(
         return None;
     }
 
+    report::restarting(key);
     if let Some((attempt, total_attempts)) = retry {
         report::retry_starting(key, attempt, total_attempts);
     } else {

--- a/crates/iii-compose/src/report.rs
+++ b/crates/iii-compose/src/report.rs
@@ -35,6 +35,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use chrono::Local;
 use colored::{Color, Colorize};
 
 /// Marks left of a container name.
@@ -525,6 +526,16 @@ fn ensure_ticker() {
             }
         });
     });
+}
+
+/// Records the local time a restart begins outside the animated progress block.
+pub(crate) fn restarting(key: &str) {
+    line(&format!(
+        "{} {} {}",
+        RUNNING.dimmed(),
+        key.bold(),
+        format!("restarting at {}", Local::now().format("%H:%M:%S")).dimmed()
+    ));
 }
 
 /// A container is being worked on. On a terminal this spins until the container


### PR DESCRIPTION
## What

Show the local start time of each worker restart in Compose terminal feedback:

```text
→ api restarting at 14:32:10
```

The message applies to requested restarts and automatic recovery attempts. It stays visible above the animated progress block and is also included in redirected output.

## Why

Operators can see when a worker restart began and compare that time with worker logs.

## Notes

- Uses the Compose host's local time in 24-hour `HH:MM:SS` format.
- `cargo fmt --all` passed.
- `cargo test -p iii-compose --offline`: 421 passed, 2 ignored helper fixtures.
- `cargo clippy -p iii-compose --all-targets --all-features --locked --offline -- -D warnings` passed.
- Checked the timestamp in animated and redirected terminal output.
- Built the PR CLI with `SKIP_UI_BUILD=1 cargo build -p iii --release --locked --offline` (using the committed UI assets).

<!-- cli-demos:start -->
## CLI demos

### Requested worker restart

Foreground output from `iii compose --up` when another terminal requests:

```sh
iii trigger compose::restart worker=api --address 127.0.0.1 --port 49571 --namespace restart-demo
```

![Compose displays the local start time of a requested worker restart](https://vhs.charm.sh/vhs-5s3hMJmReZm62mnwDt9KLM.gif)

### Automatic worker recovery

The `api` worker exits once with `restart: on-failure`. Compose displays the restart time and confirms recovery.

```sh
iii compose --up
```

![Compose displays the local start time during automatic worker recovery](https://vhs.charm.sh/vhs-3UUWuzUR7mIuXfTVxCEV8L.gif)
<!-- cli-demos:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Added a progress update when a container restart begins, including the container name and local start time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->