### PR TITLE
fix(compose): let III_URL select the engine, as --engine does

### DIFF
--- a/crates/iii-compose/src/lib.rs
+++ b/crates/iii-compose/src/lib.rs
@@ -61,11 +61,19 @@ pub enum EngineMode {
 
 /// Resolves the engine URL and ownership after the compose file is parsed.
 ///
-/// An explicit CLI URL always selects an external engine. Without one, an
-/// `engine:` section is managed only when `--up` starts that file; a bare
-/// daemon connects to its URL without taking ownership. File configuration
-/// wins over the process environment, and the local engine address is the
-/// final fallback.
+/// The order is `--engine`, then `III_URL`, then the compose file, then the
+/// local engine address. The environment beats the file: an exported variable
+/// is the caller's live intent, while the file is only what the working
+/// directory happens to hold. `iii trigger` resolves its endpoint the same
+/// way.
+///
+/// `III_URL` selects an engine exactly as `--engine` does, ownership included:
+/// an address that comes from outside the file names an engine that is already
+/// running, so compose connects to it and starts none of its own. Only the
+/// file can hand compose an engine to own, and only `--up` takes it: an
+/// `engine:` section carries the engine's whole configuration, not just an
+/// address, so a bare URL is not a thing compose could spawn from. A bare
+/// daemon connects to the file's engine without taking ownership.
 pub fn resolve_engine_mode(
     file: Option<&ComposeFile>,
     start: bool,
@@ -78,16 +86,25 @@ pub fn resolve_engine_mode(
         };
     }
 
-    if start && let Some(engine) = file.and_then(|file| file.engine.as_ref()) {
+    if let Some(url) = environment_engine_url
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+    {
+        return EngineMode::External {
+            url: url.to_string(),
+        };
+    }
+
+    let file_engine = file.and_then(|file| file.engine.as_ref());
+
+    if start && let Some(engine) = file_engine {
         return EngineMode::Managed {
             url: engine.url.clone(),
         };
     }
 
-    let url = file
-        .and_then(|file| file.engine.as_ref())
+    let url = file_engine
         .map(|engine| engine.url.as_str())
-        .or(environment_engine_url)
         .unwrap_or(config::DEFAULT_ENGINE_URL);
     EngineMode::External {
         url: url.to_string(),
@@ -402,10 +419,13 @@ async fn serve(
             policy
         }
         EngineMode::External { .. } => {
+            // An address from outside the file overrides the file's engine, so
+            // the file's declared engine is no longer what this daemon must
+            // match. `III_URL` counts here for the same reason `--engine`
+            // does: it named the engine that won.
+            let overridden = explicit_engine_url.is_some() || environment_engine_url.is_some();
             match initial_file.as_ref().filter(|file| file.engine.is_some()) {
-                Some(file) if explicit_engine_url.is_some() => {
-                    daemon::EnginePolicy::external_overriding(file)
-                }
+                Some(file) if overridden => daemon::EnginePolicy::external_overriding(file),
                 Some(file) => daemon::EnginePolicy::external_from_file(file),
                 None => daemon::EnginePolicy::External,
             }

--- a/crates/iii-compose/tests/cli.rs
+++ b/crates/iii-compose/tests/cli.rs
@@ -358,7 +358,23 @@ fn up_without_a_cli_namespace_defers_to_the_compose_file() {
 }
 
 #[test]
-fn up_uses_the_file_engine_when_the_cli_does_not_override_it() {
+fn up_uses_the_file_engine_when_nothing_else_names_one() {
+    let managed = ComposeFile::parse(
+        "engine: { workers: {} }\ncontainers: {}\n",
+        "/srv/app/worker-compose.yaml",
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolve_engine_mode(Some(&managed), true, None, None),
+        EngineMode::Managed {
+            url: "ws://127.0.0.1:49134".to_string()
+        }
+    );
+}
+
+#[test]
+fn up_with_an_environment_engine_connects_without_owning_it() {
     let managed = ComposeFile::parse(
         "engine: { workers: {} }\ncontainers: {}\n",
         "/srv/app/worker-compose.yaml",
@@ -372,10 +388,68 @@ fn up_uses_the_file_engine_when_the_cli_does_not_override_it() {
             None,
             Some("ws://global-environment:49134"),
         ),
-        EngineMode::Managed {
-            url: "ws://127.0.0.1:49134".to_string()
+        EngineMode::External {
+            url: "ws://global-environment:49134".to_string()
         },
-        "a process-wide III_URL must not override a file-owned engine"
+        "III_URL selects an engine the same way --engine does, ownership included"
+    );
+}
+
+#[test]
+fn explicit_engine_beats_the_environment_with_up() {
+    let managed = ComposeFile::parse(
+        "engine: { workers: {} }\ncontainers: {}\n",
+        "/srv/app/worker-compose.yaml",
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolve_engine_mode(
+            Some(&managed),
+            true,
+            Some("ws://flag:1"),
+            Some("ws://global-environment:49134"),
+        ),
+        EngineMode::External {
+            url: "ws://flag:1".to_string()
+        }
+    );
+}
+
+#[test]
+fn bare_compose_prefers_the_environment_over_the_file_engine() {
+    let managed = ComposeFile::parse(
+        "engine: { url: 'ws://file-engine:49134', workers: {} }\ncontainers: {}\n",
+        "/srv/app/worker-compose.yaml",
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolve_engine_mode(
+            Some(&managed),
+            false,
+            None,
+            Some("ws://global-environment:49134"),
+        ),
+        EngineMode::External {
+            url: "ws://global-environment:49134".to_string()
+        }
+    );
+}
+
+#[test]
+fn an_empty_environment_url_falls_through_to_the_file_engine() {
+    let managed = ComposeFile::parse(
+        "engine: { url: 'ws://file-engine:49134', workers: {} }\ncontainers: {}\n",
+        "/srv/app/worker-compose.yaml",
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolve_engine_mode(Some(&managed), false, None, Some("   ")),
+        EngineMode::External {
+            url: "ws://file-engine:49134".to_string()
+        }
     );
 }
 

--- a/docs/next/using-iii/compose.mdx
+++ b/docs/next/using-iii/compose.mdx
@@ -564,6 +564,17 @@ and `iii-sandbox`. Use `#instance` for another instance of an allowed type, for 
   Changes to these worker configurations take effect only after the engine restarts.
 </Note>
 
+#### Which engine Compose uses
+
+Compose takes the engine address from the first of these that supplies one: the `--engine` flag,
+the `III_URL` environment variable, the `engine:` section of the compose file, then
+`ws://127.0.0.1:49134`.
+
+An address from `--engine` or `III_URL` names an engine that already runs, so Compose connects to
+it and starts no engine of its own, even with `--up`. Only the compose file can give Compose an
+engine to own, and only `--up` takes it: an `engine:` section carries the engine's whole
+configuration, not only an address.
+
 ### Worker fields
 
 Each key under `containers` is the name the worker registers under.

--- a/docs/next/using-iii/compose.mdx.skill.md
+++ b/docs/next/using-iii/compose.mdx.skill.md
@@ -558,6 +558,17 @@ and `iii-sandbox`. Use `#instance` for another instance of an allowed type, for 
   Changes to these worker configurations take effect only after the engine restarts.
 </Note>
 
+#### Which engine Compose uses
+
+Compose takes the engine address from the first of these that supplies one: the `--engine` flag,
+the `III_URL` environment variable, the `engine:` section of the compose file, then
+`ws://127.0.0.1:49134`.
+
+An address from `--engine` or `III_URL` names an engine that already runs, so Compose connects to
+it and starts no engine of its own, even with `--up`. Only the compose file can give Compose an
+engine to own, and only `--up` takes it: an `engine:` section carries the engine's whole
+configuration, not only an address.
+
 ### Worker fields
 
 Each key under `containers` is the name the worker registers under.


### PR DESCRIPTION
Follow-up to #2168, which made `iii trigger` read `III_URL` ahead of the compose file. This PR gives `iii compose` the same rule, so that the environment always wins over what is on disk.

## Problem

`resolve_engine_mode` read `III_URL` only when the compose file named no engine:

```rust
let url = file
    .and_then(|file| file.engine.as_ref())
    .map(|engine| engine.url.as_str())
    .or(environment_engine_url)
    .unwrap_or(config::DEFAULT_ENGINE_URL);
```

So in a project directory that declares an engine, a shell (or a worker that compose itself spawned) pointed at another engine still reached the one the checked-in file names. The variable looked set and did nothing.

## Change

The engine address now comes from the first of these that supplies one:

| Precedence | Source |
| --- | --- |
| 1 | `--engine <URL>` |
| 2 | `III_URL` |
| 3 | `engine:` in the compose file |
| 4 | `ws://127.0.0.1:49134` |

`III_URL` selects an engine exactly as `--engine` does, ownership included. An address that comes from outside the file names an engine that already runs, so compose connects to it and starts none of its own, even with `--up`. Only the compose file can give compose an engine to own, and only `--up` takes it: an `engine:` section carries the engine's whole configuration (its `workers:` map, ports, adapters), not only an address, so a bare URL is not something compose could spawn from.

The daemon's engine policy follows the same rule. An address from `III_URL` now produces `EnginePolicy::external_overriding`, as `--engine` already did, because the file's declared engine is no longer the engine this daemon must match.

An empty or blank `III_URL` falls through to the file, so an exported but unset variable changes nothing.

## Verification

`cargo test -p iii-compose`: 396 passed, 0 failed. New and changed cases in `crates/iii-compose/tests/cli.rs`:

- `up_with_an_environment_engine_connects_without_owning_it`
- `explicit_engine_beats_the_environment_with_up`
- `bare_compose_prefers_the_environment_over_the_file_engine`
- `an_empty_environment_url_falls_through_to_the_file_engine`
- `up_uses_the_file_engine_when_nothing_else_names_one`

Live, with a compose file that declares `engine.url: ws://127.0.0.1:4300` and a second engine already running on 4340:

| Command | Result |
| --- | --- |
| `III_URL=ws://127.0.0.1:4340 iii compose --up` | `Engine Connecting`, served on 4340, nothing bound 4300 |
| `iii compose --up` (no `III_URL`) | `Engine Starting`, bound and owned 4300 |
| `iii compose --up --engine ws://127.0.0.1:4340` | unchanged: connects to 4340, spawns nothing |

`cargo fmt --check -p iii-compose` is clean. `docs/next/using-iii/compose.mdx` gains a "Which engine Compose uses" section, and its `.skill.md` artifact was re-rendered with `iii-skill-render`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer engine selection precedence: `--engine`, `III_URL`, the compose file, then the local default.
  - External engines specified through `--engine` or `III_URL` now take priority and are not started by Compose.

- **Bug Fixes**
  - Corrected `--up` behavior so environment-provided engine URLs override engines defined in compose files.

- **Documentation**
  - Documented engine selection order and ownership behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->