### PR TITLE
(MOT-4761) fix(compose): a terminal operation event stops claiming a dead worker is ready

### DIFF
--- a/crates/iii-compose/src/daemon.rs
+++ b/crates/iii-compose/src/daemon.rs
@@ -1492,6 +1492,14 @@ impl MutationOutcome {
     pub(crate) fn is_failed(&self) -> bool {
         self.status == OpStatus::Failed
     }
+
+    /// Requested containers that ended in error while the operation still
+    /// succeeded — only possible for a container whose effective `required`
+    /// is false. A terminal progress event must name these: "every requested
+    /// worker is ready" is false while one of them is not.
+    pub(crate) fn not_required_failures(&self) -> &[String] {
+        self.not_required_failures.as_deref().unwrap_or(&[])
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema, PartialEq, Eq)]

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -460,6 +460,7 @@ async fn dispatch(
                 operation,
                 mutation,
                 "all requested workers are ready",
+                "workers that did not start",
                 "one or more workers failed",
             );
             Ok(to_value(&accepted))
@@ -497,6 +498,7 @@ async fn dispatch(
                 operation,
                 mutation,
                 "all requested workers were removed",
+                "workers that could not be removed",
                 "one or more workers could not be removed",
             );
             Ok(to_value(&accepted))
@@ -556,6 +558,7 @@ async fn dispatch(
                 operation,
                 mutation,
                 "all requested workers were updated",
+                "workers that could not be updated",
                 "one or more workers could not be updated",
             );
             Ok(to_value(&accepted))
@@ -687,10 +690,38 @@ async fn admit_mutation(
     Ok((operation, accepted))
 }
 
+/// Compose the terminal detail for a mutation that succeeded.
+///
+/// A non-required container that never reached its target state leaves the
+/// operation succeeding, which is by design — but the blanket success line
+/// then claims every worker is up while one is not, and a caller polling
+/// `compose::operation` has no other place to learn it. Name those containers
+/// instead (MOT-4761).
+///
+/// The list is the project's, not this operation's request: reconciliation
+/// reports every container it touched, so one left broken by an earlier
+/// operation keeps being named until it starts. That is the point — the
+/// alternative is a success line that is false about the project.
+fn succeeded_detail(
+    success_detail: &str,
+    partial_detail: &str,
+    not_required_failures: &[String],
+) -> String {
+    if not_required_failures.is_empty() {
+        return success_detail.to_string();
+    }
+    format!(
+        "{partial_detail}: {}. The operation still succeeded because they are not required; \
+         check compose::status and their logs before using them.",
+        not_required_failures.join(", ")
+    )
+}
+
 fn spawn_mutation<F>(
     operation: Arc<crate::operation::Operation>,
     mutation: F,
     success_detail: &'static str,
+    partial_detail: &'static str,
     failed_detail: &'static str,
 ) where
     F: Future<Output = Result<MutationOutcome, ComposeError>> + Send + 'static,
@@ -717,9 +748,13 @@ fn spawn_mutation<F>(
                             crate::operation::OperationStatus::Succeeded
                         },
                         if failed {
-                            failed_detail
+                            failed_detail.to_string()
                         } else {
-                            success_detail
+                            succeeded_detail(
+                                success_detail,
+                                partial_detail,
+                                outcome.not_required_failures(),
+                            )
                         },
                     )
                     .await;
@@ -1446,5 +1481,35 @@ mod tests {
                 "{function_id} exposes container internals"
             );
         }
+    }
+
+    #[test]
+    fn a_succeeding_mutation_names_the_workers_that_did_not_start() {
+        assert_eq!(
+            super::succeeded_detail(
+                "all requested workers are ready",
+                "workers that did not start",
+                &[],
+            ),
+            "all requested workers are ready",
+            "nothing failed, so the blanket line is true"
+        );
+        let partial = super::succeeded_detail(
+            "all requested workers are ready",
+            "workers that did not start",
+            &["bulk-importer".to_string(), "analytics".to_string()],
+        );
+        assert!(
+            partial.starts_with("workers that did not start: bulk-importer, analytics."),
+            "the terminal detail names them: {partial}"
+        );
+        assert!(
+            !partial.contains("all requested workers are ready"),
+            "and never claims they are ready: {partial}"
+        );
+        assert!(
+            partial.contains("compose::status"),
+            "pointing at where to look: {partial}"
+        );
     }
 }

--- a/crates/iii-compose/src/remote.rs
+++ b/crates/iii-compose/src/remote.rs
@@ -456,13 +456,7 @@ async fn dispatch(
                     .add_configured(file.as_deref(), &workers, task_operation_id)
                     .await
             };
-            spawn_mutation(
-                operation,
-                mutation,
-                "all requested workers are ready",
-                "workers that did not start",
-                "one or more workers failed",
-            );
+            spawn_mutation(operation, mutation, ADD_DETAILS);
             Ok(to_value(&accepted))
         }
         Operation::Remove => {
@@ -494,13 +488,7 @@ async fn dispatch(
                     .remove(file.as_deref(), &workers, task_operation_id)
                     .await
             };
-            spawn_mutation(
-                operation,
-                mutation,
-                "all requested workers were removed",
-                "workers that could not be removed",
-                "one or more workers could not be removed",
-            );
+            spawn_mutation(operation, mutation, REMOVE_DETAILS);
             Ok(to_value(&accepted))
         }
         Operation::Restart => match daemon
@@ -554,13 +542,7 @@ async fn dispatch(
                     .update(file.as_deref(), &workers, task_operation_id)
                     .await
             };
-            spawn_mutation(
-                operation,
-                mutation,
-                "all requested workers were updated",
-                "workers that could not be updated",
-                "one or more workers could not be updated",
-            );
+            spawn_mutation(operation, mutation, UPDATE_DETAILS);
             Ok(to_value(&accepted))
         }
         Operation::Down => match daemon
@@ -702,27 +684,53 @@ async fn admit_mutation(
 /// reports every container it touched, so one left broken by an earlier
 /// operation keeps being named until it starts. That is the point — the
 /// alternative is a success line that is false about the project.
-fn succeeded_detail(
-    success_detail: &str,
-    partial_detail: &str,
-    not_required_failures: &[String],
-) -> String {
+fn succeeded_detail(details: MutationDetails, not_required_failures: &[String]) -> String {
     if not_required_failures.is_empty() {
-        return success_detail.to_string();
+        return details.success.to_string();
     }
     format!(
-        "{partial_detail}: {}. The operation still succeeded because they are not required; \
+        "{}: {}. The operation still succeeded because they are not required; \
          check compose::status and their logs before using them.",
+        details.partial,
         not_required_failures.join(", ")
     )
 }
 
+/// The three terminal lines one mutation can finish with. Named fields rather
+/// than three positional `&str`s: they are the same type, so a swap at a call
+/// site would compile and only show up as a wrong sentence in a live run.
+#[derive(Clone, Copy)]
+struct MutationDetails {
+    /// Every container reached its target state.
+    success: &'static str,
+    /// The operation succeeded, but some non-required container did not.
+    partial: &'static str,
+    /// A required container did not, so the operation failed.
+    failed: &'static str,
+}
+
+const ADD_DETAILS: MutationDetails = MutationDetails {
+    success: "all requested workers are ready",
+    partial: "workers that did not start",
+    failed: "one or more workers failed",
+};
+
+const REMOVE_DETAILS: MutationDetails = MutationDetails {
+    success: "all requested workers were removed",
+    partial: "workers that could not be removed",
+    failed: "one or more workers could not be removed",
+};
+
+const UPDATE_DETAILS: MutationDetails = MutationDetails {
+    success: "all requested workers were updated",
+    partial: "workers that could not be updated",
+    failed: "one or more workers could not be updated",
+};
+
 fn spawn_mutation<F>(
     operation: Arc<crate::operation::Operation>,
     mutation: F,
-    success_detail: &'static str,
-    partial_detail: &'static str,
-    failed_detail: &'static str,
+    details: MutationDetails,
 ) where
     F: Future<Output = Result<MutationOutcome, ComposeError>> + Send + 'static,
 {
@@ -748,13 +756,9 @@ fn spawn_mutation<F>(
                             crate::operation::OperationStatus::Succeeded
                         },
                         if failed {
-                            failed_detail.to_string()
+                            details.failed.to_string()
                         } else {
-                            succeeded_detail(
-                                success_detail,
-                                partial_detail,
-                                outcome.not_required_failures(),
-                            )
+                            succeeded_detail(details, outcome.not_required_failures())
                         },
                     )
                     .await;
@@ -1485,31 +1489,54 @@ mod tests {
 
     #[test]
     fn a_succeeding_mutation_names_the_workers_that_did_not_start() {
-        assert_eq!(
-            super::succeeded_detail(
-                "all requested workers are ready",
-                "workers that did not start",
-                &[],
-            ),
-            "all requested workers are ready",
-            "nothing failed, so the blanket line is true"
-        );
-        let partial = super::succeeded_detail(
-            "all requested workers are ready",
-            "workers that did not start",
-            &["bulk-importer".to_string(), "analytics".to_string()],
-        );
-        assert!(
-            partial.starts_with("workers that did not start: bulk-importer, analytics."),
-            "the terminal detail names them: {partial}"
-        );
-        assert!(
-            !partial.contains("all requested workers are ready"),
-            "and never claims they are ready: {partial}"
-        );
-        assert!(
-            partial.contains("compose::status"),
-            "pointing at where to look: {partial}"
-        );
+        for details in [
+            super::ADD_DETAILS,
+            super::REMOVE_DETAILS,
+            super::UPDATE_DETAILS,
+        ] {
+            assert_eq!(
+                super::succeeded_detail(details, &[]),
+                details.success,
+                "nothing failed, so the blanket line is true"
+            );
+            let partial = super::succeeded_detail(
+                details,
+                &["bulk-importer".to_string(), "analytics".to_string()],
+            );
+            assert!(
+                partial.starts_with(&format!("{}: bulk-importer, analytics.", details.partial)),
+                "the terminal detail names them: {partial}"
+            );
+            assert!(
+                !partial.contains(details.success),
+                "and never claims they are ready: {partial}"
+            );
+            assert!(
+                partial.contains("compose::status"),
+                "pointing at where to look: {partial}"
+            );
+        }
+    }
+
+    /// The three lines are the same type, so the compiler cannot catch a swap
+    /// at a call site; distinctness is what makes a swap visible in a test.
+    #[test]
+    fn every_mutation_names_its_own_three_outcomes() {
+        let all = [
+            super::ADD_DETAILS,
+            super::REMOVE_DETAILS,
+            super::UPDATE_DETAILS,
+        ];
+        let mut lines: Vec<&str> = all
+            .iter()
+            .flat_map(|d| [d.success, d.partial, d.failed])
+            .collect();
+        let total = lines.len();
+        lines.sort_unstable();
+        lines.dedup();
+        assert_eq!(lines.len(), total, "two mutations share a terminal line");
+        for d in all {
+            assert!(!d.partial.contains("ready") && !d.partial.contains("were "));
+        }
     }
 }


### PR DESCRIPTION
`compose::add` with a worker that never starts finished like this:

```
{"operation_id":"bulkimporter-add-53e0b4","phase":"complete","terminal":true,
 "last_event":{"detail":"all requested workers are ready","current":20,"total":20}}
```

while `compose::status` showed the container `stopped` and none of its functions registered.

The operation was right to succeed. `required_default` is false, so a non-required container that exhausts its retries leaves the rest of the graph running. The completion line was the lie, and it is the only thing a caller polling `compose::operation` gets to read.

`MutationOutcome` already carries `not_required_failures` for exactly this case, populated whenever the status is ok and some container ended in error. `spawn_mutation` collapsed the outcome to a boolean and threw the names away. It now composes the terminal detail from them.

The list is the project's rather than this request's, because reconciliation reports every container it touched: one left broken by an earlier operation keeps being named until it starts. That surfaced in the live check below, where a later healthy add still named the earlier casualty, and it is the behaviour I kept: the alternative is a success line that is false about the project.

## Verification

`cargo fmt --all -- --check`, `cargo clippy -p iii-compose --all-targets -- -D warnings` and `cargo test -p iii-compose` (370 tests) pass, with a new unit test over the detail composition.

Live, on a two-container project with one worker whose start command exits 1:

| operation | terminal detail |
| --- | --- |
| add a healthy worker | `all requested workers are ready` |
| add the failing worker | `workers that did not start: broken. The operation still succeeded because they are not required; check compose::status and their logs before using them.` |

## Why it mattered

Measured on the Linkly tutorial: the `bulk-importer` add reported terminal success five times while the worker never registered. The sub-agent gave up with "BLOCKED on container start", three scenario criteria failed, and twenty of the parent's forty-three `engine::functions::list` calls were it polling for a registration the completion event had already promised.

Closes MOT-4761.

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved consistency and clarity of terminal messages for adding, removing, and updating compositions.
  - Operations now distinguish more clearly between successful, partially successful, and failed outcomes.
  - Successful operations without optional-container failures continue to report completion as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->